### PR TITLE
Change requirements.txt to add missing python repos

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -4,3 +4,5 @@ APScheduler~=3.9.1
 Cerberus~=1.3.4
 confuse~=1.7.0
 urllib3~=1.26.8
+logfmt-logger~=0.1.2
+prometheus-client~=0.13.1


### PR DESCRIPTION
The docker image failed to load some python libraries on first startup, thus failed to set up the container. I added them in the requirements.txt