### PR TITLE
Revert to Ticker.info

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -65,6 +65,15 @@ jobs:
             estate:
               quantity: 2
               received_dividend: 2.85
+          - name: Bitcoin
+            symbol: BTC-USD
+            purchase:
+              quantity: 1
+              fee: 2
+              cost_price: 5000
+            estate:
+              quantity: 1
+              received_dividend: 0
           EOL
           python3 app/src/testing.py
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -5,4 +5,4 @@ confuse == 2.0.0
 logfmt_logger == 0.1.2
 prometheus_client == 0.16.0
 urllib3 ==1.26.15
-yfinance ==0.2.14
+yfinance ==0.2.18

--- a/app/src/testing.py
+++ b/app/src/testing.py
@@ -20,8 +20,7 @@ shares_validator = Validator(dataSchema)
 
 try:
     # Start up the server to expose the metrics.
-    prometheus_client.start_http_server(
-        int(os.getenv('SB_METRICS_PORT', default='8081')))
+    prometheus_client.start_http_server(8081)
     # Init SuiviBourseMetrics
     sb_metrics = SuiviBourseMetrics(config, shares_validator)
     # Schedule run the job on startup.

--- a/app/src/testing.py
+++ b/app/src/testing.py
@@ -3,7 +3,6 @@ import requests
 import sys
 import prometheus_client
 import yaml
-import os
 from cerberus import Validator
 from confuse import Configuration
 from pathlib import Path

--- a/assets/grafana-dashboard-external-v9.json
+++ b/assets/grafana-dashboard-external-v9.json
@@ -21,7 +21,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "9.0.7"
+      "version": "9.4.7"
     },
     {
       "type": "datasource",
@@ -108,13 +108,15 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -172,13 +174,15 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -236,13 +240,15 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -296,6 +302,8 @@
             "mode": "fixed"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -361,8 +369,9 @@
         "includeAllFields": false,
         "legend": {
           "calcs": [],
-          "displayMode": "hidden",
-          "placement": "bottom"
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
         },
         "mode": "candles"
       },
@@ -462,14 +471,16 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -533,14 +544,16 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -603,14 +616,16 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -674,14 +689,16 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -753,14 +770,16 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -823,14 +842,16 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -893,14 +914,16 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -972,14 +995,16 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -1007,8 +1032,9 @@
       "type": "stat"
     }
   ],
-  "refresh": false,
-  "schemaVersion": 36,
+  "refresh": "",
+  "revision": 1,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1019,7 +1045,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(sb_share_info{share_market=~\"$market\", share_exchange=~\"$exchange\"},share_name)",
+        "definition": "label_values(sb_share_info{quote_type=~\"$quote_type\", share_exchange=~\"$exchange\"},share_name)",
         "hide": 0,
         "includeAll": true,
         "label": "Share",
@@ -1027,7 +1053,7 @@
         "name": "share",
         "options": [],
         "query": {
-          "query": "label_values(sb_share_info{share_market=~\"$market\", share_exchange=~\"$exchange\"},share_name)",
+          "query": "label_values(sb_share_info{quote_type=~\"$quote_type\", share_exchange=~\"$exchange\"},share_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -1045,15 +1071,15 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(sb_share_info, share_market)",
+        "definition": "label_values(sb_share_info, quote_type)",
         "hide": 0,
         "includeAll": true,
-        "label": "Market",
+        "label": "Quote Type",
         "multi": true,
-        "name": "market",
+        "name": "quote_type",
         "options": [],
         "query": {
-          "query": "label_values(sb_share_info, share_market)",
+          "query": "label_values(sb_share_info, quote_type)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -1095,6 +1121,6 @@
   "timezone": "",
   "title": "Stock share monitoring",
   "uid": "O9_AegInk",
-  "version": 14,
+  "version": 3,
   "weekStart": ""
 }

--- a/docker-compose/config.yaml
+++ b/docker-compose/config.yaml
@@ -9,3 +9,12 @@ shares:
   estate:
     quantity: 2
     received_dividend: 2.85
+- name: Bitcoin
+  symbol: BTC-USD
+  purchase:
+    quantity: 1
+    fee: 2
+    cost_price: 5000
+  estate:
+    quantity: 1
+    received_dividend: 0

--- a/docker-compose/grafana_provisioning/dashboards/suivi_bourse.json
+++ b/docker-compose/grafana_provisioning/dashboards/suivi_bourse.json
@@ -79,7 +79,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -145,7 +145,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -211,7 +211,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -265,6 +265,8 @@
             "mode": "fixed"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -330,8 +332,9 @@
         "includeAllFields": false,
         "legend": {
           "calcs": [],
-          "displayMode": "hidden",
-          "placement": "bottom"
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
         },
         "mode": "candles"
       },
@@ -437,7 +440,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -507,7 +510,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -576,7 +579,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -646,7 +649,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -724,7 +727,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -793,7 +796,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -862,7 +865,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -940,7 +943,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.7",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
           "datasource": {
@@ -968,8 +971,9 @@
       "type": "stat"
     }
   ],
-  "refresh": false,
-  "schemaVersion": 36,
+  "refresh": "",
+  "revision": 1,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -984,7 +988,7 @@
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
         },
-        "definition": "label_values(sb_share_info{share_market=~\"$market\", share_exchange=~\"$exchange\"},share_name)",
+        "definition": "label_values(sb_share_info{quote_type=~\"$quote_type\", share_exchange=~\"$exchange\"},share_name)",
         "hide": 0,
         "includeAll": true,
         "label": "Share",
@@ -992,7 +996,7 @@
         "name": "share",
         "options": [],
         "query": {
-          "query": "label_values(sb_share_info{share_market=~\"$market\", share_exchange=~\"$exchange\"},share_name)",
+          "query": "label_values(sb_share_info{quote_type=~\"$quote_type\", share_exchange=~\"$exchange\"},share_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -1018,15 +1022,15 @@
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
         },
-        "definition": "label_values(sb_share_info, share_market)",
+        "definition": "label_values(sb_share_info, quote_type)",
         "hide": 0,
         "includeAll": true,
-        "label": "Market",
+        "label": "Quote Type",
         "multi": true,
-        "name": "market",
+        "name": "quote_type",
         "options": [],
         "query": {
-          "query": "label_values(sb_share_info, share_market)",
+          "query": "label_values(sb_share_info, quote_type)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -1076,6 +1080,6 @@
   "timezone": "",
   "title": "Stock share monitoring",
   "uid": "O9_AegInk",
-  "version": 13,
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
Yfinance has improved the performance of Ticker.info() and Ticker.fast_info() is now deprecated in version 0.2.18. 

I modified the code to reuse this method and updated the labels. I added a new label in `sb_share_info` called `quote_type`. 

I also reuse Ticker.history to get the price because `ticker.info.get('currentPrice')` is not accessible for crypto-currencies.

The test procedure now includes Bitcoin to ensure that this project is crypto-currency compliant. 