### PR TITLE
fix(ci): build release docs with pnpm instead of yarn

### DIFF
--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -91,10 +91,22 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: "0"
-      - run: yarn install
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.11.0
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          # pnpm 11.9 requires node:sqlite (Node >= 22.5)
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: website/pnpm-lock.yaml
+      - name: Build docs
         working-directory: website
-      - run: yarn build
-        working-directory: website
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
       - name: Setup Pages
         uses: actions/configure-pages@v6
       - name: Upload artifact


### PR DESCRIPTION
## Problem

The 4.0.0 release workflow **failed** on the `doc` job: `yarn install` errored
because the website migrated from yarn to pnpm (`yarn.lock` was deleted in the
InfluxDB migration PR). Only the release-time doc-deploy job was missed — the PR
`Building doc` check was already converted to pnpm, which is why this stayed
hidden until an actual release ran.

## Fix

Replace the `yarn install` / `yarn build` steps in the `doc` job with the same
pnpm setup used by `pr-checks.yml` (`pnpm/action-setup` 11.11.0 + Node 22 +
`pnpm install --frozen-lockfile && pnpm build`).

## Note

The v4.0.0 GitHub release and Docker images were created fine — only the docs
deploy failed. After this merges, the docs will deploy correctly on the next
release; redeploying the 4.0.0 docs is handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation website build process to use pnpm.
  * Added Node.js 22 and pnpm setup with dependency caching for more consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->