### PR TITLE
feat(app): first-class accounts (#574)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,7 @@ Prometheus `/metrics` endpoint (enabled by default, `SB_METRICS_PORT`=8081). It
 runs in parallel with the InfluxDB writer and reflects only the current snapshot
 per share (no historical backfill). Disable it with `SB_PROMETHEUS_ENABLED=false`.
 
-Gauges (prefix `sb_`, labels `share_name`/`share_symbol`): `sb_share_price`,
+Gauges (prefix `sb_`, labels `share_name`/`share_symbol`/`account`): `sb_share_price`,
 `sb_purchased_quantity`, `sb_purchased_price`, `sb_purchased_fee`,
 `sb_owned_quantity`, `sb_received_dividend`, `sb_dividend_yield`, `sb_pe_ratio`,
 `sb_market_cap`, `sb_volume`, plus `sb_share_info` (value `1`, with extra labels
@@ -266,6 +266,7 @@ Gauges (prefix `sb_`, labels `share_name`/`share_symbol`): `sb_share_price`,
 |------|------|-------------|
 | Tag | `share_name` | Display name |
 | Tag | `share_symbol` | Yahoo Finance ticker |
+| Tag | `account` | Account bucket (`default` unless accounts are declared) |
 | Tag | `share_currency` | Currency (USD, EUR, etc.) |
 | Tag | `share_exchange` | Exchange (NMS, PAR, etc.) |
 | Tag | `quote_type` | Type (EQUITY, ETF, etc.) |

--- a/app/src/events/__init__.py
+++ b/app/src/events/__init__.py
@@ -5,18 +5,24 @@ This module handles portfolio event imports from CSV/XLSX files
 and generates aggregated configuration compatible with the existing schema.
 """
 
-from .schemas import Event, EventType, ShareState, PurchaseState, EstateState
+from .schemas import (
+    DEFAULT_ACCOUNT, Event, EventType, ShareState, PurchaseState, EstateState,
+    Account, Portfolio,
+)
 from .loader import EventLoader
 from .validator import EventValidator
 from .aggregator import EventAggregator
 from .watcher import EventWatcher
 
 __all__ = [
+    'DEFAULT_ACCOUNT',
     'Event',
     'EventType',
     'ShareState',
     'PurchaseState',
     'EstateState',
+    'Account',
+    'Portfolio',
     'EventLoader',
     'EventValidator',
     'EventAggregator',

--- a/app/src/events/aggregator.py
+++ b/app/src/events/aggregator.py
@@ -145,7 +145,9 @@ class EventAggregator:
         self,
         events: List[Event],
         target_date: date,
-        symbol: str
+        symbol: str,
+        account: Optional[str] = None,
+        accounts_declared: bool = False,
     ) -> Optional[Dict]:
         """
         Aggregate events for a specific symbol up to a given date.
@@ -154,15 +156,24 @@ class EventAggregator:
             events: List of events sorted by date.
             target_date: Only process events up to this date (inclusive).
             symbol: The symbol to aggregate.
+            account: When provided, only events belonging to this account bucket
+                are replayed, so each account's historical state is independent.
+                When None, every account is merged (symbol-scoped, legacy).
+            accounts_declared: Whether accounts are declared, to resolve each
+                event's bucket the same way :meth:`aggregate` does.
 
         Returns:
             Share dictionary for the symbol, or None if no events exist.
         """
-        # Filter events for the symbol up to target_date
-        filtered_events = [
-            e for e in events
-            if e.symbol == symbol and e.date <= target_date
-        ]
+        # Filter events for the symbol up to target_date (and account if given)
+        def _keep(e: Event) -> bool:
+            if e.symbol != symbol or e.date > target_date:
+                return False
+            if account is None:
+                return True
+            return self._event_account(e, accounts_declared) == account
+
+        filtered_events = [e for e in events if _keep(e)]
 
         if not filtered_events:
             return None
@@ -171,6 +182,7 @@ class EventAggregator:
         state = ShareState(
             name=filtered_events[0].name,
             symbol=symbol,
+            account=account or DEFAULT_ACCOUNT,
             purchase=PurchaseState(),
             estate=EstateState(),
         )

--- a/app/src/events/aggregator.py
+++ b/app/src/events/aggregator.py
@@ -3,9 +3,11 @@ Event aggregator for computing portfolio state from events.
 """
 
 from datetime import date
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
-from .schemas import Event, EventType, ShareState, PurchaseState, EstateState
+from .schemas import (
+    DEFAULT_ACCOUNT, Event, EventType, ShareState, PurchaseState, EstateState,
+)
 
 
 class AggregationError(Exception):
@@ -16,12 +18,26 @@ class AggregationError(Exception):
 class EventAggregator:
     """Aggregates portfolio events into share states."""
 
-    def aggregate(self, events: List[Event]) -> List[Dict]:
+    def _event_account(self, event: Event, accounts_declared: bool) -> str:
+        """Resolve the account bucket for an event.
+
+        When accounts are declared, positions are keyed by the event's own
+        account (guaranteed present by validation). Otherwise everything falls
+        into the implicit ``default`` account — a single code path either way.
+        """
+        if accounts_declared and event.account:
+            return event.account
+        return DEFAULT_ACCOUNT
+
+    def aggregate(self, events: List[Event], accounts_declared: bool = False) -> List[Dict]:
         """
         Aggregate events into share configurations.
 
         Args:
             events: List of events sorted by date.
+            accounts_declared: When True, positions are keyed by
+                ``(account, symbol)``. When False, everything is aggregated
+                under the implicit ``default`` account.
 
         Returns:
             List of share dictionaries compatible with the config schema.
@@ -29,19 +45,25 @@ class EventAggregator:
         Raises:
             AggregationError: If aggregation fails (e.g., selling more than owned).
         """
-        # Group events by symbol and process in order
-        states: Dict[str, ShareState] = {}
+        # Group events by (account, symbol) and process in order
+        states: Dict[Tuple[str, str], ShareState] = {}
+        order: List[Tuple[str, str]] = []
 
         for event in events:
-            if event.symbol not in states:
-                states[event.symbol] = ShareState(
+            account = self._event_account(event, accounts_declared)
+            key = (account, event.symbol)
+
+            if key not in states:
+                states[key] = ShareState(
                     name=event.name,
                     symbol=event.symbol,
+                    account=account,
                     purchase=PurchaseState(),
                     estate=EstateState(),
                 )
+                order.append(key)
 
-            state = states[event.symbol]
+            state = states[key]
 
             # Update name if provided (use latest name)
             if event.name:
@@ -57,13 +79,8 @@ class EventAggregator:
             elif event.event_type == EventType.DIVIDEND:
                 self._process_dividend(state, event)
 
-        # Convert to list of dicts, preserving symbol order of first appearance
-        seen_symbols = []
-        for event in events:
-            if event.symbol not in seen_symbols:
-                seen_symbols.append(event.symbol)
-
-        return [states[symbol].to_dict() for symbol in seen_symbols]
+        # Convert to list of dicts, preserving (account, symbol) first-appearance order
+        return [states[key].to_dict() for key in order]
 
     def _process_buy(self, state: ShareState, event: Event) -> None:
         """

--- a/app/src/events/loader.py
+++ b/app/src/events/loader.py
@@ -18,8 +18,8 @@ class EventLoaderError(Exception):
 class EventLoader:
     """Loads portfolio events from CSV and XLSX files."""
 
-    REQUIRED_COLUMNS = {'date', 'event_type', 'symbol', 'name'}
-    OPTIONAL_COLUMNS = {'quantity', 'unit_price', 'fee', 'amount', 'notes', 'account'}
+    REQUIRED_COLUMNS = frozenset({'date', 'event_type', 'symbol', 'name'})
+    OPTIONAL_COLUMNS = frozenset({'quantity', 'unit_price', 'fee', 'amount', 'notes', 'account'})
     ALL_COLUMNS = REQUIRED_COLUMNS | OPTIONAL_COLUMNS
 
     def __init__(self, source_path: str):

--- a/app/src/events/loader.py
+++ b/app/src/events/loader.py
@@ -19,7 +19,7 @@ class EventLoader:
     """Loads portfolio events from CSV and XLSX files."""
 
     REQUIRED_COLUMNS = {'date', 'event_type', 'symbol', 'name'}
-    OPTIONAL_COLUMNS = {'quantity', 'unit_price', 'fee', 'amount', 'notes'}
+    OPTIONAL_COLUMNS = {'quantity', 'unit_price', 'fee', 'amount', 'notes', 'account'}
     ALL_COLUMNS = REQUIRED_COLUMNS | OPTIONAL_COLUMNS
 
     def __init__(self, source_path: str):
@@ -198,6 +198,13 @@ class EventLoader:
         # Parse notes
         notes = row.get('notes', '').strip() if row.get('notes') else None
 
+        # Parse account (optional column; validation of whether it is required
+        # happens in EventValidator once declared accounts are known)
+        account_value = row.get('account')
+        if account_value is not None and not isinstance(account_value, str):
+            account_value = str(account_value)
+        account = account_value.strip() if account_value else None
+
         return Event(
             date=event_date,
             event_type=event_type,
@@ -208,6 +215,7 @@ class EventLoader:
             fee=fee,
             amount=amount,
             notes=notes if notes else None,
+            account=account if account else None,
         )
 
     def _parse_float(self, value, field_name: str) -> Optional[float]:

--- a/app/src/events/schemas.py
+++ b/app/src/events/schemas.py
@@ -5,7 +5,13 @@ Data schemas for the events module.
 from dataclasses import dataclass, field
 from datetime import date  # noqa: F401 — used in the `date: date` field annotation (eager-evaluated on Python <3.14)
 from enum import Enum
-from typing import Optional
+from typing import List, Optional, Set
+
+
+# Account bucket used when no accounts are declared (opt-out users) or for
+# points written before the accounts feature existed. Kept as a module constant
+# so every layer (aggregator, InfluxDB tag, Prometheus label) agrees on it.
+DEFAULT_ACCOUNT = "default"
 
 
 class EventType(Enum):
@@ -28,6 +34,7 @@ class Event:
     fee: Optional[float] = None
     amount: Optional[float] = None
     notes: Optional[str] = None
+    account: Optional[str] = None
 
     def __post_init__(self):
         # Convert string event_type to enum if needed
@@ -55,6 +62,7 @@ class ShareState:
     """Complete aggregated state for a share."""
     name: str
     symbol: str
+    account: str = DEFAULT_ACCOUNT
     purchase: PurchaseState = field(default_factory=PurchaseState)
     estate: EstateState = field(default_factory=EstateState)
 
@@ -63,6 +71,7 @@ class ShareState:
         return {
             'name': self.name,
             'symbol': self.symbol,
+            'account': self.account,
             'purchase': {
                 'quantity': self.purchase.quantity,
                 'cost_price': self.purchase.cost_price,
@@ -73,3 +82,29 @@ class ShareState:
                 'received_dividend': self.estate.received_dividend,
             },
         }
+
+
+@dataclass
+class Account:
+    """A declared account (opt-in feature, configured in settings.yaml)."""
+    id: str
+    type: str
+    currency: str
+    label: str
+
+
+@dataclass
+class Portfolio:
+    """The set of declared accounts."""
+    accounts: List[Account] = field(default_factory=list)
+
+    def ids(self) -> Set[str]:
+        """Return the set of declared account ids."""
+        return {a.id for a in self.accounts}
+
+    def get(self, account_id: str) -> Optional[Account]:
+        """Return the declared account with this id, or None."""
+        for account in self.accounts:
+            if account.id == account_id:
+                return account
+        return None

--- a/app/src/events/schemas.py
+++ b/app/src/events/schemas.py
@@ -9,10 +9,9 @@ from typing import List, Optional, Set
 
 
 # Canonical account bucket used when no accounts are declared (opt-out users) or
-# for points written before the accounts feature existed. The events/aggregation
-# layer and main.py reference this constant; the lower-level InfluxDB writer and
-# Prometheus exporter keep the same literal "default" as a parameter default so
-# they stay decoupled from the events domain.
+# for points written before the accounts feature existed. Single source of truth:
+# the aggregation layer, main.py, the InfluxDB writer and the Prometheus exporter
+# all reference this constant so the tag, the label and the aggregation agree.
 DEFAULT_ACCOUNT = "default"
 
 

--- a/app/src/events/schemas.py
+++ b/app/src/events/schemas.py
@@ -8,9 +8,11 @@ from enum import Enum
 from typing import List, Optional, Set
 
 
-# Account bucket used when no accounts are declared (opt-out users) or for
-# points written before the accounts feature existed. Kept as a module constant
-# so every layer (aggregator, InfluxDB tag, Prometheus label) agrees on it.
+# Canonical account bucket used when no accounts are declared (opt-out users) or
+# for points written before the accounts feature existed. The events/aggregation
+# layer and main.py reference this constant; the lower-level InfluxDB writer and
+# Prometheus exporter keep the same literal "default" as a parameter default so
+# they stay decoupled from the events domain.
 DEFAULT_ACCOUNT = "default"
 
 

--- a/app/src/events/validator.py
+++ b/app/src/events/validator.py
@@ -2,7 +2,7 @@
 Event validator for validating portfolio events.
 """
 
-from typing import List, Tuple
+from typing import List, Optional, Set, Tuple
 
 from .schemas import Event, EventType
 
@@ -14,6 +14,16 @@ class EventValidationError(Exception):
 
 class EventValidator:
     """Validates portfolio events."""
+
+    def __init__(self, account_ids: Optional[Set[str]] = None):
+        """
+        Args:
+            account_ids: Set of declared account ids. When provided (accounts are
+                declared, opt-in feature), every event must carry an ``account``
+                matching one of these ids. When ``None``, accounts are not
+                declared and the ``account`` column is ignored.
+        """
+        self.account_ids = account_ids
 
     def validate(self, events: List[Event]) -> Tuple[bool, List[str]]:
         """
@@ -54,6 +64,10 @@ class EventValidator:
         errors = []
         prefix = f"Event #{event_num} ({event.date}, {event.event_type.value}, {event.symbol})"
 
+        # When accounts are declared, every event must carry a valid account
+        if self.account_ids is not None:
+            errors.extend(self._validate_account(event, prefix))
+
         if event.event_type == EventType.BUY:
             errors.extend(self._validate_buy(event, prefix))
         elif event.event_type == EventType.SELL:
@@ -62,6 +76,21 @@ class EventValidator:
             errors.extend(self._validate_grant(event, prefix))
         elif event.event_type == EventType.DIVIDEND:
             errors.extend(self._validate_dividend(event, prefix))
+
+        return errors
+
+    def _validate_account(self, event: Event, prefix: str) -> List[str]:
+        """Validate the account of an event against the declared account ids."""
+        errors = []
+
+        if not event.account:
+            errors.append(
+                f"{prefix}: account is required (accounts are declared in settings.yaml)")
+        elif event.account not in self.account_ids:
+            declared = ", ".join(sorted(self.account_ids)) or "none"
+            errors.append(
+                f"{prefix}: account '{event.account}' is not a declared account id "
+                f"(declared: {declared})")
 
         return errors
 

--- a/app/src/influxdb_writer.py
+++ b/app/src/influxdb_writer.py
@@ -87,6 +87,7 @@ class InfluxDBWriter:
         self,
         share_name: str,
         share_symbol: str,
+        account: str = "default",
         share_price: Optional[float] = None,
         purchased_quantity: Optional[float] = None,
         purchased_price: Optional[float] = None,
@@ -108,6 +109,7 @@ class InfluxDBWriter:
         Args:
             share_name: Name of the share (tag)
             share_symbol: Yahoo Finance symbol (tag)
+            account: Account bucket (tag, default 'default')
             share_price: Current price (field)
             purchased_quantity: Quantity purchased (field)
             purchased_price: Weighted average cost price (field)
@@ -131,6 +133,8 @@ class InfluxDBWriter:
         # Tags (always set)
         point.tag("share_name", share_name)
         point.tag("share_symbol", share_symbol)
+        # account is always written (default 'default') so every point carries it
+        point.tag("account", account or "default")
 
         # Optional tags
         if share_currency:
@@ -182,7 +186,8 @@ class InfluxDBWriter:
         prices: List[Dict[str, Any]],
         share_currency: Optional[str] = None,
         share_exchange: Optional[str] = None,
-        quote_type: Optional[str] = None
+        quote_type: Optional[str] = None,
+        account: str = "default"
     ) -> int:
         """
         Write historical price data to InfluxDB in batch.
@@ -201,6 +206,7 @@ class InfluxDBWriter:
             share_currency: Currency (tag)
             share_exchange: Exchange (tag)
             quote_type: Type (tag)
+            account: Account bucket (tag, default 'default')
 
         Returns:
             Number of points written
@@ -220,6 +226,7 @@ class InfluxDBWriter:
             point = Point(self.MEASUREMENT)
             point.tag("share_name", share_name)
             point.tag("share_symbol", share_symbol)
+            point.tag("account", account or "default")
 
             if share_currency:
                 point.tag("share_currency", share_currency)

--- a/app/src/influxdb_writer.py
+++ b/app/src/influxdb_writer.py
@@ -10,6 +10,8 @@ from typing import Dict, List, Optional, Any
 from influxdb_client_3 import InfluxDBClient3, Point, WritePrecision
 from logfmt_logger import getLogger
 
+from events.schemas import DEFAULT_ACCOUNT
+
 LOG_LEVEL = os.getenv('LOG_LEVEL', default='INFO')
 logger = getLogger("influxdb_writer", level=LOG_LEVEL)
 
@@ -87,7 +89,7 @@ class InfluxDBWriter:
         self,
         share_name: str,
         share_symbol: str,
-        account: str = "default",
+        account: str = DEFAULT_ACCOUNT,
         share_price: Optional[float] = None,
         purchased_quantity: Optional[float] = None,
         purchased_price: Optional[float] = None,
@@ -133,8 +135,8 @@ class InfluxDBWriter:
         # Tags (always set)
         point.tag("share_name", share_name)
         point.tag("share_symbol", share_symbol)
-        # account is always written (default 'default') so every point carries it
-        point.tag("account", account or "default")
+        # account is always written (default bucket) so every point carries it
+        point.tag("account", account or DEFAULT_ACCOUNT)
 
         # Optional tags
         if share_currency:
@@ -187,7 +189,7 @@ class InfluxDBWriter:
         share_currency: Optional[str] = None,
         share_exchange: Optional[str] = None,
         quote_type: Optional[str] = None,
-        account: str = "default"
+        account: str = DEFAULT_ACCOUNT
     ) -> int:
         """
         Write historical price data to InfluxDB in batch.
@@ -226,7 +228,7 @@ class InfluxDBWriter:
             point = Point(self.MEASUREMENT)
             point.tag("share_name", share_name)
             point.tag("share_symbol", share_symbol)
-            point.tag("account", account or "default")
+            point.tag("account", account or DEFAULT_ACCOUNT)
 
             if share_currency:
                 point.tag("share_currency", share_currency)

--- a/app/src/influxdb_writer.py
+++ b/app/src/influxdb_writer.py
@@ -268,12 +268,19 @@ class InfluxDBWriter:
 
         return len(points)
 
-    def get_oldest_timestamp(self, share_symbol: str) -> Optional[datetime]:
+    def get_oldest_timestamp(
+        self, share_symbol: str, account: Optional[str] = None
+    ) -> Optional[datetime]:
         """
         Get the oldest timestamp for a given share symbol in InfluxDB.
 
         Args:
             share_symbol: Yahoo Finance symbol
+            account: When provided, scope the lookup to this account so backfill
+                gaps are detected per account. Uses COALESCE(account, 'default')
+                so points written before the account tag existed count as
+                'default' — never a bare ``WHERE account = ...`` that would drop
+                them.
 
         Returns:
             Oldest timestamp as datetime, or None if no data exists
@@ -283,11 +290,15 @@ class InfluxDBWriter:
 
         # Escape single quotes to keep share_symbol a safe SQL string literal
         safe_symbol = share_symbol.replace("'", "''")
+        where = f"share_symbol = '{safe_symbol}'"
+        if account is not None:
+            safe_account = account.replace("'", "''")
+            where += f" AND COALESCE(account, 'default') = '{safe_account}'"
         # Use SQL query for InfluxDB 3
         query = f"""
         SELECT time
         FROM "{self.MEASUREMENT}"
-        WHERE share_symbol = '{safe_symbol}'
+        WHERE {where}
         ORDER BY time ASC
         LIMIT 1
         """

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -23,7 +23,7 @@ from events import EventLoader, EventValidator, EventAggregator, EventWatcher
 from events.loader import EventLoaderError
 from events.validator import EventValidationError
 from events.aggregator import AggregationError
-from events.schemas import EventType
+from events.schemas import EventType, Account, Portfolio, DEFAULT_ACCOUNT
 from influxdb_writer import InfluxDBWriter
 from prometheus_exporter import PrometheusExporter
 
@@ -31,6 +31,26 @@ LOG_LEVEL = os.getenv('LOG_LEVEL', default='INFO')
 app_logger = getLogger("suivi_bourse", level=LOG_LEVEL)
 scheduler_logger = getLogger("apscheduler.scheduler", level=LOG_LEVEL)
 yfinance_logger = getLogger("yfinance", level=LOG_LEVEL)
+
+# Cerberus schema for the opt-in `accounts:` block of settings.yaml. Declaring
+# this block turns on first-class accounts; its absence leaves behaviour
+# strictly unchanged.
+ACCOUNTS_SCHEMA = {
+    'accounts': {
+        'type': 'list',
+        'required': True,
+        'empty': False,
+        'schema': {
+            'type': 'dict',
+            'schema': {
+                'id': {'type': 'string', 'required': True, 'empty': False},
+                'type': {'type': 'string', 'required': True, 'empty': False},
+                'currency': {'type': 'string', 'required': True, 'empty': False},
+                'label': {'type': 'string', 'required': False},
+            },
+        },
+    },
+}
 
 
 class InvalidConfigFile(Exception):
@@ -66,6 +86,8 @@ class ConfigurationManager:
         self._mode: Optional[str] = None
         self._events_source: Optional[str] = None
         self._watch_enabled: bool = False
+        # Declared accounts (opt-in). None means no accounts block was declared.
+        self._accounts: Optional[Portfolio] = None
         self._confuse_config: Optional[Configuration] = None
         self._watcher: Optional[EventWatcher] = None
         self._reload_callback: Optional[callable] = None
@@ -79,6 +101,13 @@ class ConfigurationManager:
 
     def _load_settings(self) -> None:
         """Load settings from settings.yaml or environment."""
+        # Read settings.yaml once (if present) so the accounts block is available
+        # regardless of how the mode is ultimately selected.
+        settings = {}
+        if self.settings_path.exists():
+            with open(self.settings_path, 'r', encoding='utf-8') as f:
+                settings = yaml.safe_load(f) or {}
+
         # Priority 1: Environment variable
         env_mode = os.getenv('SB_CONFIG_MODE')
         if env_mode:
@@ -86,8 +115,6 @@ class ConfigurationManager:
             app_logger.info(f"Using config mode from environment: {self._mode}")
         # Priority 2: settings.yaml
         elif self.settings_path.exists():
-            with open(self.settings_path, 'r', encoding='utf-8') as f:
-                settings = yaml.safe_load(f) or {}
             self._mode = settings.get('mode', self.MODE_MANUAL).lower()
             events_settings = settings.get('events', {})
             self._events_source = events_settings.get('source')
@@ -98,9 +125,59 @@ class ConfigurationManager:
             self._mode = self.MODE_MANUAL
             app_logger.info(f"No settings found, using default mode: {self._mode}")
 
+        # Accounts are an opt-in feature declared in settings.yaml, independent of
+        # how the mode was selected. Absence leaves behaviour strictly unchanged.
+        self._accounts = self._parse_accounts(settings.get('accounts'))
+        if self._accounts is not None:
+            app_logger.info(
+                f"Loaded {len(self._accounts.accounts)} declared account(s): "
+                f"{', '.join(sorted(self._accounts.ids()))}")
+
         # Default events source if not specified
         if self._mode == self.MODE_EVENTS and not self._events_source:
             self._events_source = str(self.config_dir / 'events')
+
+    def _parse_accounts(self, raw) -> Optional[Portfolio]:
+        """Validate and build the declared accounts from the raw settings block.
+
+        Returns None when no accounts are declared (opt-out). Raises ValueError
+        on a malformed block or duplicate account ids.
+        """
+        if not raw:
+            return None
+
+        validator = Validator(ACCOUNTS_SCHEMA)
+        if not validator.validate({'accounts': raw}):
+            raise ValueError(
+                f"Invalid 'accounts' block in settings.yaml: {validator.errors}")
+
+        accounts = [
+            Account(
+                id=a['id'],
+                type=a['type'],
+                currency=a['currency'],
+                label=a.get('label', a['id']),
+            )
+            for a in raw
+        ]
+
+        ids = [a.id for a in accounts]
+        duplicates = sorted({i for i in ids if ids.count(i) > 1})
+        if duplicates:
+            raise ValueError(
+                f"Duplicate account id(s) in settings.yaml: {duplicates}")
+
+        return Portfolio(accounts=accounts)
+
+    def load_accounts(self) -> Optional[Portfolio]:
+        """Return the declared accounts, or None when none are declared.
+
+        The None return is the single signal that later gates per-account series
+        publication (see the accounts roadmap).
+        """
+        if self._mode is None:
+            self._load_settings()
+        return self._accounts
 
     def get_mode(self) -> str:
         """Get the current configuration mode."""
@@ -172,11 +249,16 @@ class ConfigurationManager:
             self._cache_key = current_key
             return []
 
-        validator = EventValidator()
+        # When accounts are declared, every event must carry a valid account and
+        # positions are keyed per account; otherwise everything falls under
+        # 'default' (a single code path either way).
+        account_ids = self._accounts.ids() if self._accounts else None
+
+        validator = EventValidator(account_ids=account_ids)
         validator.validate_or_raise(events)
 
         aggregator = EventAggregator()
-        shares = aggregator.aggregate(events)
+        shares = aggregator.aggregate(events, accounts_declared=account_ids is not None)
 
         # Update cache
         self._cached_shares = shares
@@ -451,6 +533,7 @@ class SuiviBourseMetrics:
         for i, share in enumerate(self.shares):
             share_name = share['name']
             share_symbol = share['symbol']
+            share_account = share.get('account', DEFAULT_ACCOUNT)
 
             last_quote, info = self._fetch_ticker_data(share_symbol)
 
@@ -476,6 +559,7 @@ class SuiviBourseMetrics:
                     self.influxdb.write_metrics(
                         share_name=share_name,
                         share_symbol=share_symbol,
+                        account=share_account,
                         share_price=last_quote,
                         purchased_quantity=share['purchase']['quantity'],
                         purchased_price=share['purchase']['cost_price'],
@@ -547,6 +631,7 @@ class SuiviBourseMetrics:
         for share in self.shares:
             symbol = share['symbol']
             name = share['name']
+            account = share.get('account', DEFAULT_ACCOUNT)
 
             # Get the target date (first BUY)
             first_buy_date = self.config_manager.get_first_buy_date(symbol)
@@ -673,7 +758,8 @@ class SuiviBourseMetrics:
                     prices=prices,
                     share_currency=info.get('currency'),
                     share_exchange=info.get('exchange'),
-                    quote_type=info.get('quoteType')
+                    quote_type=info.get('quoteType'),
+                    account=account
                 )
                 backfilled_count += written
             except Exception as e:

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -7,7 +7,7 @@ import sys
 import time
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Tuple
 
 import pandas as pd
 import yaml
@@ -387,9 +387,10 @@ class SuiviBourseMetrics:
         # Cache for share info (to avoid repeated API calls during backfill)
         self._share_info_cache: Dict[str, Dict] = {}
 
-        # Track symbols whose backfill has reached the first BUY date, keyed by
-        # that date so an earlier newly-added event re-triggers backfill.
-        self._backfill_complete: Dict[str, datetime] = {}
+        # Track (symbol, account) pairs whose backfill has reached the first BUY
+        # date, mapped to that date so an earlier newly-added event re-triggers
+        # backfill for that account.
+        self._backfill_complete: Dict[Tuple[str, str], datetime] = {}
 
     def validate(self) -> bool:
         """

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -628,6 +628,10 @@ class SuiviBourseMetrics:
         app_logger.info("Starting backfill cycle")
         backfilled_count = 0
 
+        # Accounts are resolved per (symbol, account) so a symbol held in two
+        # accounts backfills each series independently.
+        accounts_declared = self.config_manager.load_accounts() is not None
+
         for share in self.shares:
             symbol = share['symbol']
             name = share['name']
@@ -650,8 +654,8 @@ class SuiviBourseMetrics:
             # Skip symbols already backfilled up to their first BUY date to avoid
             # refetching the same window every cycle (e.g. a first BUY on a
             # non-trading day never lets oldest reach it exactly).
-            if self._backfill_complete.get(symbol) == first_buy_date:
-                app_logger.debug(f"Backfill already complete for {symbol}")
+            if self._backfill_complete.get((symbol, account)) == first_buy_date:
+                app_logger.debug(f"Backfill already complete for {symbol} ({account})")
                 continue
 
             # Ensure share info (tags) is available so historical points share the
@@ -666,8 +670,8 @@ class SuiviBourseMetrics:
                     f"No share info available for {symbol}, deferring backfill")
                 continue
 
-            # Get the oldest data point in InfluxDB
-            oldest_timestamp = self.influxdb.get_oldest_timestamp(symbol)
+            # Get the oldest data point in InfluxDB for this (symbol, account)
+            oldest_timestamp = self.influxdb.get_oldest_timestamp(symbol, account=account)
 
             # Determine if we need to backfill (compare at day granularity)
             if oldest_timestamp is not None:
@@ -675,9 +679,9 @@ class SuiviBourseMetrics:
                 # Compare dates only to avoid tiny time windows
                 if oldest_timestamp.date() <= first_buy_date.date():
                     app_logger.debug(
-                        f"Backfill complete for {symbol}: "
+                        f"Backfill complete for {symbol} ({account}): "
                         f"oldest={oldest_timestamp.date()}, target={first_buy_date.date()}")
-                    self._backfill_complete[symbol] = first_buy_date
+                    self._backfill_complete[(symbol, account)] = first_buy_date
                     continue
 
                 # Need to fetch data before oldest_timestamp
@@ -719,9 +723,9 @@ class SuiviBourseMetrics:
                 # mark the symbol complete to avoid refetching this window forever.
                 if start_date <= first_buy_date:
                     app_logger.debug(
-                        f"Backfill complete for {symbol}: reached first BUY date "
-                        f"with no earlier trading data")
-                    self._backfill_complete[symbol] = first_buy_date
+                        f"Backfill complete for {symbol} ({account}): reached first BUY "
+                        f"date with no earlier trading data")
+                    self._backfill_complete[(symbol, account)] = first_buy_date
                 time.sleep(self.backfill_delay)
                 continue
 
@@ -739,7 +743,8 @@ class SuiviBourseMetrics:
                     point_date = ts.date() if isinstance(ts, datetime) else ts
                     if point_date not in state_by_date:
                         state_by_date[point_date] = aggregator.aggregate_until_date(
-                            events, point_date, symbol)
+                            events, point_date, symbol,
+                            account=account, accounts_declared=accounts_declared)
                     state = state_by_date[point_date]
                     if state:
                         price_point['purchased_quantity'] = state['purchase']['quantity']

--- a/app/src/prometheus_exporter.py
+++ b/app/src/prometheus_exporter.py
@@ -14,7 +14,9 @@ from logfmt_logger import getLogger
 LOG_LEVEL = os.getenv('LOG_LEVEL', default='INFO')
 logger = getLogger("prometheus_exporter", level=LOG_LEVEL)
 
-COMMON_LABELS = ['share_name', 'share_symbol']
+# 'account' is part of every series identity: without it a symbol held in two
+# accounts would collapse onto the same series and silently overwrite itself.
+COMMON_LABELS = ['share_name', 'share_symbol', 'account']
 
 
 class PrometheusExporter:
@@ -84,7 +86,8 @@ class PrometheusExporter:
             last_quote: Latest price, or None if the fetch failed.
             info: Enriched ticker info dict, or None if the fetch failed.
         """
-        labels = (share['name'], share['symbol'])
+        account = share.get('account', 'default')
+        labels = (share['name'], share['symbol'], account)
 
         self.purchased_quantity.labels(*labels).set(share['purchase']['quantity'])
         self.purchased_price.labels(*labels).set(share['purchase']['cost_price'])
@@ -97,7 +100,7 @@ class PrometheusExporter:
 
         self.share_price.labels(*labels).set(last_quote)
         self.share_info.labels(
-            share['name'], share['symbol'],
+            share['name'], share['symbol'], account,
             info['currency'], info['exchange'], info['quoteType']).set(1)
 
         if info.get('dividendYield') is not None:

--- a/app/src/prometheus_exporter.py
+++ b/app/src/prometheus_exporter.py
@@ -11,6 +11,8 @@ import os
 from prometheus_client import CollectorRegistry, Gauge, start_http_server
 from logfmt_logger import getLogger
 
+from events.schemas import DEFAULT_ACCOUNT
+
 LOG_LEVEL = os.getenv('LOG_LEVEL', default='INFO')
 logger = getLogger("prometheus_exporter", level=LOG_LEVEL)
 
@@ -86,7 +88,7 @@ class PrometheusExporter:
             last_quote: Latest price, or None if the fetch failed.
             info: Enriched ticker info dict, or None if the fetch failed.
         """
-        account = share.get('account', 'default')
+        account = share.get('account', DEFAULT_ACCOUNT)
         labels = (share['name'], share['symbol'], account)
 
         self.purchased_quantity.labels(*labels).set(share['purchase']['quantity'])

--- a/app/src/schema.yaml
+++ b/app/src/schema.yaml
@@ -12,6 +12,9 @@ shares:
       symbol:
         type: string
         required: True
+      account:
+        type: string
+        required: False
       purchase:
         type: dict
         required: True

--- a/app/tests/test_accounts.py
+++ b/app/tests/test_accounts.py
@@ -1,0 +1,291 @@
+"""
+Unit tests for the first-class accounts feature (issue #574).
+
+Covers, end to end at the unit level:
+  * loader — the ``account`` column is read from CSV and XLSX
+  * validator — account required/valid only when accounts are declared
+  * aggregator — positions keyed by ``(account, symbol)``; ``default`` fallback
+  * ConfigurationManager — the ``accounts:`` settings block, ``load_accounts()``,
+    validation errors, and the full events pipeline with accounts
+  * schemas — Account / Portfolio helpers
+
+No network, no real InfluxDB. Every ConfigurationManager is built with
+``config_dir=str(tmp_path)`` so nothing touches the real ~/.config/SuiviBourse.
+"""
+
+from datetime import date
+
+import pytest
+
+from events import EventAggregator, EventLoader, EventValidator, Portfolio, Account
+from events.schemas import Event, EventType, ShareState, DEFAULT_ACCOUNT
+from events.validator import EventValidationError
+from main import ConfigurationManager
+
+
+# --------------------------------------------------------------------------- #
+# Isolation: SB_CONFIG_MODE must never leak in from the real environment.
+# --------------------------------------------------------------------------- #
+@pytest.fixture(autouse=True)
+def _no_config_mode_env(monkeypatch):
+    monkeypatch.delenv("SB_CONFIG_MODE", raising=False)
+
+
+_CSV_WITH_ACCOUNTS = (
+    "date,event_type,symbol,name,quantity,unit_price,fee,amount,notes,account\n"
+    "2024-01-15,BUY,AAPL,Apple Inc,10,150.00,2.50,,,PEA\n"
+    "2024-01-16,BUY,AAPL,Apple Inc,5,160.00,1.00,,,CTO\n"
+)
+
+_SETTINGS_TWO_ACCOUNTS = (
+    "mode: events\n"
+    "accounts:\n"
+    "  - id: PEA\n"
+    "    type: PEA\n"
+    "    currency: EUR\n"
+    "    label: Mon PEA\n"
+    "  - id: CTO\n"
+    "    type: CTO\n"
+    "    currency: EUR\n"
+)
+
+
+def _write(path, text):
+    path.write_text(text, encoding="utf-8")
+
+
+def _events_dir_with_accounts(tmp_path):
+    d = tmp_path / "events"
+    d.mkdir()
+    _write(d / "2024.csv", _CSV_WITH_ACCOUNTS)
+    return d
+
+
+# --------------------------------------------------------------------------- #
+# schemas: Account / Portfolio
+# --------------------------------------------------------------------------- #
+def test_portfolio_ids_and_get():
+    pf = Portfolio(accounts=[
+        Account(id="PEA", type="PEA", currency="EUR", label="Mon PEA"),
+        Account(id="CTO", type="CTO", currency="EUR", label="CTO"),
+    ])
+    assert pf.ids() == {"PEA", "CTO"}
+    assert pf.get("PEA").label == "Mon PEA"
+    assert pf.get("UNKNOWN") is None
+
+
+# --------------------------------------------------------------------------- #
+# loader: account column
+# --------------------------------------------------------------------------- #
+def test_loader_reads_account_column_from_csv(tmp_path):
+    csv_path = tmp_path / "events.csv"
+    _write(csv_path, _CSV_WITH_ACCOUNTS)
+
+    events = EventLoader(str(csv_path)).load()
+    accounts = {e.symbol: e.account for e in events}
+    # (sorted by date; both AAPL rows preserved with their own account)
+    assert [e.account for e in events] == ["PEA", "CTO"]
+    assert accounts == {"AAPL": "CTO"}  # last write wins in the dict comprehension
+
+
+def test_loader_account_none_when_column_absent(tmp_path):
+    csv_path = tmp_path / "events.csv"
+    _write(csv_path,
+           "date,event_type,symbol,name,quantity,unit_price,fee,amount,notes\n"
+           "2024-01-15,BUY,AAPL,Apple Inc,10,150.00,2.50,,\n")
+    events = EventLoader(str(csv_path)).load()
+    assert events[0].account is None
+
+
+def test_loader_reads_account_column_from_xlsx(tmp_path):
+    openpyxl = pytest.importorskip("openpyxl")
+    xlsx_path = tmp_path / "events.xlsx"
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.append(["date", "event_type", "symbol", "name", "quantity",
+               "unit_price", "fee", "amount", "notes", "account"])
+    ws.append(["2024-01-15", "BUY", "AAPL", "Apple Inc", 10, 150.0, 2.5, None, None, "PEA"])
+    ws.append(["2024-01-16", "BUY", "AAPL", "Apple Inc", 5, 160.0, 1.0, None, None, "CTO"])
+    wb.save(xlsx_path)
+
+    events = EventLoader(str(xlsx_path)).load()
+    assert sorted(e.account for e in events) == ["CTO", "PEA"]
+
+
+# --------------------------------------------------------------------------- #
+# validator: account validation gated on declared accounts
+# --------------------------------------------------------------------------- #
+def _buy(account=None):
+    return Event(date(2024, 1, 15), EventType.BUY, "AAPL", "Apple Inc",
+                 quantity=10, unit_price=150.0, fee=2.5, account=account)
+
+
+def test_validator_ignores_account_when_none_declared():
+    """Without declared accounts, a missing account is fine."""
+    ok, errors = EventValidator().validate([_buy(account=None)])
+    assert ok
+    assert errors == []
+
+
+def test_validator_requires_account_when_declared():
+    validator = EventValidator(account_ids={"PEA", "CTO"})
+    ok, errors = validator.validate([_buy(account=None)])
+    assert not ok
+    assert any("account is required" in e for e in errors)
+
+
+def test_validator_rejects_unknown_account_id():
+    validator = EventValidator(account_ids={"PEA", "CTO"})
+    ok, errors = validator.validate([_buy(account="LIVRETA")])
+    assert not ok
+    assert any("not a declared account id" in e for e in errors)
+
+
+def test_validator_accepts_declared_account_id():
+    validator = EventValidator(account_ids={"PEA", "CTO"})
+    ok, errors = validator.validate([_buy(account="PEA")])
+    assert ok
+    assert errors == []
+
+
+# --------------------------------------------------------------------------- #
+# aggregator: (account, symbol) keying
+# --------------------------------------------------------------------------- #
+def test_aggregate_defaults_to_default_account_when_not_declared():
+    events = [
+        _buy(account="PEA"),  # account values present but ignored
+        Event(date(2024, 1, 16), EventType.BUY, "AAPL", "Apple Inc",
+              quantity=5, unit_price=160.0, fee=1.0, account="CTO"),
+    ]
+    shares = EventAggregator().aggregate(events, accounts_declared=False)
+    # Both rows collapse under a single 'default' AAPL position (10 + 5).
+    assert len(shares) == 1
+    assert shares[0]["account"] == DEFAULT_ACCOUNT
+    assert shares[0]["estate"]["quantity"] == 15
+
+
+def test_aggregate_keys_by_account_symbol_when_declared():
+    events = [
+        _buy(account="PEA"),
+        Event(date(2024, 1, 16), EventType.BUY, "AAPL", "Apple Inc",
+              quantity=5, unit_price=160.0, fee=1.0, account="CTO"),
+    ]
+    shares = EventAggregator().aggregate(events, accounts_declared=True)
+    by_account = {s["account"]: s for s in shares}
+    assert set(by_account) == {"PEA", "CTO"}
+    assert by_account["PEA"]["estate"]["quantity"] == 10
+    assert by_account["CTO"]["estate"]["quantity"] == 5
+    # Each account keeps its own weighted cost price.
+    assert by_account["PEA"]["purchase"]["cost_price"] == 150.0
+    assert by_account["CTO"]["purchase"]["cost_price"] == 160.0
+
+
+# --------------------------------------------------------------------------- #
+# ConfigurationManager: settings accounts block + load_accounts()
+# --------------------------------------------------------------------------- #
+def test_load_accounts_none_when_no_block(tmp_path):
+    cm = ConfigurationManager(config_dir=str(tmp_path))
+    assert cm.load_accounts() is None
+
+
+def test_load_accounts_parses_block(tmp_path):
+    _write(tmp_path / "settings.yaml", _SETTINGS_TWO_ACCOUNTS)
+    cm = ConfigurationManager(config_dir=str(tmp_path))
+    pf = cm.load_accounts()
+    assert pf is not None
+    assert pf.ids() == {"PEA", "CTO"}
+    # label defaults to id when omitted.
+    assert pf.get("CTO").label == "CTO"
+    assert pf.get("PEA").label == "Mon PEA"
+
+
+def test_load_accounts_available_even_with_env_mode(tmp_path, monkeypatch):
+    """Accounts are read from settings.yaml even when mode comes from env."""
+    _write(tmp_path / "settings.yaml", _SETTINGS_TWO_ACCOUNTS)
+    monkeypatch.setenv("SB_CONFIG_MODE", "events")
+    cm = ConfigurationManager(config_dir=str(tmp_path))
+    assert cm.load_accounts().ids() == {"PEA", "CTO"}
+
+
+def test_invalid_accounts_block_raises(tmp_path):
+    # Missing the required 'currency' field.
+    _write(tmp_path / "settings.yaml",
+           "accounts:\n  - id: PEA\n    type: PEA\n")
+    cm = ConfigurationManager(config_dir=str(tmp_path))
+    with pytest.raises(ValueError, match="Invalid 'accounts' block"):
+        cm.load_accounts()
+
+
+def test_duplicate_account_ids_raise(tmp_path):
+    _write(tmp_path / "settings.yaml",
+           "accounts:\n"
+           "  - id: PEA\n    type: PEA\n    currency: EUR\n"
+           "  - id: PEA\n    type: CTO\n    currency: EUR\n")
+    cm = ConfigurationManager(config_dir=str(tmp_path))
+    with pytest.raises(ValueError, match="Duplicate account id"):
+        cm.load_accounts()
+
+
+# --------------------------------------------------------------------------- #
+# ConfigurationManager: full events pipeline with accounts
+# --------------------------------------------------------------------------- #
+def test_events_pipeline_aggregates_per_account(tmp_path):
+    _write(tmp_path / "settings.yaml", _SETTINGS_TWO_ACCOUNTS)
+    _events_dir_with_accounts(tmp_path)
+
+    cm = ConfigurationManager(config_dir=str(tmp_path))
+    shares = cm.load_shares()
+
+    by_account = {s["account"]: s for s in shares}
+    assert set(by_account) == {"PEA", "CTO"}
+    assert by_account["PEA"]["estate"]["quantity"] == 10
+    assert by_account["CTO"]["estate"]["quantity"] == 5
+
+
+def test_events_pipeline_without_accounts_uses_default(tmp_path):
+    """Events mode without an accounts block: everything under 'default'."""
+    _write(tmp_path / "settings.yaml", "mode: events\n")
+    _events_dir_with_accounts(tmp_path)
+
+    cm = ConfigurationManager(config_dir=str(tmp_path))
+    shares = cm.load_shares()
+
+    assert len(shares) == 1
+    assert shares[0]["account"] == DEFAULT_ACCOUNT
+    assert shares[0]["estate"]["quantity"] == 15  # 10 (PEA) + 5 (CTO) merged
+
+
+def test_events_pipeline_missing_account_raises_when_declared(tmp_path):
+    _write(tmp_path / "settings.yaml", _SETTINGS_TWO_ACCOUNTS)
+    d = tmp_path / "events"
+    d.mkdir()
+    # Second row omits the account while accounts are declared.
+    _write(d / "2024.csv",
+           "date,event_type,symbol,name,quantity,unit_price,fee,amount,notes,account\n"
+           "2024-01-15,BUY,AAPL,Apple Inc,10,150.00,2.50,,,PEA\n"
+           "2024-01-16,BUY,AAPL,Apple Inc,5,160.00,1.00,,,\n")
+
+    cm = ConfigurationManager(config_dir=str(tmp_path))
+    with pytest.raises(EventValidationError, match="account is required"):
+        cm.load_shares()
+
+
+def test_events_pipeline_unknown_account_raises_when_declared(tmp_path):
+    _write(tmp_path / "settings.yaml", _SETTINGS_TWO_ACCOUNTS)
+    d = tmp_path / "events"
+    d.mkdir()
+    _write(d / "2024.csv",
+           "date,event_type,symbol,name,quantity,unit_price,fee,amount,notes,account\n"
+           "2024-01-15,BUY,AAPL,Apple Inc,10,150.00,2.50,,,LIVRETA\n")
+
+    cm = ConfigurationManager(config_dir=str(tmp_path))
+    with pytest.raises(EventValidationError, match="not a declared account id"):
+        cm.load_shares()
+
+
+# --------------------------------------------------------------------------- #
+# schema.yaml accepts the account key on a share dict
+# --------------------------------------------------------------------------- #
+def test_share_schema_accepts_account_key(shares_validator):
+    share = ShareState(name="Apple", symbol="AAPL", account="PEA").to_dict()
+    assert shares_validator.validate({"shares": [share]}), shares_validator.errors

--- a/app/tests/test_accounts.py
+++ b/app/tests/test_accounts.py
@@ -284,6 +284,82 @@ def test_events_pipeline_unknown_account_raises_when_declared(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
+# aggregate_until_date: account-aware point-in-time replay (backfill)
+# --------------------------------------------------------------------------- #
+def _two_account_events():
+    return [
+        Event(date(2024, 1, 15), EventType.BUY, "AAPL", "Apple Inc",
+              quantity=10, unit_price=150.0, fee=2.5, account="PEA"),
+        Event(date(2024, 1, 16), EventType.BUY, "AAPL", "Apple Inc",
+              quantity=5, unit_price=160.0, fee=1.0, account="CTO"),
+    ]
+
+
+def test_aggregate_until_date_scoped_to_account():
+    events = _two_account_events()
+    agg = EventAggregator()
+
+    pea = agg.aggregate_until_date(events, date(2024, 2, 1), "AAPL",
+                                   account="PEA", accounts_declared=True)
+    cto = agg.aggregate_until_date(events, date(2024, 2, 1), "AAPL",
+                                   account="CTO", accounts_declared=True)
+
+    assert pea["estate"]["quantity"] == 10
+    assert pea["account"] == "PEA"
+    assert cto["estate"]["quantity"] == 5
+    assert cto["account"] == "CTO"
+
+
+def test_aggregate_until_date_none_before_account_first_event():
+    events = _two_account_events()
+    # CTO's first event is 2024-01-16; before that it has no state.
+    result = EventAggregator().aggregate_until_date(
+        events, date(2024, 1, 15), "AAPL", account="CTO", accounts_declared=True)
+    assert result is None
+
+
+def test_aggregate_until_date_merges_all_accounts_when_none():
+    """Legacy symbol-scoped call (account=None) merges every account."""
+    events = _two_account_events()
+    merged = EventAggregator().aggregate_until_date(
+        events, date(2024, 2, 1), "AAPL")
+    assert merged["estate"]["quantity"] == 15
+
+
+# --------------------------------------------------------------------------- #
+# get_oldest_timestamp: account-scoped SQL (COALESCE, never WHERE account=)
+# --------------------------------------------------------------------------- #
+def test_get_oldest_timestamp_scopes_query_by_account(mocker):
+    from influxdb_writer import InfluxDBWriter
+
+    writer = InfluxDBWriter(host="http://x", token="t", database="db")
+    fake_client = mocker.MagicMock()
+    fake_client.query.return_value = None
+    writer._client = fake_client
+
+    writer.get_oldest_timestamp("AAPL", account="PEA")
+
+    sql = fake_client.query.call_args.kwargs["query"]
+    assert "COALESCE(account, 'default') = 'PEA'" in sql
+    # Never a bare account filter that would drop pre-tag (NULL) points.
+    assert "WHERE account =" not in sql
+
+
+def test_get_oldest_timestamp_no_account_filter_when_omitted(mocker):
+    from influxdb_writer import InfluxDBWriter
+
+    writer = InfluxDBWriter(host="http://x", token="t", database="db")
+    fake_client = mocker.MagicMock()
+    fake_client.query.return_value = None
+    writer._client = fake_client
+
+    writer.get_oldest_timestamp("AAPL")
+
+    sql = fake_client.query.call_args.kwargs["query"]
+    assert "account" not in sql
+
+
+# --------------------------------------------------------------------------- #
 # schema.yaml accepts the account key on a share dict
 # --------------------------------------------------------------------------- #
 def test_share_schema_accepts_account_key(shares_validator):

--- a/app/tests/test_influxdb_writer.py
+++ b/app/tests/test_influxdb_writer.py
@@ -187,8 +187,33 @@ def test_write_metrics_mandatory_tags_always_present_even_without_optionals(
     writer.write_metrics(share_name="Micro", share_symbol="MSFT")
 
     point = _last_written_record(client)
-    # Only the two mandatory tags, no optional tag keys.
-    assert set(point._tags.keys()) == {"share_name", "share_symbol"}
+    # The mandatory tags (name, symbol, account) are always present, no optionals.
+    assert set(point._tags.keys()) == {"share_name", "share_symbol", "account"}
+    # account defaults to 'default' so every point carries it.
+    assert point._tags["account"] == "default"
+
+
+def test_write_metrics_account_tag_when_provided(writer, mock_client_cls):
+    client = mock_client_cls.return_value
+
+    writer.write_metrics(share_name="Apple", share_symbol="AAPL", account="PEA")
+
+    point = _last_written_record(client)
+    assert point._tags["account"] == "PEA"
+
+
+def test_write_historical_prices_carries_account_tag(writer, mock_client_cls):
+    client = mock_client_cls.return_value
+
+    writer.write_historical_prices(
+        share_name="Apple", share_symbol="AAPL",
+        prices=[{"timestamp": datetime(2024, 1, 2, tzinfo=timezone.utc), "price": 100.0}],
+        account="CTO",
+    )
+
+    records = client.write.call_args.kwargs["record"]
+    point = records[0] if isinstance(records, list) else records
+    assert point._tags["account"] == "CTO"
 
 
 def test_write_metrics_optional_tags_only_when_provided(writer, mock_client_cls):

--- a/app/tests/test_metrics.py
+++ b/app/tests/test_metrics.py
@@ -39,14 +39,16 @@ class FakeConfigManager:
     """In-memory stand-in for main.ConfigurationManager.
 
     Exposes exactly the surface SuiviBourseMetrics relies on: load_shares(),
-    get_mode(), get_first_buy_date(), get_events().
+    get_mode(), get_first_buy_date(), get_events(), load_accounts().
     """
 
-    def __init__(self, shares, mode="manual", first_buy_dates=None, events=None):
+    def __init__(self, shares, mode="manual", first_buy_dates=None, events=None,
+                 accounts=None):
         self._shares = shares
         self._mode = mode
         self._first_buy_dates = first_buy_dates or {}
         self._events = events
+        self._accounts = accounts
         self.raise_on_load = False
 
     def load_shares(self, force=False):
@@ -56,6 +58,9 @@ class FakeConfigManager:
 
     def get_mode(self):
         return self._mode
+
+    def load_accounts(self):
+        return self._accounts
 
     def get_first_buy_date(self, symbol):
         return self._first_buy_dates.get(symbol)
@@ -344,7 +349,8 @@ def test_backfill_marks_complete_when_oldest_reaches_first_buy(
 
     mock_influx.write_historical_prices.assert_not_called()
     expected = datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc)
-    assert metrics._backfill_complete["AAPL"] == expected
+    # Completion is tracked per (symbol, account); default account here.
+    assert metrics._backfill_complete[("AAPL", "default")] == expected
 
 
 def test_backfill_fetches_chunk_when_gap_exists(mock_influx, shares_validator, mocker):
@@ -419,4 +425,4 @@ def test_backfill_empty_window_marks_complete(mock_influx, shares_validator, moc
 
     mock_influx.write_historical_prices.assert_not_called()
     expected = datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc)
-    assert metrics._backfill_complete["AAPL"] == expected
+    assert metrics._backfill_complete[("AAPL", "default")] == expected

--- a/app/tests/test_prometheus_exporter.py
+++ b/app/tests/test_prometheus_exporter.py
@@ -28,7 +28,8 @@ def _info(**overrides):
     return info
 
 
-AAPL = {'share_name': 'Apple', 'share_symbol': 'AAPL'}
+# A share without an 'account' key resolves to the 'default' account label.
+AAPL = {'share_name': 'Apple', 'share_symbol': 'AAPL', 'account': 'default'}
 
 
 @pytest.fixture
@@ -87,9 +88,27 @@ def test_dividend_yield_is_scaled_to_percentage(exporter):
 def test_share_info_gauge_carries_tag_labels(exporter):
     exporter.update_share(_share(), 150.0, _info())
     assert exporter.registry.get_sample_value('sb_share_info', {
-        'share_name': 'Apple', 'share_symbol': 'AAPL',
+        'share_name': 'Apple', 'share_symbol': 'AAPL', 'account': 'default',
         'share_currency': 'USD', 'share_exchange': 'NMS', 'quote_type': 'EQUITY',
     }) == 1.0
+
+
+# --- account label ----------------------------------------------------------
+
+def test_same_symbol_in_two_accounts_produces_distinct_series(exporter):
+    """A symbol held in two accounts must not collapse onto one series."""
+    pea = dict(_share(), account='PEA')
+    pea['estate'] = {'quantity': 10.0, 'received_dividend': 0.0}
+    cto = dict(_share(), account='CTO')
+    cto['estate'] = {'quantity': 5.0, 'received_dividend': 0.0}
+
+    exporter.update_share(pea, 150.0, _info())
+    exporter.update_share(cto, 150.0, _info())
+
+    assert exporter.registry.get_sample_value('sb_owned_quantity', {
+        'share_name': 'Apple', 'share_symbol': 'AAPL', 'account': 'PEA'}) == 10.0
+    assert exporter.registry.get_sample_value('sb_owned_quantity', {
+        'share_name': 'Apple', 'share_symbol': 'AAPL', 'account': 'CTO'}) == 5.0
 
 
 # --- None handling ----------------------------------------------------------
@@ -117,7 +136,7 @@ def test_failed_fetch_still_sets_portfolio_but_no_market(exporter):
     assert _val(exporter, 'sb_share_price') is None
     assert _val(exporter, 'sb_dividend_yield') is None
     assert exporter.registry.get_sample_value('sb_share_info', {
-        'share_name': 'Apple', 'share_symbol': 'AAPL',
+        'share_name': 'Apple', 'share_symbol': 'AAPL', 'account': 'default',
         'share_currency': 'USD', 'share_exchange': 'NMS', 'quote_type': 'EQUITY',
     }) is None
 

--- a/app/tests/test_schemas.py
+++ b/app/tests/test_schemas.py
@@ -193,6 +193,7 @@ def test_to_dict_default_structure():
     assert s.to_dict() == {
         'name': 'Apple',
         'symbol': 'AAPL',
+        'account': 'default',
         'purchase': {
             'quantity': 0.0,
             'cost_price': 0.0,
@@ -206,7 +207,7 @@ def test_to_dict_default_structure():
 
 
 def test_to_dict_reflects_populated_values():
-    s = ShareState(name="Microsoft", symbol="MSFT")
+    s = ShareState(name="Microsoft", symbol="MSFT", account="PEA")
     s.purchase.quantity = 10.0
     s.purchase.cost_price = 250.0
     s.purchase.fee = 4.0
@@ -216,6 +217,7 @@ def test_to_dict_reflects_populated_values():
     assert s.to_dict() == {
         'name': 'Microsoft',
         'symbol': 'MSFT',
+        'account': 'PEA',
         'purchase': {
             'quantity': 10.0,
             'cost_price': 250.0,
@@ -231,6 +233,13 @@ def test_to_dict_reflects_populated_values():
 def test_to_dict_exact_key_set():
     s = ShareState(name="Apple", symbol="AAPL")
     d = s.to_dict()
-    assert set(d.keys()) == {'name', 'symbol', 'purchase', 'estate'}
+    assert set(d.keys()) == {'name', 'symbol', 'account', 'purchase', 'estate'}
     assert set(d['purchase'].keys()) == {'quantity', 'cost_price', 'fee'}
     assert set(d['estate'].keys()) == {'quantity', 'received_dividend'}
+
+
+def test_to_dict_default_account_when_unset():
+    """A ShareState built without an account defaults to 'default'."""
+    s = ShareState(name="Apple", symbol="AAPL")
+    assert s.account == 'default'
+    assert s.to_dict()['account'] == 'default'

--- a/docker-compose/grafana_provisioning/dashboards/suivi_bourse.json
+++ b/docker-compose/grafana_provisioning/dashboards/suivi_bourse.json
@@ -84,7 +84,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "rawSql": "SELECT bucket as time, SUM(investment) as value FROM (SELECT DATE_BIN(INTERVAL '5 minutes', time) as bucket, share_symbol, AVG(purchased_price * purchased_quantity) as investment FROM portfolio_metrics WHERE $__timeFilter(time) AND purchased_price IS NOT NULL AND purchased_quantity IS NOT NULL GROUP BY bucket, share_symbol) GROUP BY bucket ORDER BY bucket",
+          "rawSql": "SELECT bucket as time, SUM(investment) as value FROM (SELECT DATE_BIN(INTERVAL '5 minutes', time) as bucket, share_symbol, COALESCE(account, 'default') as account, AVG(purchased_price * purchased_quantity) as investment FROM portfolio_metrics WHERE $__timeFilter(time) AND purchased_price IS NOT NULL AND purchased_quantity IS NOT NULL GROUP BY bucket, share_symbol, COALESCE(account, 'default')) GROUP BY bucket ORDER BY bucket",
           "refId": "A",
           "format": "time_series"
         }
@@ -147,7 +147,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "rawSql": "SELECT bucket as time, SUM(valuation) as value FROM (SELECT DATE_BIN(INTERVAL '5 minutes', time) as bucket, share_symbol, AVG(share_price * owned_quantity) as valuation FROM portfolio_metrics WHERE $__timeFilter(time) AND share_price IS NOT NULL AND owned_quantity IS NOT NULL GROUP BY bucket, share_symbol) GROUP BY bucket ORDER BY bucket",
+          "rawSql": "SELECT bucket as time, SUM(valuation) as value FROM (SELECT DATE_BIN(INTERVAL '5 minutes', time) as bucket, share_symbol, COALESCE(account, 'default') as account, AVG(share_price * owned_quantity) as valuation FROM portfolio_metrics WHERE $__timeFilter(time) AND share_price IS NOT NULL AND owned_quantity IS NOT NULL GROUP BY bucket, share_symbol, COALESCE(account, 'default')) GROUP BY bucket ORDER BY bucket",
           "refId": "A",
           "format": "time_series"
         }
@@ -214,7 +214,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "rawSql": "SELECT bucket as time, (SUM(valuation) + SUM(dividends) - SUM(investment)) / NULLIF(SUM(investment), 0) as value FROM (SELECT DATE_BIN(INTERVAL '5 minutes', time) as bucket, share_symbol, AVG(share_price * owned_quantity) as valuation, AVG(COALESCE(received_dividend, 0)) as dividends, AVG(purchased_price * purchased_quantity) as investment FROM portfolio_metrics WHERE $__timeFilter(time) AND share_price IS NOT NULL AND owned_quantity IS NOT NULL AND purchased_price IS NOT NULL AND purchased_quantity IS NOT NULL GROUP BY bucket, share_symbol) GROUP BY bucket ORDER BY bucket",
+          "rawSql": "SELECT bucket as time, (SUM(valuation) + SUM(dividends) - SUM(investment)) / NULLIF(SUM(investment), 0) as value FROM (SELECT DATE_BIN(INTERVAL '5 minutes', time) as bucket, share_symbol, COALESCE(account, 'default') as account, AVG(share_price * owned_quantity) as valuation, AVG(COALESCE(received_dividend, 0)) as dividends, AVG(purchased_price * purchased_quantity) as investment FROM portfolio_metrics WHERE $__timeFilter(time) AND share_price IS NOT NULL AND owned_quantity IS NOT NULL AND purchased_price IS NOT NULL AND purchased_quantity IS NOT NULL GROUP BY bucket, share_symbol, COALESCE(account, 'default')) GROUP BY bucket ORDER BY bucket",
           "refId": "A",
           "format": "time_series"
         }
@@ -454,7 +454,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "rawSql": "SELECT time, purchased_quantity as value FROM portfolio_metrics WHERE share_name = '${share}' AND $__timeFilter(time) AND purchased_quantity IS NOT NULL ORDER BY time DESC LIMIT 1",
+          "rawSql": "SELECT MAX(time) as time, SUM(value) as value FROM (SELECT time, purchased_quantity as value, ROW_NUMBER() OVER (PARTITION BY COALESCE(account, 'default') ORDER BY time DESC) as rn FROM portfolio_metrics WHERE share_name = '${share}' AND $__timeFilter(time) AND purchased_quantity IS NOT NULL) WHERE rn = 1",
           "refId": "A",
           "format": "time_series"
         }
@@ -518,7 +518,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "rawSql": "SELECT time, purchased_price as value FROM portfolio_metrics WHERE share_name = '${share}' AND $__timeFilter(time) AND purchased_price IS NOT NULL ORDER BY time DESC LIMIT 1",
+          "rawSql": "SELECT MAX(time) as time, SUM(pp * pq) / NULLIF(SUM(pq), 0) as value FROM (SELECT time, purchased_price as pp, purchased_quantity as pq, ROW_NUMBER() OVER (PARTITION BY COALESCE(account, 'default') ORDER BY time DESC) as rn FROM portfolio_metrics WHERE share_name = '${share}' AND $__timeFilter(time) AND purchased_price IS NOT NULL AND purchased_quantity IS NOT NULL) WHERE rn = 1",
           "refId": "A",
           "format": "time_series"
         }
@@ -581,7 +581,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "rawSql": "SELECT time, purchased_fee as value FROM portfolio_metrics WHERE share_name = '${share}' AND $__timeFilter(time) AND purchased_fee IS NOT NULL ORDER BY time DESC LIMIT 1",
+          "rawSql": "SELECT MAX(time) as time, SUM(value) as value FROM (SELECT time, purchased_fee as value, ROW_NUMBER() OVER (PARTITION BY COALESCE(account, 'default') ORDER BY time DESC) as rn FROM portfolio_metrics WHERE share_name = '${share}' AND $__timeFilter(time) AND purchased_fee IS NOT NULL) WHERE rn = 1",
           "refId": "A",
           "format": "time_series"
         }
@@ -717,7 +717,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "rawSql": "SELECT time, (share_price - purchased_price) as value FROM portfolio_metrics WHERE share_name = '${share}' AND $__timeFilter(time) AND share_price IS NOT NULL AND purchased_price IS NOT NULL ORDER BY time DESC LIMIT 1",
+          "rawSql": "SELECT MAX(time) as time, MAX(sp) - (SUM(pp * pq) / NULLIF(SUM(pq), 0)) as value FROM (SELECT time, share_price as sp, purchased_price as pp, purchased_quantity as pq, ROW_NUMBER() OVER (PARTITION BY COALESCE(account, 'default') ORDER BY time DESC) as rn FROM portfolio_metrics WHERE share_name = '${share}' AND $__timeFilter(time) AND share_price IS NOT NULL AND purchased_price IS NOT NULL AND purchased_quantity IS NOT NULL) WHERE rn = 1",
           "refId": "A",
           "format": "time_series"
         }
@@ -779,7 +779,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "rawSql": "SELECT time, owned_quantity as value FROM portfolio_metrics WHERE share_name = '${share}' AND $__timeFilter(time) AND owned_quantity IS NOT NULL ORDER BY time DESC LIMIT 1",
+          "rawSql": "SELECT MAX(time) as time, SUM(value) as value FROM (SELECT time, owned_quantity as value, ROW_NUMBER() OVER (PARTITION BY COALESCE(account, 'default') ORDER BY time DESC) as rn FROM portfolio_metrics WHERE share_name = '${share}' AND $__timeFilter(time) AND owned_quantity IS NOT NULL) WHERE rn = 1",
           "refId": "A",
           "format": "time_series"
         }
@@ -842,7 +842,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "rawSql": "SELECT time, received_dividend as value FROM portfolio_metrics WHERE share_name = '${share}' AND $__timeFilter(time) AND received_dividend IS NOT NULL ORDER BY time DESC LIMIT 1",
+          "rawSql": "SELECT MAX(time) as time, SUM(value) as value FROM (SELECT time, received_dividend as value, ROW_NUMBER() OVER (PARTITION BY COALESCE(account, 'default') ORDER BY time DESC) as rn FROM portfolio_metrics WHERE share_name = '${share}' AND $__timeFilter(time) AND received_dividend IS NOT NULL) WHERE rn = 1",
           "refId": "A",
           "format": "time_series"
         }
@@ -914,7 +914,7 @@
             "type": "influxdb",
             "uid": "${DS_INFLUXDB}"
           },
-          "rawSql": "SELECT time, ((owned_quantity * share_price) + COALESCE(received_dividend, 0) - (purchased_quantity * purchased_price) - COALESCE(purchased_fee, 0)) as value FROM portfolio_metrics WHERE share_name = '${share}' AND $__timeFilter(time) AND share_price IS NOT NULL AND owned_quantity IS NOT NULL AND purchased_price IS NOT NULL AND purchased_quantity IS NOT NULL ORDER BY time DESC LIMIT 1",
+          "rawSql": "SELECT MAX(time) as time, SUM(oq * sp) + SUM(COALESCE(rd, 0)) - SUM(pq * pp) - SUM(COALESCE(pf, 0)) as value FROM (SELECT time, owned_quantity as oq, share_price as sp, received_dividend as rd, purchased_quantity as pq, purchased_price as pp, purchased_fee as pf, ROW_NUMBER() OVER (PARTITION BY COALESCE(account, 'default') ORDER BY time DESC) as rn FROM portfolio_metrics WHERE share_name = '${share}' AND $__timeFilter(time) AND share_price IS NOT NULL AND owned_quantity IS NOT NULL AND purchased_price IS NOT NULL AND purchased_quantity IS NOT NULL) WHERE rn = 1",
           "refId": "A",
           "format": "time_series"
         }

--- a/website/docs/configuration/events-mode.mdx
+++ b/website/docs/configuration/events-mode.mdx
@@ -98,6 +98,7 @@ Requires the `openpyxl` library, which is bundled in the Docker image.
 | `fee` | Optional | Transaction fee (must be `>= 0`) |
 | `amount` | For `DIVIDEND` | Dividend amount received |
 | `notes` | Optional | Free-text comment (ignored by the app) |
+| `account` | Only when [accounts](#accounts-opt-in) are declared | Account `id` this event belongs to |
 
 The four required columns must always be present in the header. Empty cells are
 allowed for the columns that don't apply to a given event type.
@@ -155,6 +156,80 @@ so raises an aggregation error and the previous valid configuration is kept.
 ### DIVIDEND — received dividends
 
 - Increases `estate.received_dividend` by `amount`.
+
+## Accounts (opt-in)
+
+By default every position is tracked in a single implicit account named
+`default`. If you hold the **same share across several accounts** (e.g. a PEA
+and a CTO, or several brokers), you can declare them as first-class accounts so
+each position is tracked — and priced — separately.
+
+This is an **opt-in** feature: it is enabled only by adding an `accounts:` block
+to `settings.yaml`. Without it, nothing changes.
+
+### Declaring accounts
+
+```yaml title="settings.yaml"
+mode: events
+events:
+  source: ~/.config/SuiviBourse/events/
+accounts:
+  - id: PEA          # referenced by the `account` column in your event files
+    type: PEA        # free-form label (PEA, CTO, 401k, …)
+    currency: EUR
+    label: Mon PEA   # optional display name (defaults to `id`)
+  - id: CTO
+    type: CTO
+    currency: EUR
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Unique identifier, referenced by the `account` column of your events |
+| `type` | Yes | Free-form account type (`PEA`, `CTO`, `401k`, …) |
+| `currency` | Yes | Account currency (`EUR`, `USD`, …) |
+| `label` | No | Display name (defaults to `id`) |
+
+### The `account` column
+
+Once accounts are declared, **every event line must carry an `account` column**
+whose value matches a declared `id`:
+
+```csv title="events/2024.csv"
+date,event_type,symbol,name,quantity,unit_price,fee,amount,notes,account
+2024-01-15,BUY,AAPL,Apple Inc,10,150.00,2.50,,,PEA
+2024-01-16,BUY,AAPL,Apple Inc,5,160.00,1.00,,,CTO
+```
+
+- A line **without** an `account` value is a validation error.
+- An `account` value that does **not** match any declared `id` is a validation
+  error.
+- With the example above, AAPL is tracked as **two independent positions** —
+  10 shares in the PEA and 5 in the CTO — each with its own weighted average
+  cost price.
+
+:::note What if I don't declare accounts?
+The `account` column is simply ignored and every position falls under the
+implicit `default` account. Manual mode is unaffected as well.
+:::
+
+### How accounts appear downstream
+
+- **InfluxDB** — every point of `portfolio_metrics` carries an `account` tag
+  (`default` when accounts aren't declared).
+- **Prometheus** — the `sb_*` gauges gain an `account` label, so the same
+  symbol held in two accounts no longer overwrites itself.
+- **Grafana (dashboard 1)** — the "patrimoine total" dashboard **aggregates
+  across all accounts**: `Owned quantity`, `Total Investment`, etc. sum the
+  accounts, and `Cost price` is their quantity-weighted average. It stays a
+  single "total wealth" view and does **not** add an account selector.
+
+:::info Existing data
+Points written before this feature existed have no `account` tag; InfluxDB
+exposes them as `NULL`. The dashboard queries read them with
+`COALESCE(account, 'default')`, so your historical data stays visible and is
+aggregated correctly. No migration or history rewrite is performed.
+:::
 
 ## Key behaviours
 


### PR DESCRIPTION
## Résumé

Implémente **#574** — les comptes deviennent des objets de premier ordre en mode `events`, de bout en bout (déclaration dans `settings.yaml` → tag InfluxDB / label Prometheus → dashboard Grafana). Feature **opt-in** : sans bloc `accounts:`, le comportement est strictement inchangé.

Closes #574

## Ce qui change

- **Config** : `settings.yaml` accepte un bloc `accounts:` (`id`, `type`, `currency`, `label`), validé par Cerberus. Les events CSV **et** XLSX gagnent une colonne `account`, requise et validée contre les `id` déclarés dès lors que des comptes existent.
- **Agrégation** : positions keyées par `(account, symbol)`. Sans comptes déclarés, tout tombe sous le compte implicite `default` (un seul code path). `shares` est **étendu** d'une clé `account` ; `ConfigurationManager.load_accounts() -> Optional[Portfolio]`.
- **Sortie** : `portfolio_metrics` porte un tag `account` sur 100 % des points écrits (`default` par défaut) ; les gauges `sb_*` gagnent un label `account` (deux comptes d'un même symbole ne s'écrasent plus).
- **Dashboard 1** : requêtes corrigées pour **agréger sur tous les comptes** (`SUM`, moyenne pondérée du `cost_price`, `GROUP BY (share_symbol, account)` avant le `SUM`). Lecture en `COALESCE(account, 'default')` — jamais `WHERE account = …` — donc les points antérieurs (tag `NULL`) restent visibles et correctement agrégés. Pas de variable `$account` : la vue reste « patrimoine total ».
- **Backfill par compte** (corrigé après revue) : détection de gap et suivi de complétion keyés par `(symbol, account)`, `aggregate_until_date` conscient du compte — l'historique de chaque compte est écrit indépendamment.

## Tests & qualité

- `260 passed` (`uv run pytest tests/`), dont un nouveau `tests/test_accounts.py` couvrant loader/validator/agrégateur/ConfigurationManager/backfill par compte.
- `flake8 --ignore=E501` propre ; build docusaurus OK (pas de lien cassé).
- Revue `/code-review` (axes Standards + Spec) passée ; le bug de backfill multi-comptes remonté par l'axe Spec est corrigé dans ce PR.

## Notes de compat

- Mode `manual` et mode `events` sans bloc `accounts:` : inchangés fonctionnellement (le tag/label `account=default` universel est attendu par le critère « 100 % des points »).
- Aucune migration ni réécriture d'historique (conforme à #572).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional multi-account support for event imports and portfolio tracking.
  * Added account validation and separate aggregation for identical shares held in different accounts.
  * Added account tags to InfluxDB metrics and labels to Prometheus metrics.
  * Added volume metrics to Prometheus.
  * Updated Grafana totals to aggregate holdings across accounts.

* **Documentation**
  * Documented account configuration, event columns, validation rules, and dashboard behavior.
  * Updated metrics schemas to include account information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->