### PR TITLE
feat(app): Timeline replay aggregation (#575)

### DIFF
--- a/app/src/events/__init__.py
+++ b/app/src/events/__init__.py
@@ -7,7 +7,7 @@ and generates aggregated configuration compatible with the existing schema.
 
 from .schemas import (
     DEFAULT_ACCOUNT, Event, EventType, ShareState, PurchaseState, EstateState,
-    Account, Portfolio,
+    Account, Portfolio, Timeline, InKindFlow,
 )
 from .loader import EventLoader
 from .validator import EventValidator
@@ -23,6 +23,8 @@ __all__ = [
     'EstateState',
     'Account',
     'Portfolio',
+    'Timeline',
+    'InKindFlow',
     'EventLoader',
     'EventValidator',
     'EventAggregator',

--- a/app/src/events/aggregator.py
+++ b/app/src/events/aggregator.py
@@ -2,11 +2,13 @@
 Event aggregator for computing portfolio state from events.
 """
 
+import copy
 from datetime import date
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 from .schemas import (
     DEFAULT_ACCOUNT, Event, EventType, ShareState, PurchaseState, EstateState,
+    Timeline, InKindFlow,
 )
 
 
@@ -31,7 +33,10 @@ class EventAggregator:
 
     def aggregate(self, events: List[Event], accounts_declared: bool = False) -> List[Dict]:
         """
-        Aggregate events into share configurations.
+        Aggregate events into share configurations (latest state).
+
+        Thin wrapper over :meth:`replay`: there is a single replay implementation
+        and this returns its final state per position.
 
         Args:
             events: List of events sorted by date.
@@ -45,9 +50,31 @@ class EventAggregator:
         Raises:
             AggregationError: If aggregation fails (e.g., selling more than owned).
         """
-        # Group events by (account, symbol) and process in order
+        return self.replay(events, accounts_declared).current()
+
+    def replay(self, events: List[Event], accounts_declared: bool = False) -> Timeline:
+        """
+        Replay events once into a sparse :class:`Timeline`.
+
+        A single replay serves every symbol and every date: the timeline records
+        one snapshot per position per date where its state changes, and
+        forward-fills on query (``Timeline.at`` / ``position_at``). External
+        flows are emitted **without** a price (the aggregator never reads one).
+
+        Args:
+            events: List of events sorted by date.
+            accounts_declared: When True, positions are keyed by
+                ``(account, symbol)``; otherwise everything falls under
+                ``default``.
+
+        Returns:
+            A Timeline covering all positions.
+
+        Raises:
+            AggregationError: If aggregation fails (e.g., selling more than owned).
+        """
+        timeline = Timeline()
         states: Dict[Tuple[str, str], ShareState] = {}
-        order: List[Tuple[str, str]] = []
 
         for event in events:
             account = self._event_account(event, accounts_declared)
@@ -61,7 +88,8 @@ class EventAggregator:
                     purchase=PurchaseState(),
                     estate=EstateState(),
                 )
-                order.append(key)
+                timeline.snapshots[key] = []
+                timeline.order.append(key)
 
             state = states[key]
 
@@ -76,11 +104,32 @@ class EventAggregator:
                 self._process_sell(state, event)
             elif event.event_type == EventType.GRANT:
                 self._process_grant(state, event)
+                # GRANT is an external in-kind flow, emitted non-valued.
+                timeline.flows.append(InKindFlow(
+                    date=event.date, account=account,
+                    symbol=event.symbol, quantity=event.quantity))
             elif event.event_type == EventType.DIVIDEND:
                 self._process_dividend(state, event)
 
-        # Convert to list of dicts, preserving (account, symbol) first-appearance order
-        return [states[key].to_dict() for key in order]
+            # Record the position's state as of this date (one snapshot per date)
+            self._snapshot(timeline.snapshots[key], event.date, state)
+
+        return timeline
+
+    @staticmethod
+    def _snapshot(
+        snaps: List[Tuple[date, ShareState]], on_date: date, state: ShareState
+    ) -> None:
+        """Append (or, for a same-date change, replace) an immutable snapshot.
+
+        Events are date-sorted, so a same-date event just supersedes the day's
+        prior snapshot — the timeline keeps exactly one snapshot per change date.
+        """
+        snap = copy.deepcopy(state)
+        if snaps and snaps[-1][0] == on_date:
+            snaps[-1] = (on_date, snap)
+        else:
+            snaps.append((on_date, snap))
 
     def _process_buy(self, state: ShareState, event: Event) -> None:
         """
@@ -140,66 +189,3 @@ class EventAggregator:
         Increases estate.received_dividend.
         """
         state.estate.received_dividend += event.amount
-
-    def aggregate_until_date(
-        self,
-        events: List[Event],
-        target_date: date,
-        symbol: str,
-        account: Optional[str] = None,
-        accounts_declared: bool = False,
-    ) -> Optional[Dict]:
-        """
-        Aggregate events for a specific symbol up to a given date.
-
-        Args:
-            events: List of events sorted by date.
-            target_date: Only process events up to this date (inclusive).
-            symbol: The symbol to aggregate.
-            account: When provided, only events belonging to this account bucket
-                are replayed, so each account's historical state is independent.
-                When None, every account is merged (symbol-scoped, legacy).
-            accounts_declared: Whether accounts are declared, to resolve each
-                event's bucket the same way :meth:`aggregate` does.
-
-        Returns:
-            Share dictionary for the symbol, or None if no events exist.
-        """
-        # Filter events for the symbol up to target_date (and account if given)
-        def _keep(e: Event) -> bool:
-            if e.symbol != symbol or e.date > target_date:
-                return False
-            if account is None:
-                return True
-            return self._event_account(e, accounts_declared) == account
-
-        filtered_events = [e for e in events if _keep(e)]
-
-        if not filtered_events:
-            return None
-
-        # Create initial state
-        state = ShareState(
-            name=filtered_events[0].name,
-            symbol=symbol,
-            account=account or DEFAULT_ACCOUNT,
-            purchase=PurchaseState(),
-            estate=EstateState(),
-        )
-
-        for event in filtered_events:
-            # Update name if provided (use latest name)
-            if event.name:
-                state.name = event.name
-
-            # Process based on event type
-            if event.event_type == EventType.BUY:
-                self._process_buy(state, event)
-            elif event.event_type == EventType.SELL:
-                self._process_sell(state, event)
-            elif event.event_type == EventType.GRANT:
-                self._process_grant(state, event)
-            elif event.event_type == EventType.DIVIDEND:
-                self._process_dividend(state, event)
-
-        return state.to_dict()

--- a/app/src/events/schemas.py
+++ b/app/src/events/schemas.py
@@ -2,6 +2,7 @@
 Data schemas for the events module.
 """
 
+import bisect
 from dataclasses import dataclass, field
 from datetime import date  # noqa: F401 — used in the `date: date` field annotation (eager-evaluated on Python <3.14)
 from enum import Enum
@@ -122,14 +123,13 @@ class Timeline:
     def _state_at(
         snaps: List[Tuple[date, "ShareState"]], target_date: date
     ) -> Optional["ShareState"]:
-        """Latest snapshot at or before ``target_date`` (forward-fill), or None."""
-        result = None
-        for change_date, state in snaps:
-            if change_date <= target_date:
-                result = state
-            else:
-                break
-        return result
+        """Latest snapshot at or before ``target_date`` (forward-fill), or None.
+
+        Snapshots are date-sorted, so this is a binary search: the position just
+        left of the insertion point is the latest change on or before the date.
+        """
+        idx = bisect.bisect_right(snaps, target_date, key=lambda snap: snap[0])
+        return snaps[idx - 1][1] if idx else None
 
     def position_at(
         self, account: str, symbol: str, target_date: date

--- a/app/src/events/schemas.py
+++ b/app/src/events/schemas.py
@@ -5,7 +5,7 @@ Data schemas for the events module.
 from dataclasses import dataclass, field
 from datetime import date  # noqa: F401 — used in the `date: date` field annotation (eager-evaluated on Python <3.14)
 from enum import Enum
-from typing import List, Optional, Set
+from typing import Dict, List, Optional, Set, Tuple
 
 
 # Canonical account bucket used when no accounts are declared (opt-out users) or
@@ -83,6 +83,83 @@ class ShareState:
                 'received_dividend': self.estate.received_dividend,
             },
         }
+
+
+@dataclass
+class InKindFlow:
+    """A non-valued in-kind external flow (currently a GRANT).
+
+    The aggregator emits it *without* a price — valuation at the day's price is
+    resolved downstream (performance module), which is why the aggregator never
+    needs to know a price. Kept here as the tracer for future cash flows
+    (DEPOSIT/WITHDRAWAL land in a later slice).
+    """
+    date: date
+    account: str
+    symbol: str
+    quantity: float
+
+
+@dataclass
+class Timeline:
+    """A sparse replay of portfolio events.
+
+    Holds, per ``(account, symbol)`` position, one snapshot per date where that
+    position's state changed (not one per calendar day). ``at()`` /
+    ``position_at()`` forward-fill: they return the latest snapshot at or before
+    the requested date, so the timeline is agnostic to the query window (the
+    window is an InfluxDB property that grows with backfill, not a property of
+    the events).
+    """
+    # (account, symbol) -> ascending [(change_date, ShareState snapshot)]
+    snapshots: Dict[Tuple[str, str], List[Tuple[date, "ShareState"]]] = field(default_factory=dict)
+    # First-appearance order of the positions (stable output ordering)
+    order: List[Tuple[str, str]] = field(default_factory=list)
+    # Non-valued external flows collected during the replay
+    flows: List[InKindFlow] = field(default_factory=list)
+
+    @staticmethod
+    def _state_at(
+        snaps: List[Tuple[date, "ShareState"]], target_date: date
+    ) -> Optional["ShareState"]:
+        """Latest snapshot at or before ``target_date`` (forward-fill), or None."""
+        result = None
+        for change_date, state in snaps:
+            if change_date <= target_date:
+                result = state
+            else:
+                break
+        return result
+
+    def position_at(
+        self, account: str, symbol: str, target_date: date
+    ) -> Optional[dict]:
+        """State of one ``(account, symbol)`` position at ``target_date``.
+
+        Returns None when the position has no event on or before that date
+        (including before its first event — an empty state, never an error).
+        """
+        snaps = self.snapshots.get((account, symbol))
+        if not snaps:
+            return None
+        state = self._state_at(snaps, target_date)
+        return state.to_dict() if state is not None else None
+
+    def at(self, target_date: date) -> List[dict]:
+        """Every position's state at ``target_date`` (forward-filled).
+
+        Positions with no event on or before ``target_date`` are omitted.
+        """
+        result = []
+        for key in self.order:
+            state = self._state_at(self.snapshots[key], target_date)
+            if state is not None:
+                result.append(state.to_dict())
+        return result
+
+    def current(self) -> List[dict]:
+        """The latest state of every position (replaces the old full aggregate)."""
+        return [self.snapshots[key][-1][1].to_dict() for key in self.order]
 
 
 @dataclass

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -633,6 +633,12 @@ class SuiviBourseMetrics:
         # accounts backfills each series independently.
         accounts_declared = self.config_manager.load_accounts() is not None
 
+        # A single replay per cycle serves every symbol and every date; each
+        # per-date lookup below is a forward-fill on this timeline, never a
+        # re-replay (backfill drops from O(days × events) to O(events + days)).
+        events = self.config_manager.get_events()
+        timeline = EventAggregator().replay(events, accounts_declared) if events else None
+
         for share in self.shares:
             symbol = share['symbol']
             name = share['name']
@@ -730,22 +736,18 @@ class SuiviBourseMetrics:
                 time.sleep(self.backfill_delay)
                 continue
 
-            # Enrich price data with portfolio state at each date
-            events = self.config_manager.get_events()
-            if events:
-                aggregator = EventAggregator()
-                # Many price points (esp. hourly) share the same calendar day and
-                # thus the same portfolio state; aggregate once per date instead of
-                # replaying all events for every point.
+            # Enrich price data with portfolio state at each date, read from the
+            # single per-cycle timeline. Many price points (esp. hourly) share the
+            # same calendar day and thus the same state; look up once per date.
+            if timeline is not None:
                 state_by_date: Dict = {}
                 for price_point in prices:
                     ts = price_point['timestamp']
-                    # Convert datetime to date for aggregation
+                    # Convert datetime to date for the timeline lookup
                     point_date = ts.date() if isinstance(ts, datetime) else ts
                     if point_date not in state_by_date:
-                        state_by_date[point_date] = aggregator.aggregate_until_date(
-                            events, point_date, symbol,
-                            account=account, accounts_declared=accounts_declared)
+                        state_by_date[point_date] = timeline.position_at(
+                            account, symbol, point_date)
                     state = state_by_date[point_date]
                     if state:
                         price_point['purchased_quantity'] = state['purchase']['quantity']

--- a/app/tests/test_accounts.py
+++ b/app/tests/test_accounts.py
@@ -284,7 +284,7 @@ def test_events_pipeline_unknown_account_raises_when_declared(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
-# aggregate_until_date: account-aware point-in-time replay (backfill)
+# replay + Timeline.position_at: account-aware point-in-time state (backfill)
 # --------------------------------------------------------------------------- #
 def _two_account_events():
     return [
@@ -295,14 +295,11 @@ def _two_account_events():
     ]
 
 
-def test_aggregate_until_date_scoped_to_account():
-    events = _two_account_events()
-    agg = EventAggregator()
+def test_position_at_scoped_to_account():
+    tl = EventAggregator().replay(_two_account_events(), accounts_declared=True)
 
-    pea = agg.aggregate_until_date(events, date(2024, 2, 1), "AAPL",
-                                   account="PEA", accounts_declared=True)
-    cto = agg.aggregate_until_date(events, date(2024, 2, 1), "AAPL",
-                                   account="CTO", accounts_declared=True)
+    pea = tl.position_at("PEA", "AAPL", date(2024, 2, 1))
+    cto = tl.position_at("CTO", "AAPL", date(2024, 2, 1))
 
     assert pea["estate"]["quantity"] == 10
     assert pea["account"] == "PEA"
@@ -310,20 +307,19 @@ def test_aggregate_until_date_scoped_to_account():
     assert cto["account"] == "CTO"
 
 
-def test_aggregate_until_date_none_before_account_first_event():
-    events = _two_account_events()
-    # CTO's first event is 2024-01-16; before that it has no state.
-    result = EventAggregator().aggregate_until_date(
-        events, date(2024, 1, 15), "AAPL", account="CTO", accounts_declared=True)
-    assert result is None
+def test_position_at_none_before_account_first_event():
+    tl = EventAggregator().replay(_two_account_events(), accounts_declared=True)
+    # CTO's first event is 2024-01-16; before that it has no state (not an error).
+    assert tl.position_at("CTO", "AAPL", date(2024, 1, 15)) is None
 
 
-def test_aggregate_until_date_merges_all_accounts_when_none():
-    """Legacy symbol-scoped call (account=None) merges every account."""
-    events = _two_account_events()
-    merged = EventAggregator().aggregate_until_date(
-        events, date(2024, 2, 1), "AAPL")
+def test_replay_merges_all_events_under_default_when_not_declared():
+    """Without declared accounts every event falls under 'default'."""
+    tl = EventAggregator().replay(_two_account_events(), accounts_declared=False)
+    merged = tl.position_at("default", "AAPL", date(2024, 2, 1))
     assert merged["estate"]["quantity"] == 15
+    # No per-account positions exist in this mode.
+    assert tl.position_at("PEA", "AAPL", date(2024, 2, 1)) is None
 
 
 # --------------------------------------------------------------------------- #

--- a/app/tests/test_aggregator.py
+++ b/app/tests/test_aggregator.py
@@ -298,7 +298,7 @@ def test_full_pipeline_matches_expected_state(aggregator):
 
 
 # ---------------------------------------------------------------------------
-# aggregate_until_date()
+# replay() + Timeline.position_at() — point-in-time state (forward-fill)
 # ---------------------------------------------------------------------------
 
 def _timeline():
@@ -316,16 +316,18 @@ def _timeline():
     ]
 
 
-def test_until_date_returns_none_when_no_matching_events(aggregator):
+def test_position_at_returns_none_when_no_matching_events(aggregator):
+    tl = aggregator.replay(_timeline())
     # Symbol not present at all.
-    assert aggregator.aggregate_until_date(_timeline(), date(2024, 12, 31), "TSLA") is None
-    # Symbol present but every event is after the target date.
-    assert aggregator.aggregate_until_date(_timeline(), date(2024, 1, 1), "AAPL") is None
+    assert tl.position_at("default", "TSLA", date(2024, 12, 31)) is None
+    # Symbol present but every event is after the target date (empty, not error).
+    assert tl.position_at("default", "AAPL", date(2024, 1, 1)) is None
 
 
-def test_until_date_boundary_is_inclusive(aggregator):
+def test_position_at_boundary_is_inclusive(aggregator):
+    tl = aggregator.replay(_timeline())
     # target_date exactly equals the first AAPL event date -> that event counts.
-    result = aggregator.aggregate_until_date(_timeline(), date(2024, 1, 15), "AAPL")
+    result = tl.position_at("default", "AAPL", date(2024, 1, 15))
 
     assert result is not None
     assert result["symbol"] == "AAPL"
@@ -335,12 +337,12 @@ def test_until_date_boundary_is_inclusive(aggregator):
     assert result["estate"]["received_dividend"] == 0.0
 
 
-def test_until_date_intermediate_state_differs_from_final(aggregator):
-    events = _timeline()
+def test_position_at_forward_fills_date_without_event(aggregator):
+    tl = aggregator.replay(_timeline())
 
-    # Intermediate date: after the first BUY + dividend, but BEFORE the second
-    # AAPL BUY (2024-06-15) and BEFORE the SELL (2024-09-15).
-    mid = aggregator.aggregate_until_date(events, date(2024, 5, 1), "AAPL")
+    # 2024-05-01 has no event: forward-fill from the 2024-03-01 dividend state,
+    # after the first BUY but BEFORE the second AAPL BUY and the SELL.
+    mid = tl.position_at("default", "AAPL", date(2024, 5, 1))
     assert mid is not None
     assert mid["purchase"]["quantity"] == 10
     assert mid["purchase"]["cost_price"] == 150.0
@@ -349,7 +351,7 @@ def test_until_date_intermediate_state_differs_from_final(aggregator):
     assert mid["estate"]["received_dividend"] == pytest.approx(2.40)
 
     # Final date: includes the second BUY and the SELL, so it must differ.
-    final = aggregator.aggregate_until_date(events, date(2024, 12, 31), "AAPL")
+    final = tl.position_at("default", "AAPL", date(2024, 12, 31))
     assert final is not None
     assert final["purchase"]["quantity"] == 15
     assert final["purchase"]["cost_price"] == pytest.approx(
@@ -362,12 +364,74 @@ def test_until_date_intermediate_state_differs_from_final(aggregator):
     assert mid["purchase"]["cost_price"] != final["purchase"]["cost_price"]
 
 
-def test_until_date_filters_by_symbol(aggregator):
+def test_position_at_isolates_symbol(aggregator):
+    tl = aggregator.replay(_timeline())
     # Only MSFT events should be considered; AAPL activity must not leak in.
-    result = aggregator.aggregate_until_date(_timeline(), date(2024, 12, 31), "MSFT")
+    result = tl.position_at("default", "MSFT", date(2024, 12, 31))
 
     assert result is not None
     assert result["symbol"] == "MSFT"
     assert result["purchase"]["quantity"] == 5
     assert result["purchase"]["cost_price"] == 380.0
     assert result["estate"]["quantity"] == 5
+
+
+def test_replay_timeline_is_sparse(aggregator):
+    """One snapshot per date the position changes, not per calendar day."""
+    tl = aggregator.replay(_timeline())
+    aapl_snaps = tl.snapshots[("default", "AAPL")]
+    # AAPL changes on 4 dates: 01-15 BUY, 03-01 DIVIDEND, 06-15 BUY, 09-15 SELL.
+    assert [d for d, _ in aapl_snaps] == [
+        date(2024, 1, 15), date(2024, 3, 1), date(2024, 6, 15), date(2024, 9, 15)]
+    assert len(tl.snapshots[("default", "MSFT")]) == 1
+
+
+def test_replay_snapshots_are_immutable_copies(aggregator):
+    """Later events must not mutate earlier snapshots (deep-copied)."""
+    tl = aggregator.replay(_timeline())
+    snaps = tl.snapshots[("default", "AAPL")]
+    first_state = snaps[0][1]      # state as of 2024-01-15
+    last_state = snaps[-1][1]      # state as of 2024-09-15
+    assert first_state.estate.quantity == 10
+    assert last_state.estate.quantity == 12
+    assert first_state is not last_state
+
+
+def test_replay_emits_grant_as_non_valued_inkind_flow():
+    from events import EventAggregator, InKindFlow
+    events = [
+        Event(date(2024, 1, 15), EventType.BUY, "AAPL", "Apple Inc",
+              quantity=10, unit_price=150.0, fee=2.5),
+        Event(date(2024, 6, 1), EventType.GRANT, "AAPL", "Apple Inc", quantity=2),
+    ]
+    tl = EventAggregator().replay(events)
+    assert len(tl.flows) == 1
+    flow = tl.flows[0]
+    assert isinstance(flow, InKindFlow)
+    assert (flow.date, flow.account, flow.symbol, flow.quantity) == (
+        date(2024, 6, 1), "default", "AAPL", 2)
+    # Non-valued: the flow carries no price.
+    assert not hasattr(flow, "price")
+
+
+def test_aggregate_matches_timeline_current(aggregator):
+    """Non-regression: aggregate() == replay().current() (same values/order)."""
+    events = _timeline()
+    assert aggregator.aggregate(events) == aggregator.replay(events).current()
+
+
+def test_at_returns_all_positions_forward_filled(aggregator):
+    tl = aggregator.replay(_timeline())
+
+    # Before any event: empty portfolio, not an error.
+    assert tl.at(date(2023, 12, 31)) == []
+
+    # 2024-05-01: AAPL present (forward-filled from 03-01), MSFT present (02-01).
+    mid = {s["symbol"]: s for s in tl.at(date(2024, 5, 1))}
+    assert set(mid) == {"AAPL", "MSFT"}
+    assert mid["AAPL"]["estate"]["quantity"] == 10
+    assert mid["MSFT"]["estate"]["quantity"] == 5
+
+    # 2024-01-20: only AAPL has appeared yet.
+    early = tl.at(date(2024, 1, 20))
+    assert [s["symbol"] for s in early] == ["AAPL"]

--- a/app/tests/test_e2e.py
+++ b/app/tests/test_e2e.py
@@ -184,7 +184,7 @@ def test_events_mode_full_chain_drives_write_metrics(
 def test_backfill_writes_historical_state_for_intermediate_date(
     tmp_path, monkeypatch, fake_ticker, mock_influx, shares_validator
 ):
-    """backfill() enriches each price point with aggregate_until_date state."""
+    """backfill() enriches each price point with the replay timeline state."""
     _no_sleep(monkeypatch)
     _patch_ticker(monkeypatch, fake_ticker)
 
@@ -242,12 +242,13 @@ def test_backfill_writes_historical_state_for_intermediate_date(
     assert point["owned_quantity"] == pytest.approx(21.0)  # GRANT+BUYs, no SELL
     assert point["received_dividend"] == pytest.approx(2.4)
 
-    # Cross-check against the real aggregator to prove the state is not hardcoded.
+    # Cross-check against the real replay timeline to prove the state is not
+    # hardcoded (and identical to the pre-refactor aggregate_until_date values).
     from events.aggregator import EventAggregator
     from datetime import date as _date
-    expected = EventAggregator().aggregate_until_date(
-        config_manager.get_events(), _date(2024, 6, 20), "AAPL"
-    )
+    expected = EventAggregator().replay(
+        config_manager.get_events()
+    ).position_at("default", "AAPL", _date(2024, 6, 20))
     assert point["purchased_quantity"] == expected["purchase"]["quantity"]
     assert point["owned_quantity"] == expected["estate"]["quantity"]
     assert point["received_dividend"] == expected["estate"]["received_dividend"]

--- a/app/tests/test_metrics.py
+++ b/app/tests/test_metrics.py
@@ -378,6 +378,32 @@ def test_backfill_fetches_chunk_when_gap_exists(mock_influx, shares_validator, m
     assert kwargs["share_currency"] == "USD"
 
 
+def test_backfill_does_single_replay_per_cycle(
+        mock_influx, shares_validator, mocker, sample_events):
+    """One replay serves every symbol, regardless of the number of shares."""
+    import main
+    first_buys = {"AAPL": date(2024, 1, 15), "MSFT": date(2024, 2, 1)}
+    metrics, _ = _build_metrics(
+        [_valid_shares("AAPL", "Apple"), _valid_shares("MSFT", "Microsoft")],
+        mock_influx, shares_validator, mode="events",
+        first_buy_dates=first_buys, events=sample_events)
+    for sym in ("AAPL", "MSFT"):
+        metrics._share_info_cache[sym] = {
+            "currency": "USD", "exchange": "NMS", "quoteType": "EQUITY"}
+    metrics.backfill_chunk_days = 365
+    mock_influx.get_oldest_timestamp.return_value = datetime(
+        2024, 6, 1, tzinfo=timezone.utc)
+    mocker.patch.object(metrics, "_fetch_historical_data", return_value=[
+        {"timestamp": datetime(2024, 3, 1, tzinfo=timezone.utc), "price": 170.0}])
+    mock_influx.write_historical_prices.return_value = 1
+
+    spy = mocker.spy(main.EventAggregator, "replay")
+    metrics.backfill()
+
+    # Exactly one replay for the whole cycle (two shares), not one per share.
+    assert spy.call_count == 1
+
+
 def test_backfill_write_failure_does_not_abort_remaining_shares(
         mock_influx, shares_validator, mocker):
     first_buys = {"AAPL": date(2024, 1, 15), "MSFT": date(2024, 1, 15)}


### PR DESCRIPTION
## Résumé

Implémente **#575** — refonte de l'agrégation en **replay** : l'agrégateur cesse de stocker l'historique et rejoue les events une seule fois vers une `Timeline` creuse, interrogeable par forward-fill. C'est l'habilitant des tranches suivantes (séries journalières par compte, perf money-weighted).

**Aucun changement visible pour le user** : à comportement égal, on remplace l'API et on gagne un ordre de grandeur sur le backfill.

Closes #575

## Ce qui change

- **`events/schemas.py`** : nouveau `Timeline` (creux — un snapshot par date de changement, pas par jour calendaire — avec `at(date)` / `position_at(...)` en forward-fill par recherche binaire) et `InKindFlow` (flux externe non valorisé).
- **`EventAggregator.replay(events) -> Timeline`** devient le replay unique ; `aggregate()` n'est plus qu'un wrapper `replay().current()`. **`aggregate_until_date()` supprimé.**
- **`GRANT`** est émis comme `InKindFlow` **non valorisé** — l'agrégateur ne lit jamais de prix (revalorisation en aval quand le backfill affine les prix).
- **Backfill** : **un seul `replay()` par cycle** (hissé hors de la boucle des shares), puis lookups `timeline.position_at()` par date → passe de `O(jours × events)` à `O(events + jours)`.
- **Frontière de module respectée** : `events/` n'importe rien du reste de l'app (vérifié).

## Non-régression

- `test_aggregate_matches_timeline_current` : `aggregate() == replay().current()` (mêmes valeurs **et** même ordre).
- L'e2e `test_backfill_writes_historical_state_for_intermediate_date` recroise les points écrits contre `replay().position_at(...)` — valeurs `portfolio_metrics` identiques à avant le refactor.

## Tests & qualité

- `266 passed` (`uv run pytest tests/`) — anciens tests `aggregate_until_date` réécrits vers `replay()` + `position_at()`, plus de nouveaux tests replay/at/sparse/immutabilité/flux/single-replay.
- `flake8 --ignore=E501` propre.
- Revue `/code-review` (Standards + Spec) passée ; le seul point (borne `O()` optimiste sur un scan linéaire) est corrigé par le passage en recherche binaire.

## Dépendances

Débloque **#576** (events DEPOSIT/WITHDRAWAL + livre de trésorerie) qui consommera `Timeline` et introduira `CashFlow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)