### PR TITLE
feat(app): cash events, per-account ledger & account_metrics (#576)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,10 +171,15 @@ date,event_type,symbol,name,quantity,unit_price,fee,amount,notes
 
 | Type | Effect on Portfolio |
 |------|---------------------|
-| `BUY` | +purchase.quantity, +estate.quantity, recalculates weighted avg cost_price, +purchase.fee |
-| `SELL` | -estate.quantity, +purchase.fee (sale fees are tracked) |
-| `GRANT` | +estate.quantity only (free shares, no impact on purchase) |
-| `DIVIDEND` | +estate.received_dividend |
+| `BUY` | +purchase.quantity, +estate.quantity, recalculates weighted avg cost_price, +purchase.fee, −cash |
+| `SELL` | -estate.quantity, +purchase.fee, +cash (proceeds `qty×price − fee`) |
+| `GRANT` | +estate.quantity only (free shares, no impact on purchase); cash-neutral |
+| `DIVIDEND` | +estate.received_dividend, +cash (`amount − fee`) |
+| `DEPOSIT` | +cash (`amount − fee`), +net_contributed (cash event: `account`+`amount` required, no share) |
+| `WITHDRAWAL` | −cash (`amount + fee`), −net_contributed (cash event) |
+
+Cash is a per-account ledger (starts at `0.00`). Negative balances are allowed
+(non-blocking warning); overselling stays blocking.
 
 #### Aggregation Logic
 
@@ -280,6 +285,24 @@ Gauges (prefix `sb_`, labels `share_name`/`share_symbol`/`account`): `sb_share_p
 | Field | `pe_ratio` | P/E ratio |
 | Field | `market_cap` | Market capitalization |
 | Field | `volume` | Trading volume |
+
+**Measurement**: `account_metrics` (opt-in accounts only; daily series rewritten
+in full each cycle, points stamped at midnight of the day, idempotent upsert)
+
+| Type | Name | Description |
+|------|------|-------------|
+| Tag | `account` | Account id |
+| Tag | `account_type` | Account type (PEA, CTO, …) |
+| Tag | `account_currency` | Account currency |
+| Field | `cash_balance` | Per-account cash ledger balance |
+| Field | `holdings_value` | Σ(owned_quantity × price) over the account's symbols |
+| Field | `total_value` | `cash_balance + holdings_value` |
+| Field | `net_contributed` | Σ deposits − Σ withdrawals (fees excluded) |
+
+Prometheus mirrors these as `sb_account_*{account}` gauges plus `sb_account_info`
+(labels `account_type`/`account_currency`). Price history for `holdings_value` is
+read via `InfluxDBWriter.get_price_series(symbol)` — queried by `share_symbol`
+only, never by `account` (a market price belongs to no account).
 
 ## Contributing
 

--- a/app/src/events/__init__.py
+++ b/app/src/events/__init__.py
@@ -8,7 +8,7 @@ and generates aggregated configuration compatible with the existing schema.
 from .schemas import (
     DEFAULT_ACCOUNT, CASH_EVENT_TYPES, Event, EventType, ShareState,
     PurchaseState, EstateState, Account, Portfolio, Timeline, InKindFlow,
-    CashFlow, CashState,
+    CashFlow, CashState, AccountMetricPoint,
 )
 from .loader import EventLoader
 from .validator import EventValidator
@@ -29,6 +29,7 @@ __all__ = [
     'InKindFlow',
     'CashFlow',
     'CashState',
+    'AccountMetricPoint',
     'EventLoader',
     'EventValidator',
     'EventAggregator',

--- a/app/src/events/__init__.py
+++ b/app/src/events/__init__.py
@@ -6,8 +6,9 @@ and generates aggregated configuration compatible with the existing schema.
 """
 
 from .schemas import (
-    DEFAULT_ACCOUNT, Event, EventType, ShareState, PurchaseState, EstateState,
-    Account, Portfolio, Timeline, InKindFlow,
+    DEFAULT_ACCOUNT, CASH_EVENT_TYPES, Event, EventType, ShareState,
+    PurchaseState, EstateState, Account, Portfolio, Timeline, InKindFlow,
+    CashFlow, CashState,
 )
 from .loader import EventLoader
 from .validator import EventValidator
@@ -16,6 +17,7 @@ from .watcher import EventWatcher
 
 __all__ = [
     'DEFAULT_ACCOUNT',
+    'CASH_EVENT_TYPES',
     'Event',
     'EventType',
     'ShareState',
@@ -25,6 +27,8 @@ __all__ = [
     'Portfolio',
     'Timeline',
     'InKindFlow',
+    'CashFlow',
+    'CashState',
     'EventLoader',
     'EventValidator',
     'EventAggregator',

--- a/app/src/events/aggregator.py
+++ b/app/src/events/aggregator.py
@@ -7,8 +7,8 @@ from datetime import date
 from typing import Dict, List, Tuple
 
 from .schemas import (
-    DEFAULT_ACCOUNT, Event, EventType, ShareState, PurchaseState, EstateState,
-    Timeline, InKindFlow,
+    CASH_EVENT_TYPES, DEFAULT_ACCOUNT, Event, EventType, ShareState,
+    PurchaseState, EstateState, Timeline, InKindFlow, CashFlow, CashState,
 )
 
 
@@ -75,11 +75,25 @@ class EventAggregator:
         """
         timeline = Timeline()
         states: Dict[Tuple[str, str], ShareState] = {}
+        cash_states: Dict[str, CashState] = {}
 
         for event in events:
             account = self._event_account(event, accounts_declared)
-            key = (account, event.symbol)
 
+            # Every account gets a cash ledger, starting at 0.00, on first sight.
+            if account not in cash_states:
+                cash_states[account] = CashState()
+                timeline.cash_snapshots[account] = []
+            cash = cash_states[account]
+
+            # Cash events (DEPOSIT/WITHDRAWAL) carry no share: only the ledger moves.
+            if event.event_type in CASH_EVENT_TYPES:
+                self._process_cash_event(cash, event, account, timeline)
+                self._snapshot(timeline.cash_snapshots[account], event.date, cash)
+                continue
+
+            # Share events: update the (account, symbol) position...
+            key = (account, event.symbol)
             if key not in states:
                 states[key] = ShareState(
                     name=event.name,
@@ -114,16 +128,54 @@ class EventAggregator:
             # Record the position's state as of this date (one snapshot per date)
             self._snapshot(timeline.snapshots[key], event.date, state)
 
+            # ...and apply the event's cash effect (GRANT is cash-neutral).
+            if self._apply_share_cash(cash, event):
+                self._snapshot(timeline.cash_snapshots[account], event.date, cash)
+
         return timeline
 
-    @staticmethod
-    def _snapshot(
-        snaps: List[Tuple[date, ShareState]], on_date: date, state: ShareState
+    def _process_cash_event(
+        self, cash: CashState, event: Event, account: str, timeline: Timeline
     ) -> None:
+        """Apply a DEPOSIT/WITHDRAWAL to the ledger and emit its (signed) CashFlow.
+
+        The fee always makes the cash worse; ``net_contributed`` tracks the raw
+        external contribution (fee excluded). The emitted CashFlow is non-valued.
+        """
+        fee = event.fee or 0.0
+        if event.event_type == EventType.DEPOSIT:
+            cash.cash_balance += event.amount - fee
+            cash.net_contributed += event.amount
+            timeline.flows.append(CashFlow(event.date, account, event.amount))
+        else:  # WITHDRAWAL
+            cash.cash_balance -= event.amount + fee
+            cash.net_contributed -= event.amount
+            timeline.flows.append(CashFlow(event.date, account, -event.amount))
+
+    def _apply_share_cash(self, cash: CashState, event: Event) -> bool:
+        """Apply a share event's cash effect. Returns True if cash changed.
+
+        BUY debits, SELL and DIVIDEND credit (fee always worsens cash); GRANT is
+        cash-neutral.
+        """
+        fee = event.fee or 0.0
+        if event.event_type == EventType.BUY:
+            cash.cash_balance -= event.quantity * event.unit_price + fee
+        elif event.event_type == EventType.SELL:
+            cash.cash_balance += event.quantity * event.unit_price - fee
+        elif event.event_type == EventType.DIVIDEND:
+            cash.cash_balance += event.amount - fee
+        else:  # GRANT
+            return False
+        return True
+
+    @staticmethod
+    def _snapshot(snaps: List[Tuple[date, object]], on_date: date, state) -> None:
         """Append (or, for a same-date change, replace) an immutable snapshot.
 
-        Events are date-sorted, so a same-date event just supersedes the day's
-        prior snapshot — the timeline keeps exactly one snapshot per change date.
+        Works for any per-date state (ShareState or CashState). Events are
+        date-sorted, so a same-date event just supersedes the day's prior
+        snapshot — the timeline keeps exactly one snapshot per change date.
         """
         snap = copy.deepcopy(state)
         if snaps and snaps[-1][0] == on_date:

--- a/app/src/events/loader.py
+++ b/app/src/events/loader.py
@@ -18,8 +18,11 @@ class EventLoaderError(Exception):
 class EventLoader:
     """Loads portfolio events from CSV and XLSX files."""
 
-    REQUIRED_COLUMNS = frozenset({'date', 'event_type', 'symbol', 'name'})
-    OPTIONAL_COLUMNS = frozenset({'quantity', 'unit_price', 'fee', 'amount', 'notes', 'account'})
+    # Only date + event_type are structurally required in the header; whether
+    # symbol/name/amount/… are required depends on the event type and is enforced
+    # by the validator (cash events carry no share, share events carry no amount).
+    REQUIRED_COLUMNS = frozenset({'date', 'event_type'})
+    OPTIONAL_COLUMNS = frozenset({'symbol', 'name', 'quantity', 'unit_price', 'fee', 'amount', 'notes', 'account'})
     ALL_COLUMNS = REQUIRED_COLUMNS | OPTIONAL_COLUMNS
 
     def __init__(self, source_path: str):
@@ -179,15 +182,10 @@ class EventLoader:
             raise ValueError(
                 f"Invalid event_type: {event_type_str}. Valid types: {valid_types}")
 
-        # Parse symbol
-        symbol = row.get('symbol', '').strip() if row.get('symbol') else ''
-        if not symbol:
-            raise ValueError("symbol is required")
-
-        # Parse name
-        name = row.get('name', '').strip() if row.get('name') else ''
-        if not name:
-            raise ValueError("name is required")
+        # Parse symbol / name — optional at the parse level (cash events carry
+        # none). Per-type requirements are enforced by the validator.
+        symbol = row.get('symbol', '').strip() if row.get('symbol') else None
+        name = row.get('name', '').strip() if row.get('name') else None
 
         # Parse optional numeric fields
         quantity = self._parse_float(row.get('quantity'), 'quantity')

--- a/app/src/events/schemas.py
+++ b/app/src/events/schemas.py
@@ -22,15 +22,26 @@ class EventType(Enum):
     SELL = "SELL"
     GRANT = "GRANT"
     DIVIDEND = "DIVIDEND"
+    DEPOSIT = "DEPOSIT"
+    WITHDRAWAL = "WITHDRAWAL"
+
+
+# Cash events move money in/out of an account and carry no share (symbol/name/
+# quantity/unit_price are forbidden on them).
+CASH_EVENT_TYPES = frozenset({EventType.DEPOSIT, EventType.WITHDRAWAL})
 
 
 @dataclass
 class Event:
-    """Represents a single portfolio event."""
+    """Represents a single portfolio event.
+
+    ``symbol``/``name`` are Optional because cash events (DEPOSIT/WITHDRAWAL)
+    carry no share.
+    """
     date: date
     event_type: EventType
-    symbol: str
-    name: str
+    symbol: Optional[str] = None
+    name: Optional[str] = None
     quantity: Optional[float] = None
     unit_price: Optional[float] = None
     fee: Optional[float] = None
@@ -92,13 +103,37 @@ class InKindFlow:
 
     The aggregator emits it *without* a price — valuation at the day's price is
     resolved downstream (performance module), which is why the aggregator never
-    needs to know a price. Kept here as the tracer for future cash flows
-    (DEPOSIT/WITHDRAWAL land in a later slice).
+    needs to know a price.
     """
     date: date
     account: str
     symbol: str
     quantity: float
+
+
+@dataclass
+class CashFlow:
+    """A cash external flow (DEPOSIT/WITHDRAWAL), signed at the account level.
+
+    ``amount`` is positive for a DEPOSIT and negative for a WITHDRAWAL — the
+    external contribution only, excluding any fee (fees are internal costs). The
+    performance module consumes these as the money put in/taken out.
+    """
+    date: date
+    account: str
+    amount: float
+
+
+@dataclass
+class CashState:
+    """Per-account cash ledger state.
+
+    ``cash_balance`` starts at 0.00 and every event applies its cash effect.
+    ``net_contributed`` accumulates the external cash contributions
+    (Σ deposits − Σ withdrawals, excluding fees).
+    """
+    cash_balance: float = 0.0
+    net_contributed: float = 0.0
 
 
 @dataclass
@@ -114,15 +149,15 @@ class Timeline:
     """
     # (account, symbol) -> ascending [(change_date, ShareState snapshot)]
     snapshots: Dict[Tuple[str, str], List[Tuple[date, "ShareState"]]] = field(default_factory=dict)
+    # account -> ascending [(change_date, CashState snapshot)]
+    cash_snapshots: Dict[str, List[Tuple[date, "CashState"]]] = field(default_factory=dict)
     # First-appearance order of the positions (stable output ordering)
     order: List[Tuple[str, str]] = field(default_factory=list)
-    # Non-valued external flows collected during the replay
-    flows: List[InKindFlow] = field(default_factory=list)
+    # Non-valued external flows collected during the replay (in-kind + cash)
+    flows: List[object] = field(default_factory=list)
 
     @staticmethod
-    def _state_at(
-        snaps: List[Tuple[date, "ShareState"]], target_date: date
-    ) -> Optional["ShareState"]:
+    def _state_at(snaps: list, target_date: date):
         """Latest snapshot at or before ``target_date`` (forward-fill), or None.
 
         Snapshots are date-sorted, so this is a binary search: the position just
@@ -130,6 +165,18 @@ class Timeline:
         """
         idx = bisect.bisect_right(snaps, target_date, key=lambda snap: snap[0])
         return snaps[idx - 1][1] if idx else None
+
+    def cash_at(self, account: str, target_date: date) -> Optional["CashState"]:
+        """Cash ledger state of an account at ``target_date`` (forward-filled).
+
+        Returns None when the account has no cash-affecting event on or before
+        that date — callers treat that as a zero balance (the ledger starts at
+        0.00).
+        """
+        snaps = self.cash_snapshots.get(account)
+        if not snaps:
+            return None
+        return self._state_at(snaps, target_date)
 
     def position_at(
         self, account: str, symbol: str, target_date: date

--- a/app/src/events/schemas.py
+++ b/app/src/events/schemas.py
@@ -4,9 +4,9 @@ Data schemas for the events module.
 
 import bisect
 from dataclasses import dataclass, field
-from datetime import date  # noqa: F401 — used in the `date: date` field annotation (eager-evaluated on Python <3.14)
+from datetime import date, datetime  # noqa: F401 — used in dataclass field annotations (eager-evaluated on Python <3.14)
 from enum import Enum
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 
 # Canonical account bucket used when no accounts are declared (opt-out users) or
@@ -137,6 +137,24 @@ class CashState:
 
 
 @dataclass
+class AccountMetricPoint:
+    """One daily point of the ``account_metrics`` series for one account.
+
+    A typed seam shared by the computation (main), the InfluxDB writer and the
+    Prometheus exporter, so a mistyped field fails fast instead of silently
+    dropping.
+    """
+    account: str
+    account_type: str
+    account_currency: str
+    timestamp: datetime
+    cash_balance: float
+    holdings_value: float
+    total_value: float
+    net_contributed: float
+
+
+@dataclass
 class Timeline:
     """A sparse replay of portfolio events.
 
@@ -154,17 +172,20 @@ class Timeline:
     # First-appearance order of the positions (stable output ordering)
     order: List[Tuple[str, str]] = field(default_factory=list)
     # Non-valued external flows collected during the replay (in-kind + cash)
-    flows: List[object] = field(default_factory=list)
+    flows: List[Union[InKindFlow, CashFlow]] = field(default_factory=list)
 
     @staticmethod
-    def _state_at(snaps: list, target_date: date):
-        """Latest snapshot at or before ``target_date`` (forward-fill), or None.
+    def state_at(pairs: List[Tuple[date, object]], target_date: date):
+        """Forward-fill: the value of the ``(date, value)`` pair at or before
+        ``target_date``, or None.
 
-        Snapshots are date-sorted, so this is a binary search: the position just
+        Pairs must be date-sorted, so this is a binary search — the pair just
         left of the insertion point is the latest change on or before the date.
+        Reused for any date-keyed series (position snapshots, cash snapshots,
+        price series).
         """
-        idx = bisect.bisect_right(snaps, target_date, key=lambda snap: snap[0])
-        return snaps[idx - 1][1] if idx else None
+        idx = bisect.bisect_right(pairs, target_date, key=lambda pair: pair[0])
+        return pairs[idx - 1][1] if idx else None
 
     def cash_at(self, account: str, target_date: date) -> Optional["CashState"]:
         """Cash ledger state of an account at ``target_date`` (forward-filled).
@@ -176,7 +197,7 @@ class Timeline:
         snaps = self.cash_snapshots.get(account)
         if not snaps:
             return None
-        return self._state_at(snaps, target_date)
+        return self.state_at(snaps, target_date)
 
     def position_at(
         self, account: str, symbol: str, target_date: date
@@ -189,7 +210,7 @@ class Timeline:
         snaps = self.snapshots.get((account, symbol))
         if not snaps:
             return None
-        state = self._state_at(snaps, target_date)
+        state = self.state_at(snaps, target_date)
         return state.to_dict() if state is not None else None
 
     def at(self, target_date: date) -> List[dict]:
@@ -199,7 +220,7 @@ class Timeline:
         """
         result = []
         for key in self.order:
-            state = self._state_at(self.snapshots[key], target_date)
+            state = self.state_at(self.snapshots[key], target_date)
             if state is not None:
                 result.append(state.to_dict())
         return result

--- a/app/src/events/schemas.py
+++ b/app/src/events/schemas.py
@@ -130,7 +130,7 @@ class CashState:
 
     ``cash_balance`` starts at 0.00 and every event applies its cash effect.
     ``net_contributed`` accumulates the external cash contributions
-    (Σ deposits − Σ withdrawals, excluding fees).
+    (Σ deposits - Σ withdrawals, excluding fees).
     """
     cash_balance: float = 0.0
     net_contributed: float = 0.0

--- a/app/src/events/validator.py
+++ b/app/src/events/validator.py
@@ -4,7 +4,7 @@ Event validator for validating portfolio events.
 
 from typing import List, Optional, Set, Tuple
 
-from .schemas import Event, EventType
+from .schemas import CASH_EVENT_TYPES, Event, EventType
 
 
 class EventValidationError(Exception):
@@ -62,20 +62,66 @@ class EventValidator:
     def _validate_event(self, event: Event, event_num: int) -> List[str]:
         """Validate a single event."""
         errors = []
-        prefix = f"Event #{event_num} ({event.date}, {event.event_type.value}, {event.symbol})"
+        context = event.symbol or event.account or "?"
+        prefix = f"Event #{event_num} ({event.date}, {event.event_type.value}, {context})"
 
         # When accounts are declared, every event must carry a valid account
         if self.account_ids is not None:
             errors.extend(self._validate_account(event, prefix))
 
-        if event.event_type == EventType.BUY:
-            errors.extend(self._validate_buy(event, prefix))
-        elif event.event_type == EventType.SELL:
-            errors.extend(self._validate_sell(event, prefix))
-        elif event.event_type == EventType.GRANT:
-            errors.extend(self._validate_grant(event, prefix))
-        elif event.event_type == EventType.DIVIDEND:
-            errors.extend(self._validate_dividend(event, prefix))
+        if event.event_type in CASH_EVENT_TYPES:
+            errors.extend(self._validate_cash(event, prefix))
+        else:
+            # Share events: symbol and name are required (the loader no longer
+            # enforces them, so cash events can omit them).
+            if not event.symbol:
+                errors.append(f"{prefix}: symbol is required")
+            if not event.name:
+                errors.append(f"{prefix}: name is required")
+
+            if event.event_type == EventType.BUY:
+                errors.extend(self._validate_buy(event, prefix))
+            elif event.event_type == EventType.SELL:
+                errors.extend(self._validate_sell(event, prefix))
+            elif event.event_type == EventType.GRANT:
+                errors.extend(self._validate_grant(event, prefix))
+            elif event.event_type == EventType.DIVIDEND:
+                errors.extend(self._validate_dividend(event, prefix))
+
+        return errors
+
+    def _validate_cash(self, event: Event, prefix: str) -> List[str]:
+        """Validate a DEPOSIT / WITHDRAWAL event.
+
+        Required: account + amount (> 0). Optional: fee (>= 0). Forbidden:
+        symbol / name / quantity / unit_price (cash events carry no share).
+        """
+        errors = []
+
+        # account is always required for cash events. When accounts are declared
+        # _validate_account already enforced presence + validity, so only add the
+        # requirement here when accounts are not declared (avoids a duplicate).
+        if self.account_ids is None and not event.account:
+            errors.append(f"{prefix}: account is required for {event.event_type.value}")
+
+        if event.amount is None:
+            errors.append(f"{prefix}: amount is required for {event.event_type.value}")
+        elif event.amount <= 0:
+            errors.append(
+                f"{prefix}: amount must be positive for {event.event_type.value} "
+                f"(direction is carried by the event type, never the sign)")
+
+        if event.fee is not None and event.fee < 0:
+            errors.append(f"{prefix}: fee cannot be negative")
+
+        forbidden = [
+            name for name in ('symbol', 'name', 'quantity', 'unit_price')
+            if getattr(event, name) is not None
+        ]
+        if forbidden:
+            errors.append(
+                f"{prefix}: {', '.join(forbidden)} not allowed on "
+                f"{event.event_type.value} (cash events carry no share)")
 
         return errors
 

--- a/app/src/influxdb_writer.py
+++ b/app/src/influxdb_writer.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional, Any
 from influxdb_client_3 import InfluxDBClient3, Point, WritePrecision
 from logfmt_logger import getLogger
 
-from events.schemas import DEFAULT_ACCOUNT
+from events.schemas import DEFAULT_ACCOUNT, AccountMetricPoint
 
 LOG_LEVEL = os.getenv('LOG_LEVEL', default='INFO')
 logger = getLogger("influxdb_writer", level=LOG_LEVEL)
@@ -402,15 +402,15 @@ class InfluxDBWriter:
 
         return series
 
-    def write_account_metrics(self, points: List[Dict[str, Any]]) -> int:
+    def write_account_metrics(self, points: List[AccountMetricPoint]) -> int:
         """Write the daily ``account_metrics`` series (batch, idempotent).
 
-        Each point carries the tags ``account`` / ``account_type`` /
-        ``account_currency`` and the fields ``cash_balance`` / ``holdings_value``
-        / ``total_value`` / ``net_contributed`` at a midnight ``timestamp``.
-        Re-writing the same (tags, time) series overwrites rather than
-        duplicates, so recomputing and rewriting the whole series every cycle is
-        idempotent.
+        Each :class:`AccountMetricPoint` carries the tags ``account`` /
+        ``account_type`` / ``account_currency`` and the fields ``cash_balance`` /
+        ``holdings_value`` / ``total_value`` / ``net_contributed`` at a midnight
+        ``timestamp``. Re-writing the same (tags, time) series overwrites rather
+        than duplicates, so recomputing and rewriting the whole series every
+        cycle is idempotent.
         """
         if self._client is None:
             self.connect()
@@ -418,20 +418,20 @@ class InfluxDBWriter:
         records = []
         for p in points:
             point = Point(self.ACCOUNT_MEASUREMENT)
-            point.tag("account", p.get("account") or "default")
-            if p.get("account_type"):
-                point.tag("account_type", p["account_type"])
-            if p.get("account_currency"):
-                point.tag("account_currency", p["account_currency"])
+            point.tag("account", p.account or DEFAULT_ACCOUNT)
+            if p.account_type:
+                point.tag("account_type", p.account_type)
+            if p.account_currency:
+                point.tag("account_currency", p.account_currency)
 
             for field_name in (
                 "cash_balance", "holdings_value", "total_value", "net_contributed"
             ):
-                value = p.get(field_name)
+                value = getattr(p, field_name)
                 if _is_valid_number(value):
                     point.field(field_name, float(value))
 
-            point.time(p["timestamp"], WritePrecision.S)
+            point.time(p.timestamp, WritePrecision.S)
             records.append(point)
 
         if records:

--- a/app/src/influxdb_writer.py
+++ b/app/src/influxdb_writer.py
@@ -4,7 +4,7 @@ Handles writing and reading metrics to/from InfluxDB 3.x
 """
 import math
 import os
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Dict, List, Optional, Any
 
 from influxdb_client_3 import InfluxDBClient3, Point, WritePrecision
@@ -45,6 +45,7 @@ class InfluxDBWriter:
     """
 
     MEASUREMENT = "portfolio_metrics"
+    ACCOUNT_MEASUREMENT = "account_metrics"
 
     def __init__(
         self,
@@ -358,6 +359,86 @@ class InfluxDBWriter:
             logger.error(f"Error checking data for {share_symbol} on {date}: {e}")
 
         return False
+
+    def get_price_series(self, share_symbol: str) -> Dict[date, float]:
+        """Return the daily close price of a symbol from ``portfolio_metrics``.
+
+        🔒 Queries by ``share_symbol`` **only**, never by ``account``: a market
+        price belongs to no account, and points written before the account tag
+        existed have ``account = NULL`` — filtering on account would silently
+        truncate the price history. This is the shared price source consumed by
+        the account/performance series.
+
+        Returns a ``{date: close_price}`` mapping (one entry per day that has a
+        price), empty if there is no data.
+        """
+        if self._client is None:
+            self.connect()
+
+        safe_symbol = share_symbol.replace("'", "''")
+        # One row per day: the last (latest-time) price of each calendar day.
+        query = f"""
+        SELECT day, price FROM (
+            SELECT date_trunc('day', time) AS day, share_price AS price,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY date_trunc('day', time) ORDER BY time DESC) AS rn
+            FROM "{self.MEASUREMENT}"
+            WHERE share_symbol = '{safe_symbol}' AND share_price IS NOT NULL
+        ) WHERE rn = 1
+        ORDER BY day
+        """
+
+        series: Dict[date, float] = {}
+        try:
+            table = self._client.query(query=query, language="sql")
+            if table and len(table) > 0:
+                df = table.to_pandas()
+                for _, row in df.iterrows():
+                    day = row['day']
+                    day = day.date() if hasattr(day, 'date') else day
+                    series[day] = float(row['price'])
+        except Exception as e:
+            logger.error(f"Error querying price series for {share_symbol}: {e}")
+
+        return series
+
+    def write_account_metrics(self, points: List[Dict[str, Any]]) -> int:
+        """Write the daily ``account_metrics`` series (batch, idempotent).
+
+        Each point carries the tags ``account`` / ``account_type`` /
+        ``account_currency`` and the fields ``cash_balance`` / ``holdings_value``
+        / ``total_value`` / ``net_contributed`` at a midnight ``timestamp``.
+        Re-writing the same (tags, time) series overwrites rather than
+        duplicates, so recomputing and rewriting the whole series every cycle is
+        idempotent.
+        """
+        if self._client is None:
+            self.connect()
+
+        records = []
+        for p in points:
+            point = Point(self.ACCOUNT_MEASUREMENT)
+            point.tag("account", p.get("account") or "default")
+            if p.get("account_type"):
+                point.tag("account_type", p["account_type"])
+            if p.get("account_currency"):
+                point.tag("account_currency", p["account_currency"])
+
+            for field_name in (
+                "cash_balance", "holdings_value", "total_value", "net_contributed"
+            ):
+                value = p.get(field_name)
+                if _is_valid_number(value):
+                    point.field(field_name, float(value))
+
+            point.time(p["timestamp"], WritePrecision.S)
+            records.append(point)
+
+        if records:
+            self._client.write(record=records, write_precision='s')
+            logger.info(f"Written {len(records)} account_metrics points")
+
+        return len(records)
 
     def __enter__(self):
         self.connect()

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -2,7 +2,6 @@
 SuiviBourse
 Paul Brissaud
 """
-import bisect
 import os
 import sys
 import time
@@ -20,7 +19,9 @@ from logfmt_logger import getLogger
 from urllib3 import exceptions as u_exceptions
 from yfinance.exceptions import YFRateLimitError
 
-from events import EventLoader, EventValidator, EventAggregator, EventWatcher
+from events import (
+    EventLoader, EventValidator, EventAggregator, EventWatcher, AccountMetricPoint,
+)
 from events.loader import EventLoaderError
 from events.validator import EventValidationError
 from events.aggregator import AggregationError
@@ -801,12 +802,6 @@ class SuiviBourseMetrics:
         except Exception as e:
             app_logger.error(f"Failed to update account metrics: {e}")
 
-    @staticmethod
-    def _price_on(sorted_days: List, series: Dict, day) -> Optional[float]:
-        """Forward-fill: the latest price at or before ``day``, or None."""
-        idx = bisect.bisect_right(sorted_days, day)
-        return series[sorted_days[idx - 1]] if idx else None
-
     def update_account_metrics(self):
         """Recompute and write the daily ``account_metrics`` series per account.
 
@@ -826,20 +821,19 @@ class SuiviBourseMetrics:
 
         timeline = EventAggregator().replay(events, accounts_declared=True)
 
-        # Per-symbol daily close prices (market data; forward-filled per day).
+        # Per-symbol daily close prices (market data), as date-sorted (date, price)
+        # pairs forward-filled with the timeline's shared helper.
         symbols = {s['symbol'] for s in self.shares if s.get('symbol')}
-        price_series: Dict[str, Dict] = {}
-        price_days: Dict[str, List] = {}
-        for sym in symbols:
-            series = self.influxdb.get_price_series(sym)
-            price_series[sym] = series
-            price_days[sym] = sorted(series.keys())
+        price_pairs: Dict[str, List] = {
+            sym: sorted(self.influxdb.get_price_series(sym).items())
+            for sym in symbols
+        }
 
         start = min(e.date for e in events)
         today = datetime.now(timezone.utc).date()
 
         points = []
-        latest_by_account: Dict[str, Dict] = {}
+        latest_by_account: Dict[str, AccountMetricPoint] = {}
         day = start
         while day <= today:
             for account in portfolio.accounts:
@@ -861,21 +855,21 @@ class SuiviBourseMetrics:
                     qty = pos['estate']['quantity']
                     if not qty:
                         continue
-                    price = self._price_on(price_days[sym], price_series[sym], day)
+                    price = timeline.state_at(price_pairs[sym], day)
                     if price is not None:
                         holdings += qty * price
 
-                point = {
-                    'account': acc,
-                    'account_type': account.type,
-                    'account_currency': account.currency,
+                point = AccountMetricPoint(
+                    account=acc,
+                    account_type=account.type,
+                    account_currency=account.currency,
                     # Midnight of the day, never stamped in the future.
-                    'timestamp': datetime(day.year, day.month, day.day, tzinfo=timezone.utc),
-                    'cash_balance': cash_balance,
-                    'holdings_value': holdings,
-                    'total_value': cash_balance + holdings,
-                    'net_contributed': net_contributed,
-                }
+                    timestamp=datetime(day.year, day.month, day.day, tzinfo=timezone.utc),
+                    cash_balance=cash_balance,
+                    holdings_value=holdings,
+                    total_value=cash_balance + holdings,
+                    net_contributed=net_contributed,
+                )
                 points.append(point)
                 latest_by_account[acc] = point
             day += timedelta(days=1)
@@ -887,10 +881,10 @@ class SuiviBourseMetrics:
         # who adds accounts without rewriting their DEPOSIT history running), but
         # it is worth a non-blocking warning.
         for acc, p in latest_by_account.items():
-            if p['cash_balance'] < 0:
+            if p.cash_balance < 0:
                 app_logger.warning(
                     f"Account '{acc}' has a negative cash balance "
-                    f"({p['cash_balance']:.2f}) — insufficient recorded cash")
+                    f"({p.cash_balance:.2f}) — insufficient recorded cash")
 
         # Prometheus: expose the latest (today) value per account.
         if self.prometheus is not None:

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -2,6 +2,7 @@
 SuiviBourse
 Paul Brissaud
 """
+import bisect
 import os
 import sys
 import time
@@ -792,6 +793,113 @@ class SuiviBourseMetrics:
             return
 
         self.expose_metrics()
+
+        # Recompute the per-account cash & value series after prices are fresh.
+        # Guarded so an account_metrics error never aborts the scrape cycle.
+        try:
+            self.update_account_metrics()
+        except Exception as e:
+            app_logger.error(f"Failed to update account metrics: {e}")
+
+    @staticmethod
+    def _price_on(sorted_days: List, series: Dict, day) -> Optional[float]:
+        """Forward-fill: the latest price at or before ``day``, or None."""
+        idx = bisect.bisect_right(sorted_days, day)
+        return series[sorted_days[idx - 1]] if idx else None
+
+    def update_account_metrics(self):
+        """Recompute and write the daily ``account_metrics`` series per account.
+
+        Opt-in only: gated on ``load_accounts()`` returning a Portfolio. The
+        whole series (earliest event date → today, one point per calendar day at
+        midnight) is rebuilt and rewritten every cycle — an idempotent upsert, so
+        the curve extends on its own as backfill fills earlier prices, with no
+        catch-up code. Never stamps a point in the future (midnight of the day).
+        """
+        portfolio = self.config_manager.load_accounts()
+        if portfolio is None:
+            return  # single gate: no declared accounts -> no account series
+
+        events = self.config_manager.get_events()
+        if not events:
+            return
+
+        timeline = EventAggregator().replay(events, accounts_declared=True)
+
+        # Per-symbol daily close prices (market data; forward-filled per day).
+        symbols = {s['symbol'] for s in self.shares if s.get('symbol')}
+        price_series: Dict[str, Dict] = {}
+        price_days: Dict[str, List] = {}
+        for sym in symbols:
+            series = self.influxdb.get_price_series(sym)
+            price_series[sym] = series
+            price_days[sym] = sorted(series.keys())
+
+        start = min(e.date for e in events)
+        today = datetime.now(timezone.utc).date()
+
+        points = []
+        latest_by_account: Dict[str, Dict] = {}
+        day = start
+        while day <= today:
+            for account in portfolio.accounts:
+                acc = account.id
+                cash = timeline.cash_at(acc, day)
+                positions = [
+                    (sym, timeline.position_at(acc, sym, day)) for sym in symbols
+                ]
+                positions = [(sym, p) for sym, p in positions if p]
+
+                # Skip days before the account has any activity (no zero noise).
+                if cash is None and not positions:
+                    continue
+
+                cash_balance = cash.cash_balance if cash else 0.0
+                net_contributed = cash.net_contributed if cash else 0.0
+                holdings = 0.0
+                for sym, pos in positions:
+                    qty = pos['estate']['quantity']
+                    if not qty:
+                        continue
+                    price = self._price_on(price_days[sym], price_series[sym], day)
+                    if price is not None:
+                        holdings += qty * price
+
+                point = {
+                    'account': acc,
+                    'account_type': account.type,
+                    'account_currency': account.currency,
+                    # Midnight of the day, never stamped in the future.
+                    'timestamp': datetime(day.year, day.month, day.day, tzinfo=timezone.utc),
+                    'cash_balance': cash_balance,
+                    'holdings_value': holdings,
+                    'total_value': cash_balance + holdings,
+                    'net_contributed': net_contributed,
+                }
+                points.append(point)
+                latest_by_account[acc] = point
+            day += timedelta(days=1)
+
+        if points:
+            self.influxdb.write_account_metrics(points)
+
+        # Permissive cash policy: a negative balance is allowed (it keeps a user
+        # who adds accounts without rewriting their DEPOSIT history running), but
+        # it is worth a non-blocking warning.
+        for acc, p in latest_by_account.items():
+            if p['cash_balance'] < 0:
+                app_logger.warning(
+                    f"Account '{acc}' has a negative cash balance "
+                    f"({p['cash_balance']:.2f}) — insufficient recorded cash")
+
+        # Prometheus: expose the latest (today) value per account.
+        if self.prometheus is not None:
+            for acc, p in latest_by_account.items():
+                try:
+                    self.prometheus.update_account(p)
+                except Exception as e:
+                    app_logger.error(
+                        f"Failed to update Prometheus account metrics for {acc}: {e}")
 
     def reload(self):
         """

--- a/app/src/prometheus_exporter.py
+++ b/app/src/prometheus_exporter.py
@@ -134,19 +134,17 @@ class PrometheusExporter:
         if info.get('volume') is not None:
             self.volume.labels(*labels).set(info['volume'])
 
-    def update_account(self, point: dict) -> None:
+    def update_account(self, point) -> None:
         """Update the per-account gauges from a computed account_metrics point.
 
         Args:
-            point: dict with account / account_type / account_currency and the
-                cash_balance / holdings_value / total_value / net_contributed
-                fields (the latest, today's, values for the account).
+            point: an :class:`~events.schemas.AccountMetricPoint` (the latest,
+                today's, values for the account).
         """
-        account = point['account']
-        self.account_cash_balance.labels(account).set(point['cash_balance'])
-        self.account_holdings_value.labels(account).set(point['holdings_value'])
-        self.account_total_value.labels(account).set(point['total_value'])
-        self.account_net_contributed.labels(account).set(point['net_contributed'])
+        account = point.account
+        self.account_cash_balance.labels(account).set(point.cash_balance)
+        self.account_holdings_value.labels(account).set(point.holdings_value)
+        self.account_total_value.labels(account).set(point.total_value)
+        self.account_net_contributed.labels(account).set(point.net_contributed)
         self.account_info.labels(
-            account, point.get('account_type', ''),
-            point.get('account_currency', '')).set(1)
+            account, point.account_type or '', point.account_currency or '').set(1)

--- a/app/src/prometheus_exporter.py
+++ b/app/src/prometheus_exporter.py
@@ -69,6 +69,25 @@ class PrometheusExporter:
             "sb_volume", "Trading volume of the share", COMMON_LABELS,
             registry=self.registry)
 
+        # Per-account cash & value gauges (opt-in accounts feature). Labelled by
+        # account so each account is its own series.
+        self.account_cash_balance = Gauge(
+            "sb_account_cash_balance", "Cash balance of the account", ['account'],
+            registry=self.registry)
+        self.account_holdings_value = Gauge(
+            "sb_account_holdings_value", "Market value of the account's holdings",
+            ['account'], registry=self.registry)
+        self.account_total_value = Gauge(
+            "sb_account_total_value", "Total value (cash + holdings) of the account",
+            ['account'], registry=self.registry)
+        self.account_net_contributed = Gauge(
+            "sb_account_net_contributed", "Net external cash contributed to the account",
+            ['account'], registry=self.registry)
+        self.account_info = Gauge(
+            "sb_account_info", "Account informations as label",
+            ['account', 'account_type', 'account_currency'],
+            registry=self.registry)
+
     def start(self, port: int) -> None:
         """Start the HTTP server exposing this exporter's registry."""
         start_http_server(port, registry=self.registry)
@@ -114,3 +133,20 @@ class PrometheusExporter:
             self.market_cap.labels(*labels).set(info['marketCap'])
         if info.get('volume') is not None:
             self.volume.labels(*labels).set(info['volume'])
+
+    def update_account(self, point: dict) -> None:
+        """Update the per-account gauges from a computed account_metrics point.
+
+        Args:
+            point: dict with account / account_type / account_currency and the
+                cash_balance / holdings_value / total_value / net_contributed
+                fields (the latest, today's, values for the account).
+        """
+        account = point['account']
+        self.account_cash_balance.labels(account).set(point['cash_balance'])
+        self.account_holdings_value.labels(account).set(point['holdings_value'])
+        self.account_total_value.labels(account).set(point['total_value'])
+        self.account_net_contributed.labels(account).set(point['net_contributed'])
+        self.account_info.labels(
+            account, point.get('account_type', ''),
+            point.get('account_currency', '')).set(1)

--- a/app/tests/test_cash.py
+++ b/app/tests/test_cash.py
@@ -19,6 +19,7 @@ import pytest
 
 from events import (
     EventAggregator, EventValidator, Event, EventType, CashFlow, Account, Portfolio,
+    AccountMetricPoint,
 )
 
 
@@ -179,11 +180,11 @@ def test_write_account_metrics_tags_and_fields(mocker):
     writer._client = fake_client
 
     ts = datetime(2024, 1, 15, tzinfo=timezone.utc)
-    n = writer.write_account_metrics([{
-        "account": "PEA", "account_type": "PEA", "account_currency": "EUR",
-        "timestamp": ts, "cash_balance": 100.0, "holdings_value": 900.0,
-        "total_value": 1000.0, "net_contributed": 800.0,
-    }])
+    n = writer.write_account_metrics([AccountMetricPoint(
+        account="PEA", account_type="PEA", account_currency="EUR",
+        timestamp=ts, cash_balance=100.0, holdings_value=900.0,
+        total_value=1000.0, net_contributed=800.0,
+    )])
 
     assert n == 1
     records = fake_client.write.call_args.kwargs["record"]
@@ -266,20 +267,20 @@ def test_update_account_metrics_writes_series_with_midnight_stamp(
 
     points = mock_influx.write_account_metrics.call_args.args[0]
     # Two calendar days: 01-01 (cash only) and 01-02 (cash + holdings).
-    by_day = {p["timestamp"].date(): p for p in points}
+    by_day = {p.timestamp.date(): p for p in points}
     assert set(by_day) == {date(2024, 1, 1), date(2024, 1, 2)}
     # Every point is stamped at midnight, never in the future.
     for p in points:
-        ts = p["timestamp"]
+        ts = p.timestamp
         assert (ts.hour, ts.minute, ts.second) == (0, 0, 0)
     d1 = by_day[date(2024, 1, 1)]
-    assert d1["cash_balance"] == pytest.approx(1000.0)
-    assert d1["holdings_value"] == pytest.approx(0.0)
+    assert d1.cash_balance == pytest.approx(1000.0)
+    assert d1.holdings_value == pytest.approx(0.0)
     d2 = by_day[date(2024, 1, 2)]
-    assert d2["cash_balance"] == pytest.approx(800.0)   # 1000 - 2*100
-    assert d2["holdings_value"] == pytest.approx(220.0)  # 2 * 110
-    assert d2["total_value"] == pytest.approx(1020.0)
-    assert d2["net_contributed"] == pytest.approx(1000.0)
+    assert d2.cash_balance == pytest.approx(800.0)   # 1000 - 2*100
+    assert d2.holdings_value == pytest.approx(220.0)  # 2 * 110
+    assert d2.total_value == pytest.approx(1020.0)
+    assert d2.net_contributed == pytest.approx(1000.0)
 
 
 def test_update_account_metrics_is_idempotent(mock_influx, shares_validator, mocker):
@@ -310,11 +311,12 @@ def test_prometheus_update_account_sets_gauges():
     from prometheus_exporter import PrometheusExporter
 
     exp = PrometheusExporter(registry=CollectorRegistry())
-    exp.update_account({
-        "account": "PEA", "account_type": "PEA", "account_currency": "EUR",
-        "cash_balance": 100.0, "holdings_value": 900.0,
-        "total_value": 1000.0, "net_contributed": 800.0,
-    })
+    exp.update_account(AccountMetricPoint(
+        account="PEA", account_type="PEA", account_currency="EUR",
+        timestamp=datetime(2024, 1, 15, tzinfo=timezone.utc),
+        cash_balance=100.0, holdings_value=900.0,
+        total_value=1000.0, net_contributed=800.0,
+    ))
 
     reg = exp.registry
     assert reg.get_sample_value("sb_account_cash_balance", {"account": "PEA"}) == 100.0

--- a/app/tests/test_cash.py
+++ b/app/tests/test_cash.py
@@ -1,0 +1,325 @@
+"""
+Unit tests for cash events and the per-account cash ledger (issue #576).
+
+Covers:
+  * validator — DEPOSIT/WITHDRAWAL required/forbidden fields
+  * replay ledger — the six cash rules, net_contributed, SELL crediting cash,
+    per-account siloing, CashFlow emission
+  * Timeline.cash_at forward-fill
+  * InfluxDBWriter.get_price_series / write_account_metrics SQL & tags
+  * SuiviBourseMetrics.update_account_metrics wiring (gate, midnight stamp,
+    holdings valuation, negative-balance warning)
+
+No network, no real InfluxDB.
+"""
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from events import (
+    EventAggregator, EventValidator, Event, EventType, CashFlow, Account, Portfolio,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Validator: DEPOSIT / WITHDRAWAL
+# --------------------------------------------------------------------------- #
+def _deposit(**kw):
+    base = dict(amount=1000.0, account="PEA")
+    base.update(kw)
+    return Event(date(2024, 1, 15), EventType.DEPOSIT, **base)
+
+
+def test_cash_event_valid():
+    ok, errors = EventValidator().validate([_deposit()])
+    assert ok, errors
+
+
+def test_cash_event_requires_positive_amount():
+    ok, errors = EventValidator().validate([_deposit(amount=None)])
+    assert not ok and any("amount is required" in e for e in errors)
+    ok, errors = EventValidator().validate([_deposit(amount=0)])
+    assert not ok and any("amount must be positive" in e for e in errors)
+
+
+def test_cash_event_requires_account_when_not_declared():
+    ok, errors = EventValidator().validate([_deposit(account=None)])
+    assert not ok and any("account is required" in e for e in errors)
+
+
+def test_cash_event_forbids_share_fields():
+    ok, errors = EventValidator().validate([_deposit(symbol="AAPL", quantity=1)])
+    assert not ok
+    assert any("not allowed" in e and "symbol" in e and "quantity" in e for e in errors)
+
+
+def test_cash_event_negative_fee_rejected():
+    ok, errors = EventValidator().validate([_deposit(fee=-1)])
+    assert not ok and any("fee cannot be negative" in e for e in errors)
+
+
+def test_withdrawal_valid():
+    ev = Event(date(2024, 2, 1), EventType.WITHDRAWAL, amount=500.0, account="PEA")
+    ok, errors = EventValidator().validate([ev])
+    assert ok, errors
+
+
+def test_share_event_still_requires_symbol_and_name():
+    # The loader no longer enforces symbol/name; the validator must.
+    ev = Event(date(2024, 1, 1), EventType.BUY, quantity=1, unit_price=10.0)
+    ok, errors = EventValidator().validate([ev])
+    assert not ok
+    assert any("symbol is required" in e for e in errors)
+    assert any("name is required" in e for e in errors)
+
+
+# --------------------------------------------------------------------------- #
+# Ledger rules (replay)
+# --------------------------------------------------------------------------- #
+def _cash(tl, account, on):
+    state = tl.cash_at(account, on)
+    return state.cash_balance if state else 0.0
+
+
+def test_ledger_applies_the_six_rules():
+    events = [
+        Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, fee=1.0, account="A"),
+        Event(date(2024, 1, 2), EventType.BUY, "AAPL", "Apple", quantity=2,
+              unit_price=100.0, fee=2.0, account="A"),
+        Event(date(2024, 1, 3), EventType.DIVIDEND, "AAPL", "Apple", amount=5.0,
+              fee=0.5, account="A"),
+        Event(date(2024, 1, 4), EventType.SELL, "AAPL", "Apple", quantity=1,
+              unit_price=120.0, fee=1.5, account="A"),
+        Event(date(2024, 1, 5), EventType.GRANT, "AAPL", "Apple", quantity=1, account="A"),
+        Event(date(2024, 1, 6), EventType.WITHDRAWAL, amount=100.0, fee=2.0, account="A"),
+    ]
+    tl = EventAggregator().replay(events, accounts_declared=True)
+
+    # DEPOSIT +999; BUY -202; DIVIDEND +4.5; SELL +118.5; GRANT 0; WITHDRAWAL -102
+    assert _cash(tl, "A", date(2024, 1, 1)) == pytest.approx(999.0)
+    assert _cash(tl, "A", date(2024, 1, 2)) == pytest.approx(797.0)
+    assert _cash(tl, "A", date(2024, 1, 3)) == pytest.approx(801.5)
+    assert _cash(tl, "A", date(2024, 1, 4)) == pytest.approx(920.0)
+    assert _cash(tl, "A", date(2024, 1, 5)) == pytest.approx(920.0)  # GRANT cash-neutral
+    assert _cash(tl, "A", date(2024, 1, 6)) == pytest.approx(818.0)
+
+
+def test_net_contributed_excludes_fees():
+    events = [
+        Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, fee=5.0, account="A"),
+        Event(date(2024, 1, 2), EventType.WITHDRAWAL, amount=300.0, fee=2.0, account="A"),
+    ]
+    tl = EventAggregator().replay(events, accounts_declared=True)
+    state = tl.cash_at("A", date(2024, 1, 2))
+    # net_contributed = 1000 - 300 (fees excluded); cash = 995 - 302 = 693
+    assert state.net_contributed == pytest.approx(700.0)
+    assert state.cash_balance == pytest.approx(693.0)
+
+
+def test_cash_is_siloed_per_account():
+    events = [
+        Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA"),
+        Event(date(2024, 1, 2), EventType.DEPOSIT, amount=500.0, account="CTO"),
+    ]
+    tl = EventAggregator().replay(events, accounts_declared=True)
+    assert _cash(tl, "PEA", date(2024, 1, 2)) == pytest.approx(1000.0)
+    assert _cash(tl, "CTO", date(2024, 1, 2)) == pytest.approx(500.0)
+
+
+def test_cash_at_none_before_first_event():
+    events = [Event(date(2024, 6, 1), EventType.DEPOSIT, amount=100.0, account="A")]
+    tl = EventAggregator().replay(events, accounts_declared=True)
+    assert tl.cash_at("A", date(2024, 1, 1)) is None
+    assert tl.cash_at("A", date(2024, 6, 1)).cash_balance == pytest.approx(100.0)
+
+
+def test_negative_balance_allowed():
+    # BUY without a prior DEPOSIT drives cash negative — permitted, no error.
+    events = [
+        Event(date(2024, 1, 2), EventType.BUY, "AAPL", "Apple", quantity=1,
+              unit_price=100.0, account="A"),
+    ]
+    tl = EventAggregator().replay(events, accounts_declared=True)
+    assert _cash(tl, "A", date(2024, 1, 2)) == pytest.approx(-100.0)
+
+
+def test_replay_emits_signed_cashflows():
+    events = [
+        Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="A"),
+        Event(date(2024, 1, 2), EventType.WITHDRAWAL, amount=300.0, account="A"),
+    ]
+    flows = [f for f in EventAggregator().replay(events, accounts_declared=True).flows
+             if isinstance(f, CashFlow)]
+    assert [(f.account, f.amount) for f in flows] == [("A", 1000.0), ("A", -300.0)]
+
+
+# --------------------------------------------------------------------------- #
+# InfluxDBWriter: get_price_series + write_account_metrics
+# --------------------------------------------------------------------------- #
+def test_get_price_series_queries_symbol_only_never_account(mocker):
+    from influxdb_writer import InfluxDBWriter
+    writer = InfluxDBWriter(host="http://x", token="t", database="db")
+    fake_client = mocker.MagicMock()
+    fake_client.query.return_value = None
+    writer._client = fake_client
+
+    writer.get_price_series("AAPL")
+
+    sql = fake_client.query.call_args.kwargs["query"]
+    assert "share_symbol = 'AAPL'" in sql
+    # The 🔒 lock: a market price belongs to no account.
+    assert "account" not in sql
+
+
+def test_write_account_metrics_tags_and_fields(mocker):
+    from influxdb_writer import InfluxDBWriter
+    writer = InfluxDBWriter(host="http://x", token="t", database="db")
+    fake_client = mocker.MagicMock()
+    writer._client = fake_client
+
+    ts = datetime(2024, 1, 15, tzinfo=timezone.utc)
+    n = writer.write_account_metrics([{
+        "account": "PEA", "account_type": "PEA", "account_currency": "EUR",
+        "timestamp": ts, "cash_balance": 100.0, "holdings_value": 900.0,
+        "total_value": 1000.0, "net_contributed": 800.0,
+    }])
+
+    assert n == 1
+    records = fake_client.write.call_args.kwargs["record"]
+    point = records[0]
+    assert point._name == "account_metrics"
+    assert point._tags == {
+        "account": "PEA", "account_type": "PEA", "account_currency": "EUR"}
+    assert point._fields["cash_balance"] == 100.0
+    assert point._fields["holdings_value"] == 900.0
+    assert point._fields["total_value"] == 1000.0
+    assert point._fields["net_contributed"] == 800.0
+
+
+# --------------------------------------------------------------------------- #
+# SuiviBourseMetrics.update_account_metrics wiring
+# --------------------------------------------------------------------------- #
+class _CashConfigManager:
+    """Fake config manager exposing accounts + events for account_metrics."""
+
+    def __init__(self, shares, events, accounts):
+        self._shares = shares
+        self._events = events
+        self._accounts = accounts
+
+    def load_shares(self, force=False):
+        return self._shares
+
+    def get_mode(self):
+        return "events"
+
+    def get_first_buy_date(self, symbol):
+        return None
+
+    def get_events(self):
+        return self._events
+
+    def load_accounts(self):
+        return self._accounts
+
+
+def _metrics(mock_influx, shares_validator, shares, events, accounts):
+    import main
+    cfg = _CashConfigManager(shares, events, accounts)
+    return main.SuiviBourseMetrics(cfg, shares_validator, influxdb_writer=mock_influx)
+
+
+def test_update_account_metrics_gated_on_declared_accounts(mock_influx, shares_validator):
+    # No accounts -> nothing written.
+    m = _metrics(mock_influx, shares_validator, shares=[], events=[
+        Event(date(2024, 1, 1), EventType.DEPOSIT, amount=100.0, account="A")],
+        accounts=None)
+    m.update_account_metrics()
+    mock_influx.write_account_metrics.assert_not_called()
+
+
+def test_update_account_metrics_writes_series_with_midnight_stamp(
+        mock_influx, shares_validator, mocker):
+    events = [
+        Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA"),
+        Event(date(2024, 1, 2), EventType.BUY, "AAPL", "Apple", quantity=2,
+              unit_price=100.0, account="PEA"),
+    ]
+    shares = [{"name": "Apple", "symbol": "AAPL", "account": "PEA",
+               "purchase": {"quantity": 2, "cost_price": 100.0, "fee": 0.0},
+               "estate": {"quantity": 2, "received_dividend": 0.0}}]
+    portfolio = Portfolio([Account("PEA", "PEA", "EUR", "Mon PEA")])
+    # Price series: AAPL at 110 from 2024-01-02.
+    mock_influx.get_price_series.return_value = {date(2024, 1, 2): 110.0}
+
+    m = _metrics(mock_influx, shares_validator, shares, events, portfolio)
+
+    # Freeze "today" to 2024-01-02 while keeping real datetime construction.
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2024, 1, 2, 15, 0, tzinfo=tz)
+    mocker.patch("main.datetime", _FixedDatetime)
+
+    m.update_account_metrics()
+
+    points = mock_influx.write_account_metrics.call_args.args[0]
+    # Two calendar days: 01-01 (cash only) and 01-02 (cash + holdings).
+    by_day = {p["timestamp"].date(): p for p in points}
+    assert set(by_day) == {date(2024, 1, 1), date(2024, 1, 2)}
+    # Every point is stamped at midnight, never in the future.
+    for p in points:
+        ts = p["timestamp"]
+        assert (ts.hour, ts.minute, ts.second) == (0, 0, 0)
+    d1 = by_day[date(2024, 1, 1)]
+    assert d1["cash_balance"] == pytest.approx(1000.0)
+    assert d1["holdings_value"] == pytest.approx(0.0)
+    d2 = by_day[date(2024, 1, 2)]
+    assert d2["cash_balance"] == pytest.approx(800.0)   # 1000 - 2*100
+    assert d2["holdings_value"] == pytest.approx(220.0)  # 2 * 110
+    assert d2["total_value"] == pytest.approx(1020.0)
+    assert d2["net_contributed"] == pytest.approx(1000.0)
+
+
+def test_update_account_metrics_is_idempotent(mock_influx, shares_validator, mocker):
+    """Two cycles with no new event produce the identical (tags, time) point set."""
+    events = [Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA")]
+    portfolio = Portfolio([Account("PEA", "PEA", "EUR", "Mon PEA")])
+    mock_influx.get_price_series.return_value = {}
+
+    m = _metrics(mock_influx, shares_validator, shares=[], events=events, accounts=portfolio)
+
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2024, 1, 1, 12, 0, tzinfo=tz)
+    mocker.patch("main.datetime", _FixedDatetime)
+
+    m.update_account_metrics()
+    first = mock_influx.write_account_metrics.call_args.args[0]
+    m.update_account_metrics()
+    second = mock_influx.write_account_metrics.call_args.args[0]
+
+    # Same timestamps, tags and values -> InfluxDB overwrites rather than dupes.
+    assert first == second
+
+
+def test_prometheus_update_account_sets_gauges():
+    from prometheus_client import CollectorRegistry
+    from prometheus_exporter import PrometheusExporter
+
+    exp = PrometheusExporter(registry=CollectorRegistry())
+    exp.update_account({
+        "account": "PEA", "account_type": "PEA", "account_currency": "EUR",
+        "cash_balance": 100.0, "holdings_value": 900.0,
+        "total_value": 1000.0, "net_contributed": 800.0,
+    })
+
+    reg = exp.registry
+    assert reg.get_sample_value("sb_account_cash_balance", {"account": "PEA"}) == 100.0
+    assert reg.get_sample_value("sb_account_holdings_value", {"account": "PEA"}) == 900.0
+    assert reg.get_sample_value("sb_account_total_value", {"account": "PEA"}) == 1000.0
+    assert reg.get_sample_value("sb_account_net_contributed", {"account": "PEA"}) == 800.0
+    assert reg.get_sample_value("sb_account_info", {
+        "account": "PEA", "account_type": "PEA", "account_currency": "EUR"}) == 1.0

--- a/app/tests/test_loader.py
+++ b/app/tests/test_loader.py
@@ -98,9 +98,13 @@ def test_empty_numeric_cells_parse_to_none(tmp_path):
 # Missing required columns                                                    #
 # --------------------------------------------------------------------------- #
 
-@pytest.mark.parametrize("missing_col", ["date", "event_type", "symbol", "name"])
+@pytest.mark.parametrize("missing_col", ["date", "event_type"])
 def test_missing_required_column_raises(tmp_path, missing_col):
-    """Dropping any of date/event_type/symbol/name raises EventLoaderError."""
+    """Dropping either structurally-required header (date/event_type) raises.
+
+    symbol/name are no longer required in the header (cash events carry none);
+    their per-type requirement is enforced by the validator, not the loader.
+    """
     cols = ["date", "event_type", "symbol", "name",
             "quantity", "unit_price", "fee", "amount", "notes"]
     kept = [c for c in cols if c != missing_col]
@@ -286,14 +290,29 @@ def test_xlsx_parses_with_normalized_headers(tmp_path):
 
 
 def test_xlsx_missing_required_column_raises(tmp_path):
-    header = ["date", "event_type", "name",  # no 'symbol'
+    header = ["date", "symbol", "name",  # no 'event_type'
               "quantity", "unit_price", "fee", "amount", "notes"]
-    rows = [["2024-01-15", "BUY", "Apple Inc", 10, 150.0, 2.5, None, "n"]]
+    rows = [["2024-01-15", "AAPL", "Apple Inc", 10, 150.0, 2.5, None, "n"]]
     path = _write_xlsx(tmp_path / "bad.xlsx", header, rows)
 
     with pytest.raises(EventLoaderError) as exc:
         EventLoader(str(path)).load()
-    assert "symbol" in str(exc.value)
+    assert "event_type" in str(exc.value)
+
+
+def test_symbol_and_name_columns_are_optional(tmp_path):
+    """A file without symbol/name columns loads (cash events carry none)."""
+    path = tmp_path / "cash.csv"
+    path.write_text(
+        "date,event_type,amount,account\n"
+        "2024-01-15,DEPOSIT,1000,PEA\n", encoding="utf-8")
+    events = EventLoader(str(path)).load()
+    assert len(events) == 1
+    assert events[0].event_type is EventType.DEPOSIT
+    assert events[0].symbol is None
+    assert events[0].name is None
+    assert events[0].amount == 1000.0
+    assert events[0].account == "PEA"
 
 
 # --------------------------------------------------------------------------- #

--- a/app/tests/test_prometheus_exporter.py
+++ b/app/tests/test_prometheus_exporter.py
@@ -177,6 +177,9 @@ def test_scrape_populates_injected_exporter(monkeypatch, mock_influx,
         def get_events(self):
             return None
 
+        def load_accounts(self):
+            return None
+
     exporter = PrometheusExporter(registry=CollectorRegistry())
     metrics = main.SuiviBourseMetrics(
         FakeConfigManager(), shares_validator,

--- a/app/tests/test_schemas.py
+++ b/app/tests/test_schemas.py
@@ -25,7 +25,8 @@ def test_event_type_enum_values():
 
 
 def test_event_type_membership_is_exhaustive():
-    assert {e.value for e in EventType} == {"BUY", "SELL", "GRANT", "DIVIDEND"}
+    assert {e.value for e in EventType} == {
+        "BUY", "SELL", "GRANT", "DIVIDEND", "DEPOSIT", "WITHDRAWAL"}
 
 
 # ---------------------------------------------------------------------------

--- a/docker-compose/grafana_provisioning/dashboards/accounts_performance.json
+++ b/docker-compose/grafana_provisioning/dashboards/accounts_performance.json
@@ -42,7 +42,7 @@
         "type": "influxdb",
         "uid": "${DS_INFLUXDB}"
       },
-      "description": "Cash currently sitting in the account.",
+      "description": "Cash currently sitting in the account. Amounts are formatted in EUR (the dashboard assumes EUR accounts; multi-currency formatting is out of scope).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -108,7 +108,7 @@
         "type": "influxdb",
         "uid": "${DS_INFLUXDB}"
       },
-      "description": "cash_balance + holdings_value are stacked areas — their sum is total_value, so you read the portfolio value and its cash/holdings split at a glance. net_contributed is the thick line on top: the gap between the top of the areas and the line is the absolute gain.",
+      "description": "cash_balance + holdings_value are stacked areas — their sum is total_value, so you read the portfolio value and its cash/holdings split at a glance. net_contributed is the thick line on top: the gap between the top of the areas and the line is the absolute gain. Amounts are formatted in EUR (the dashboard assumes EUR accounts; multi-currency formatting is out of scope).",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/docker-compose/grafana_provisioning/dashboards/accounts_performance.json
+++ b/docker-compose/grafana_provisioning/dashboards/accounts_performance.json
@@ -1,0 +1,291 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Per-account cash and value tracking (opt-in accounts).",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "repeat": "account",
+      "repeatDirection": "v",
+      "title": "Account: $account",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "description": "Cash currently sitting in the account.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "currencyEUR"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT time, cash_balance as value FROM account_metrics WHERE account = '$account' AND $__timeFilter(time) AND cash_balance IS NOT NULL ORDER BY time DESC LIMIT 1",
+          "refId": "A"
+        }
+      ],
+      "title": "Cash balance",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_INFLUXDB}"
+      },
+      "description": "cash_balance + holdings_value are stacked areas — their sum is total_value, so you read the portfolio value and its cash/holdings split at a glance. net_contributed is the thick line on top: the gap between the top of the areas and the line is the absolute gain.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "currencyEUR"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "net_contributed"
+            },
+            "properties": [
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 3
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_INFLUXDB}"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT time, cash_balance, holdings_value, net_contributed FROM account_metrics WHERE account = '$account' AND $__timeFilter(time) ORDER BY time",
+          "refId": "A"
+        }
+      ],
+      "title": "Cash & value over time",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5m",
+  "revision": 1,
+  "schemaVersion": 39,
+  "tags": [
+    "suivibourse",
+    "accounts"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "InfluxDB",
+          "value": "InfluxDB"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "DS_INFLUXDB",
+        "options": [],
+        "query": "influxdb",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "${DS_INFLUXDB}"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Account",
+        "multi": true,
+        "name": "account",
+        "options": [],
+        "query": "SELECT DISTINCT account AS __text, account AS __value FROM account_metrics ORDER BY account",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-90d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "SuiviBourse - Accounts",
+  "uid": "suivibourse-accounts",
+  "version": 1,
+  "weekStart": ""
+}

--- a/website/docs/configuration/events-mode.mdx
+++ b/website/docs/configuration/events-mode.mdx
@@ -55,7 +55,9 @@ variable — it takes priority over `settings.yaml`. See
 ## File format
 
 Both **CSV** and **XLSX** files are supported. Every file must contain a header
-row with (at least) the four required columns.
+row; only `date` and `event_type` are structurally required. Which of the other
+columns apply depends on the event type (a share `BUY` needs `symbol`/`name`/
+`quantity`/`unit_price`; a cash `DEPOSIT` needs `account`/`amount`).
 
 <Tabs>
   <TabItem value="csv" label="CSV" default>
@@ -90,9 +92,9 @@ Requires the `openpyxl` library, which is bundled in the Docker image.
 | Column | Required | Description |
 |--------|----------|-------------|
 | `date` | Yes | ISO format `YYYY-MM-DD` |
-| `event_type` | Yes | `BUY`, `SELL`, `GRANT` or `DIVIDEND` (case-insensitive) |
-| `symbol` | Yes | Yahoo! Finance ticker (e.g. `AAPL`, `MSFT`) |
-| `name` | Yes | Display name for the share |
+| `event_type` | Yes | `BUY`, `SELL`, `GRANT`, `DIVIDEND`, `DEPOSIT` or `WITHDRAWAL` (case-insensitive) |
+| `symbol` | For share events | Yahoo! Finance ticker (e.g. `AAPL`, `MSFT`); **forbidden** on cash events |
+| `name` | For share events | Display name for the share; **forbidden** on cash events |
 | `quantity` | For `BUY` / `SELL` / `GRANT` | Number of shares |
 | `unit_price` | For `BUY` / `SELL` | Price per share |
 | `fee` | Optional | Transaction fee (must be `>= 0`) |
@@ -100,8 +102,9 @@ Requires the `openpyxl` library, which is bundled in the Docker image.
 | `notes` | Optional | Free-text comment (ignored by the app) |
 | `account` | For cash events, and for any event when [accounts](#accounts-opt-in) are declared | Account `id` this event belongs to |
 
-The four required columns must always be present in the header. Empty cells are
-allowed for the columns that don't apply to a given event type.
+`date` and `event_type` must always be present in the header. Empty cells are
+allowed for the columns that don't apply to a given event type, and cash-only
+files may omit the share columns entirely.
 
 ## Event types
 

--- a/website/docs/configuration/events-mode.mdx
+++ b/website/docs/configuration/events-mode.mdx
@@ -96,9 +96,9 @@ Requires the `openpyxl` library, which is bundled in the Docker image.
 | `quantity` | For `BUY` / `SELL` / `GRANT` | Number of shares |
 | `unit_price` | For `BUY` / `SELL` | Price per share |
 | `fee` | Optional | Transaction fee (must be `>= 0`) |
-| `amount` | For `DIVIDEND` | Dividend amount received |
+| `amount` | For `DIVIDEND` / `DEPOSIT` / `WITHDRAWAL` | Amount received (dividend) or moved (cash) |
 | `notes` | Optional | Free-text comment (ignored by the app) |
-| `account` | Only when [accounts](#accounts-opt-in) are declared | Account `id` this event belongs to |
+| `account` | For cash events, and for any event when [accounts](#accounts-opt-in) are declared | Account `id` this event belongs to |
 
 The four required columns must always be present in the header. Empty cells are
 allowed for the columns that don't apply to a given event type.
@@ -107,10 +107,12 @@ allowed for the columns that don't apply to a given event type.
 
 | Type | Required fields | Effect on the portfolio |
 |------|-----------------|-------------------------|
-| `BUY` | `quantity` > 0, `unit_price` > 0 | +purchased quantity, +owned quantity, recomputes the weighted average cost price, +fee |
-| `SELL` | `quantity` > 0, `unit_price` > 0 | −owned quantity, +fee |
-| `GRANT` | `quantity` > 0 | +owned quantity only (free shares) |
-| `DIVIDEND` | `amount` > 0 | +received dividends |
+| `BUY` | `quantity` > 0, `unit_price` > 0 | +purchased quantity, +owned quantity, recomputes the weighted average cost price, +fee, −cash |
+| `SELL` | `quantity` > 0, `unit_price` > 0 | −owned quantity, +fee, **+cash (proceeds)** |
+| `GRANT` | `quantity` > 0 | +owned quantity only (free shares); cash-neutral |
+| `DIVIDEND` | `amount` > 0 | +received dividends, +cash |
+| `DEPOSIT` | `account`, `amount` > 0 | +cash (external contribution) |
+| `WITHDRAWAL` | `account`, `amount` > 0 | −cash (external withdrawal) |
 
 If any event fails validation, the whole ingestion is rejected and the
 **previous valid configuration is kept** — see [Error resilience](#error-resilience).
@@ -156,6 +158,56 @@ so raises an aggregation error and the previous valid configuration is kept.
 ### DIVIDEND — received dividends
 
 - Increases `estate.received_dividend` by `amount`.
+- Also **credits the account's cash** by `amount − fee`.
+
+## Cash events & the cash ledger
+
+`DEPOSIT` and `WITHDRAWAL` track the money that **enters and leaves** an account.
+Combined with the buy/sell/dividend flows, SuiviBourse keeps a **cash balance per
+account**, so you can see how much you contributed, how much it is worth, and how
+much is sitting idle as cash.
+
+```csv title="events/2024.csv"
+date,event_type,amount,fee,account,notes
+2024-01-01,DEPOSIT,10000,,PEA,Initial funding
+2024-06-01,WITHDRAWAL,500,1.5,PEA,Cash out
+```
+
+**Rules**
+
+- Required: `date`, `account`, `amount` (**> 0** — the direction is carried by the
+  event type, never by the sign). `fee` is optional (`>= 0`).
+- Forbidden on cash events: `symbol`, `name`, `quantity`, `unit_price` — providing
+  any of them is a validation error.
+- Cash is **siloed per account**: a transfer between accounts is expressed as a
+  `WITHDRAWAL` + `DEPOSIT` pair.
+
+**The cash ledger** starts at `0.00` per account. The `fee` always makes the cash
+worse:
+
+| Event | Effect on cash |
+|-------|----------------|
+| `DEPOSIT` | `+ (amount − fee)` |
+| `WITHDRAWAL` | `− (amount + fee)` |
+| `BUY` | `− (quantity × unit_price + fee)` |
+| `SELL` | `+ (quantity × unit_price − fee)` |
+| `DIVIDEND` | `+ (amount − fee)` |
+| `GRANT` | none |
+
+:::caution `SELL` now credits cash
+Previously the proceeds of a sale were not tracked. From now on, a `SELL`
+**credits the account's cash** with `quantity × unit_price − fee`.
+:::
+
+**Permissive policy** — a **negative** cash balance is **allowed**: it only logs a
+non-blocking warning. This is what keeps a user who adds accounts without
+rewriting their whole `DEPOSIT` history running (they will see negative balances,
+not an app that refuses to start). Selling more shares than you own stays
+**blocking**, as before.
+
+These values feed the **Accounts** dashboard (`cash_balance`, `holdings_value`,
+`total_value`, `net_contributed`), written to the `account_metrics` measurement
+**only for opt-in users** (accounts declared in `settings.yaml`).
 
 ## Accounts (opt-in)
 


### PR DESCRIPTION
## Résumé

Implémente **#576** — l'argent qui **entre et sort** de chaque compte devient traçable : deux nouveaux event types, un solde cash réel par compte, le measurement `account_metrics`, et un dashboard qui le montre.

Closes #576

## Ce qui change

- **Events cash** : `DEPOSIT` / `WITHDRAWAL` (`EventType`), lus CSV **et** XLSX. `Event.symbol`/`name` deviennent `Optional`. Validation stricte : `date`+`account`+`amount(>0)` requis, `fee`≥0 optionnel, `symbol`/`name`/`quantity`/`unit_price` **interdits**. Le loader ne garantit plus `symbol`/`name` (les règles par type passent au validator).
- **Ledger cash par compte** (dans `replay`) : les six règles du tableau (le `fee` dégrade toujours le cash), `net_contributed` (hors fees), émission de `CashFlow` non valorisé. **`SELL` crédite désormais le cash** (proceeds). Solde négatif **autorisé** (warning non bloquant) ; oversell reste **bloquant**.
- **`account_metrics`** : série journalière (tags `account`/`account_type`/`account_currency` ; fields `cash_balance`/`holdings_value`/`total_value`/`net_contributed`), **point du jour à minuit** (jamais dans le futur), **réécrite en entier chaque cycle** (upsert idempotent), **gated sur `load_accounts()`**. `holdings_value` lit les prix via `get_price_series()` (par `share_symbol` **uniquement**, jamais `account` — verrou conforme à #577).
- **Prometheus** : gauges `sb_account_*{account}` + `sb_account_info`.
- **Dashboard 2** `accounts_performance.json` : variable `$account`, row `repeat` par compte, **aires empilées** `cash_balance`+`holdings_value` avec `net_contributed` en **ligne** par-dessus. Provisionné sans configuration (le provider fichier pointe le dossier). User sans comptes → aucune row.
- **Doc** à jour (events cash, ledger, changement de sémantique `SELL`, politique permissive).

## Tests & qualité

- `284 passed`, `flake8` propre, build docusaurus OK.
- Revue `/code-review` (Standards + Spec) : **17/17 critères + 3 verrous** satisfaits ; SQL sûr. Les smells relevés (dict non typé, forward-fill dupliqué, `flows: List[object]`) sont corrigés dans le 2ᵉ commit (`AccountMetricPoint`, réutilisation de `Timeline.state_at`, `Union`).

## Dépendances

Débloque **#577** (perf money-weighted : XIRR/TWR, `portfolio_totals`), qui réutilisera `get_price_series`, les flux `CashFlow`/`InKindFlow` et `AccountMetricPoint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DEPOSIT` and `WITHDRAWAL` events for tracking account cash movements.
  * Added per-account cash balances, contributions, holdings value, and total value metrics.
  * Added Prometheus metrics and a Grafana dashboard for account performance.
  * Cash balances now reflect purchases, sales, dividends, fees, deposits, and withdrawals.

* **Bug Fixes**
  * Improved event-file loading so cash events can omit share-specific fields.
  * Added validation to prevent invalid cash-event data.

* **Documentation**
  * Expanded guidance on event types, cash ledger behavior, and account metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->