### PR TITLE
feat(app): money-weighted performance — XIRR, TWR & portfolio_totals (#577)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,11 +298,25 @@ in full each cycle, points stamped at midnight of the day, idempotent upsert)
 | Field | `holdings_value` | Σ(owned_quantity × price) over the account's symbols |
 | Field | `total_value` | `cash_balance + holdings_value` |
 | Field | `net_contributed` | Σ deposits − Σ withdrawals (fees excluded) |
+| Field | `xirr` | Money-weighted return (annualized); latest point only, absent without an external flow |
+| Field | `twr_index` | Time-weighted return, base 100 (per day) |
+| Field | `gain_absolu` | Absolute gain (`value − contributions`); latest point only |
+
+**Measurement**: `portfolio_totals` — the same 7 perf fields at the **global**
+level, written with **no tag** (a synthetic account tag would double every
+`SUM()`). Written only when all accounts share one currency (FX is out of scope).
+
+Money-weighted performance (XIRR by home-grown bisection, TWR base 100) is
+computed in `app/src/performance.py` — a pure module taking a `Timeline` and an
+injected `price_at` callable (no InfluxDB/yfinance). External flows
+(DEPOSIT/WITHDRAWAL/GRANT) are the contribution; internal flows (BUY/SELL/
+DIVIDEND/fees) are the performance.
 
 Prometheus mirrors these as `sb_account_*{account}` gauges plus `sb_account_info`
-(labels `account_type`/`account_currency`). Price history for `holdings_value` is
-read via `InfluxDBWriter.get_price_series(symbol)` — queried by `share_symbol`
-only, never by `account` (a market price belongs to no account).
+(labels `account_type`/`account_currency`) and global `sb_portfolio_*` gauges
+(no `account` label). Price history for `holdings_value` is read via
+`InfluxDBWriter.get_price_series(symbol)` — queried by `share_symbol` only, never
+by `account` (a market price belongs to no account).
 
 ## Contributing
 

--- a/app/src/events/__init__.py
+++ b/app/src/events/__init__.py
@@ -8,7 +8,7 @@ and generates aggregated configuration compatible with the existing schema.
 from .schemas import (
     DEFAULT_ACCOUNT, CASH_EVENT_TYPES, Event, EventType, ShareState,
     PurchaseState, EstateState, Account, Portfolio, Timeline, InKindFlow,
-    CashFlow, CashState, AccountMetricPoint,
+    CashFlow, CashState, AccountMetricPoint, PortfolioTotalPoint,
 )
 from .loader import EventLoader
 from .validator import EventValidator
@@ -30,6 +30,7 @@ __all__ = [
     'CashFlow',
     'CashState',
     'AccountMetricPoint',
+    'PortfolioTotalPoint',
     'EventLoader',
     'EventValidator',
     'EventAggregator',

--- a/app/src/events/schemas.py
+++ b/app/src/events/schemas.py
@@ -152,6 +152,29 @@ class AccountMetricPoint:
     holdings_value: float
     total_value: float
     net_contributed: float
+    # Money-weighted performance (only present once computable; xirr/gain_absolu
+    # require at least one external flow, so they may be absent).
+    xirr: Optional[float] = None
+    gain_absolu: Optional[float] = None
+    twr_index: Optional[float] = None
+
+
+@dataclass
+class PortfolioTotalPoint:
+    """One daily point of the global ``portfolio_totals`` series.
+
+    Carries **no tag** (a single global series): tagging it with a synthetic
+    account would double every ``SUM()`` over the per-account series. Written
+    only when all accounts share one currency (pooling currencies needs FX).
+    """
+    timestamp: datetime
+    cash_balance: float
+    holdings_value: float
+    total_value: float
+    net_contributed: float
+    xirr: Optional[float] = None
+    gain_absolu: Optional[float] = None
+    twr_index: Optional[float] = None
 
 
 @dataclass

--- a/app/src/influxdb_writer.py
+++ b/app/src/influxdb_writer.py
@@ -429,11 +429,7 @@ class InfluxDBWriter:
             if p.account_currency:
                 point.tag("account_currency", p.account_currency)
 
-            for field_name in self._ACCOUNT_FIELDS + self._PERF_FIELDS:
-                value = getattr(p, field_name)
-                if _is_valid_number(value):
-                    point.field(field_name, float(value))
-
+            self._set_value_fields(point, p)
             point.time(p.timestamp, WritePrecision.S)
             records.append(point)
 
@@ -442,6 +438,13 @@ class InfluxDBWriter:
             logger.info(f"Written {len(records)} account_metrics points")
 
         return len(records)
+
+    def _set_value_fields(self, point: Point, p: Any) -> None:
+        """Set the shared value + performance fields on a point (skipping NaN/None)."""
+        for field_name in self._ACCOUNT_FIELDS + self._PERF_FIELDS:
+            value = getattr(p, field_name)
+            if _is_valid_number(value):
+                point.field(field_name, float(value))
 
     def write_portfolio_totals(self, points: List[PortfolioTotalPoint]) -> int:
         """Write the global ``portfolio_totals`` series (batch, idempotent).
@@ -456,10 +459,7 @@ class InfluxDBWriter:
         records = []
         for p in points:
             point = Point(self.PORTFOLIO_MEASUREMENT)
-            for field_name in self._ACCOUNT_FIELDS + self._PERF_FIELDS:
-                value = getattr(p, field_name)
-                if _is_valid_number(value):
-                    point.field(field_name, float(value))
+            self._set_value_fields(point, p)
             point.time(p.timestamp, WritePrecision.S)
             records.append(point)
 

--- a/app/src/influxdb_writer.py
+++ b/app/src/influxdb_writer.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional, Any
 from influxdb_client_3 import InfluxDBClient3, Point, WritePrecision
 from logfmt_logger import getLogger
 
-from events.schemas import DEFAULT_ACCOUNT, AccountMetricPoint
+from events.schemas import DEFAULT_ACCOUNT, AccountMetricPoint, PortfolioTotalPoint
 
 LOG_LEVEL = os.getenv('LOG_LEVEL', default='INFO')
 logger = getLogger("influxdb_writer", level=LOG_LEVEL)
@@ -46,6 +46,11 @@ class InfluxDBWriter:
 
     MEASUREMENT = "portfolio_metrics"
     ACCOUNT_MEASUREMENT = "account_metrics"
+    PORTFOLIO_MEASUREMENT = "portfolio_totals"
+
+    # Performance fields written only when computable (None is skipped).
+    _PERF_FIELDS = ("xirr", "gain_absolu", "twr_index")
+    _ACCOUNT_FIELDS = ("cash_balance", "holdings_value", "total_value", "net_contributed")
 
     def __init__(
         self,
@@ -424,9 +429,7 @@ class InfluxDBWriter:
             if p.account_currency:
                 point.tag("account_currency", p.account_currency)
 
-            for field_name in (
-                "cash_balance", "holdings_value", "total_value", "net_contributed"
-            ):
+            for field_name in self._ACCOUNT_FIELDS + self._PERF_FIELDS:
                 value = getattr(p, field_name)
                 if _is_valid_number(value):
                     point.field(field_name, float(value))
@@ -437,6 +440,32 @@ class InfluxDBWriter:
         if records:
             self._client.write(record=records, write_precision='s')
             logger.info(f"Written {len(records)} account_metrics points")
+
+        return len(records)
+
+    def write_portfolio_totals(self, points: List[PortfolioTotalPoint]) -> int:
+        """Write the global ``portfolio_totals`` series (batch, idempotent).
+
+        A single **untagged** series (tagging it would double every ``SUM()`` over
+        the per-account series). Same 7 perf fields, same midnight-stamped,
+        rewritten-each-cycle idempotency as ``account_metrics``.
+        """
+        if self._client is None:
+            self.connect()
+
+        records = []
+        for p in points:
+            point = Point(self.PORTFOLIO_MEASUREMENT)
+            for field_name in self._ACCOUNT_FIELDS + self._PERF_FIELDS:
+                value = getattr(p, field_name)
+                if _is_valid_number(value):
+                    point.field(field_name, float(value))
+            point.time(p.timestamp, WritePrecision.S)
+            records.append(point)
+
+        if records:
+            self._client.write(record=records, write_precision='s')
+            logger.info(f"Written {len(records)} portfolio_totals points")
 
         return len(records)
 

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -809,6 +809,22 @@ class SuiviBourseMetrics:
         """Midnight UTC of ``day`` — never stamped in the future."""
         return datetime(day.year, day.month, day.day, tzinfo=timezone.utc)
 
+    @staticmethod
+    def _value_kwargs(dp, last: bool, perf) -> dict:
+        """Shared value + perf fields for a metric point built from a DailyPerf.
+
+        twr_index is per-day; xirr / gain_absolu land only on the latest point.
+        """
+        return dict(
+            cash_balance=dp.cash_balance,
+            holdings_value=dp.holdings_value,
+            total_value=dp.total_value,
+            net_contributed=dp.net_contributed,
+            twr_index=dp.twr_index,
+            xirr=perf.xirr if last else None,
+            gain_absolu=perf.gain_absolu if last else None,
+        )
+
     def update_account_metrics(self):
         """Recompute and write the daily ``account_metrics`` + ``portfolio_totals``
         series via the performance module.
@@ -865,13 +881,7 @@ class SuiviBourseMetrics:
                     account_type=account.type,
                     account_currency=account.currency,
                     timestamp=self._midnight(dp.date),
-                    cash_balance=dp.cash_balance,
-                    holdings_value=dp.holdings_value,
-                    total_value=dp.total_value,
-                    net_contributed=dp.net_contributed,
-                    twr_index=dp.twr_index,
-                    xirr=perf.xirr if last else None,
-                    gain_absolu=perf.gain_absolu if last else None,
+                    **self._value_kwargs(dp, last, perf),
                 )
                 acc_points.append(pt)
                 if last:
@@ -884,13 +894,7 @@ class SuiviBourseMetrics:
             total_points = [
                 PortfolioTotalPoint(
                     timestamp=self._midnight(dp.date),
-                    cash_balance=dp.cash_balance,
-                    holdings_value=dp.holdings_value,
-                    total_value=dp.total_value,
-                    net_contributed=dp.net_contributed,
-                    twr_index=dp.twr_index,
-                    xirr=total.xirr if i == len(total.daily) - 1 else None,
-                    gain_absolu=total.gain_absolu if i == len(total.daily) - 1 else None,
+                    **self._value_kwargs(dp, i == len(total.daily) - 1, total),
                 )
                 for i, dp in enumerate(total.daily)
             ]

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -19,8 +19,10 @@ from logfmt_logger import getLogger
 from urllib3 import exceptions as u_exceptions
 from yfinance.exceptions import YFRateLimitError
 
+import performance
 from events import (
-    EventLoader, EventValidator, EventAggregator, EventWatcher, AccountMetricPoint,
+    EventLoader, EventValidator, EventAggregator, EventWatcher,
+    AccountMetricPoint, PortfolioTotalPoint,
 )
 from events.loader import EventLoaderError
 from events.validator import EventValidationError
@@ -802,14 +804,21 @@ class SuiviBourseMetrics:
         except Exception as e:
             app_logger.error(f"Failed to update account metrics: {e}")
 
-    def update_account_metrics(self):
-        """Recompute and write the daily ``account_metrics`` series per account.
+    @staticmethod
+    def _midnight(day) -> datetime:
+        """Midnight UTC of ``day`` — never stamped in the future."""
+        return datetime(day.year, day.month, day.day, tzinfo=timezone.utc)
 
-        Opt-in only: gated on ``load_accounts()`` returning a Portfolio. The
-        whole series (earliest event date → today, one point per calendar day at
+    def update_account_metrics(self):
+        """Recompute and write the daily ``account_metrics`` + ``portfolio_totals``
+        series via the performance module.
+
+        Opt-in only: gated on ``load_accounts()`` returning a Portfolio. The whole
+        series (earliest event date → today, one point per calendar day at
         midnight) is rebuilt and rewritten every cycle — an idempotent upsert, so
-        the curve extends on its own as backfill fills earlier prices, with no
-        catch-up code. Never stamps a point in the future (midnight of the day).
+        the curve extends on its own as backfill fills earlier prices. Money-
+        weighted performance (xirr / gain_absolu / twr_index) comes from
+        ``performance.py``; xirr / gain_absolu land only on the latest point.
         """
         portfolio = self.config_manager.load_accounts()
         if portfolio is None:
@@ -821,61 +830,72 @@ class SuiviBourseMetrics:
 
         timeline = EventAggregator().replay(events, accounts_declared=True)
 
-        # Per-symbol daily close prices (market data), as date-sorted (date, price)
-        # pairs forward-filled with the timeline's shared helper.
+        # Injected price source: per-symbol daily closes, forward-filled. The
+        # performance module never touches InfluxDB — it only calls price_at.
         symbols = {s['symbol'] for s in self.shares if s.get('symbol')}
-        price_pairs: Dict[str, List] = {
+        price_pairs = {
             sym: sorted(self.influxdb.get_price_series(sym).items())
             for sym in symbols
         }
 
+        def price_at(symbol, day):
+            pairs = price_pairs.get(symbol)
+            return timeline.state_at(pairs, day) if pairs else None
+
         start = min(e.date for e in events)
         today = datetime.now(timezone.utc).date()
 
-        points = []
+        per_account = {
+            account.id: performance.compute_account(
+                timeline, account, symbols, price_at, start, today)
+            for account in portfolio.accounts
+        }
+        total = performance.compute_portfolio_total(
+            timeline, portfolio.accounts, symbols, price_at, start, today, per_account)
+
+        # --- account_metrics ------------------------------------------------
+        acc_points = []
         latest_by_account: Dict[str, AccountMetricPoint] = {}
-        day = start
-        while day <= today:
-            for account in portfolio.accounts:
-                acc = account.id
-                cash = timeline.cash_at(acc, day)
-                positions = [
-                    (sym, timeline.position_at(acc, sym, day)) for sym in symbols
-                ]
-                positions = [(sym, p) for sym, p in positions if p]
-
-                # Skip days before the account has any activity (no zero noise).
-                if cash is None and not positions:
-                    continue
-
-                cash_balance = cash.cash_balance if cash else 0.0
-                net_contributed = cash.net_contributed if cash else 0.0
-                holdings = 0.0
-                for sym, pos in positions:
-                    qty = pos['estate']['quantity']
-                    if not qty:
-                        continue
-                    price = timeline.state_at(price_pairs[sym], day)
-                    if price is not None:
-                        holdings += qty * price
-
-                point = AccountMetricPoint(
-                    account=acc,
+        for account in portfolio.accounts:
+            perf = per_account[account.id]
+            for i, dp in enumerate(perf.daily):
+                last = i == len(perf.daily) - 1
+                pt = AccountMetricPoint(
+                    account=account.id,
                     account_type=account.type,
                     account_currency=account.currency,
-                    # Midnight of the day, never stamped in the future.
-                    timestamp=datetime(day.year, day.month, day.day, tzinfo=timezone.utc),
-                    cash_balance=cash_balance,
-                    holdings_value=holdings,
-                    total_value=cash_balance + holdings,
-                    net_contributed=net_contributed,
+                    timestamp=self._midnight(dp.date),
+                    cash_balance=dp.cash_balance,
+                    holdings_value=dp.holdings_value,
+                    total_value=dp.total_value,
+                    net_contributed=dp.net_contributed,
+                    twr_index=dp.twr_index,
+                    xirr=perf.xirr if last else None,
+                    gain_absolu=perf.gain_absolu if last else None,
                 )
-                points.append(point)
-                latest_by_account[acc] = point
-            day += timedelta(days=1)
+                acc_points.append(pt)
+                if last:
+                    latest_by_account[account.id] = pt
+        if acc_points:
+            self.influxdb.write_account_metrics(acc_points)
 
-        if points:
-            self.influxdb.write_account_metrics(points)
+        # --- portfolio_totals (global, untagged; only if single currency) ---
+        if total is not None:
+            total_points = [
+                PortfolioTotalPoint(
+                    timestamp=self._midnight(dp.date),
+                    cash_balance=dp.cash_balance,
+                    holdings_value=dp.holdings_value,
+                    total_value=dp.total_value,
+                    net_contributed=dp.net_contributed,
+                    twr_index=dp.twr_index,
+                    xirr=total.xirr if i == len(total.daily) - 1 else None,
+                    gain_absolu=total.gain_absolu if i == len(total.daily) - 1 else None,
+                )
+                for i, dp in enumerate(total.daily)
+            ]
+            if total_points:
+                self.influxdb.write_portfolio_totals(total_points)
 
         # Permissive cash policy: a negative balance is allowed (it keeps a user
         # who adds accounts without rewriting their DEPOSIT history running), but
@@ -886,7 +906,7 @@ class SuiviBourseMetrics:
                     f"Account '{acc}' has a negative cash balance "
                     f"({p.cash_balance:.2f}) — insufficient recorded cash")
 
-        # Prometheus: expose the latest (today) value per account.
+        # Prometheus: expose the latest (today) value per account + global.
         if self.prometheus is not None:
             for acc, p in latest_by_account.items():
                 try:
@@ -894,6 +914,11 @@ class SuiviBourseMetrics:
                 except Exception as e:
                     app_logger.error(
                         f"Failed to update Prometheus account metrics for {acc}: {e}")
+            if total is not None and total.daily:
+                try:
+                    self.prometheus.update_portfolio(total_points[-1])
+                except Exception as e:
+                    app_logger.error(f"Failed to update Prometheus portfolio totals: {e}")
 
     def reload(self):
         """

--- a/app/src/performance.py
+++ b/app/src/performance.py
@@ -10,7 +10,7 @@ Definitions (see issue #563):
     GRANT (in-kind, valued at the day's price).
   * Internal flows (they ARE performance): BUY, SELL, DIVIDEND and every fee.
   * Daily valuation: V = cash + Σ(quantity × price), prices forward-filled.
-  * TWR return convention: flows land end-of-day, r_D = (V_D − F_D) / V_{D−1}.
+  * TWR return convention: flows land end-of-day, r_D = (V_D - F_D) / V_{D-1}.
 """
 
 from collections import defaultdict
@@ -88,7 +88,7 @@ def xirr(cashflows: List[Tuple[date, float]],
 
 def _fill_twr(daily: List[DailyPerf]) -> None:
     """Fill twr_index in place: base 100 anchored at the first day with value,
-    then compounded by r_D = (V_D − F_D) / V_{D−1} (flows land end-of-day)."""
+    then compounded by r_D = (V_D - F_D) / V_{D-1} (flows land end-of-day)."""
     prev_v: Optional[float] = None
     twr: Optional[float] = None
     for dp in daily:
@@ -128,7 +128,7 @@ def _holdings_value(timeline: Timeline, account: str, symbols,
 def _account_flows(timeline: Timeline, account: str, price_at: PriceAt):
     """Return (cash_flows, grant_flows) for one account.
 
-    cash_flows: list of (date, amount) with amount signed (+deposit, −withdrawal).
+    cash_flows: list of (date, amount) with amount signed (+deposit, -withdrawal).
     grant_flows: list of (date, symbol, quantity).
     """
     cash_flows, grant_flows = [], []
@@ -141,7 +141,7 @@ def _account_flows(timeline: Timeline, account: str, price_at: PriceAt):
 
 
 def _external_flow_by_date(cash_flows, grant_flows, price_at: PriceAt) -> Dict[date, float]:
-    """Net external inflow value per date (deposits +, withdrawals −, grants
+    """Net external inflow value per date (deposits +, withdrawals -, grants
     valued at the day's price). Unvalued grants (no price yet) are skipped."""
     by_date: Dict[date, float] = defaultdict(float)
     for d, amount in cash_flows:
@@ -159,7 +159,7 @@ def _xirr_cashflows(cash_flows, grant_flows, price_at: PriceAt,
     terminal value positive."""
     cfs: List[Tuple[date, float]] = []
     for d, amount in cash_flows:
-        cfs.append((d, -amount))               # deposit(+)→pay in(−); withdrawal(−)→receive(+)
+        cfs.append((d, -amount))               # deposit(+)→pay in(-); withdrawal(-)→receive(+)
     for d, sym, qty in grant_flows:
         price = price_at(sym, d)
         if price is not None:
@@ -169,7 +169,7 @@ def _xirr_cashflows(cash_flows, grant_flows, price_at: PriceAt,
 
 
 def _base_contributed(cash_flows, grant_flows, price_at: PriceAt) -> float:
-    """Total external contribution (deposits − withdrawals + valued grants)."""
+    """Total external contribution (deposits - withdrawals + valued grants)."""
     base = sum(amount for _, amount in cash_flows)
     for d, sym, qty in grant_flows:
         price = price_at(sym, d)

--- a/app/src/performance.py
+++ b/app/src/performance.py
@@ -1,0 +1,271 @@
+"""
+Money-weighted performance: XIRR (annualized) and TWR (time-weighted, base 100).
+
+Pure domain module: ``Timeline`` × an injected price callable → performance
+results. It knows nothing about InfluxDB or yfinance — the only dependency on the
+outside world is the ``price_at(symbol, date) -> Optional[float]`` callable.
+
+Definitions (see issue #563):
+  * External flows (the *contribution*, NOT performance): DEPOSIT, WITHDRAWAL,
+    GRANT (in-kind, valued at the day's price).
+  * Internal flows (they ARE performance): BUY, SELL, DIVIDEND and every fee.
+  * Daily valuation: V = cash + Σ(quantity × price), prices forward-filled.
+  * TWR return convention: flows land end-of-day, r_D = (V_D − F_D) / V_{D−1}.
+"""
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from typing import Callable, Dict, List, Optional, Tuple
+
+from events.schemas import CashFlow, InKindFlow, Timeline, Account
+
+
+PriceAt = Callable[[str, date], Optional[float]]
+
+
+@dataclass
+class DailyPerf:
+    """One day of an entity's (account or global) valuation and TWR."""
+    date: date
+    cash_balance: float
+    holdings_value: float
+    total_value: float
+    net_contributed: float
+    external_flow: float          # F_D: net external inflow value on this day
+    twr_index: Optional[float] = None
+
+
+@dataclass
+class Performance:
+    """Performance of one entity (an account, or the global portfolio)."""
+    daily: List[DailyPerf] = field(default_factory=list)
+    xirr: Optional[float] = None
+    gain_absolu: Optional[float] = None
+    currency: Optional[str] = None
+
+
+def xirr(cashflows: List[Tuple[date, float]],
+         low: float = -0.9999, high: float = 1e9,
+         tol: float = 1e-8, max_iter: int = 200) -> Optional[float]:
+    """Annualized internal rate of return by bisection (no external dependency).
+
+    ``cashflows`` are (date, amount) from the investor's perspective: money put
+    in is negative, money/received value taken out is positive. Returns None when
+    the flows span no time (nothing to annualize) or don't bracket a root within
+    ``[low, high]`` — including an ultra-short horizon whose annualized rate would
+    blow past the bracket (gain_absolu is the guard for that case).
+    """
+    if not cashflows:
+        return None
+
+    dates = [d for d, _ in cashflows]
+    t0 = min(dates)
+    if max(dates) == t0:
+        return None  # zero horizon — an annualized rate is undefined
+
+    def npv(rate: float) -> float:
+        return sum(amt / (1.0 + rate) ** ((d - t0).days / 365.0)
+                   for d, amt in cashflows)
+
+    f_low, f_high = npv(low), npv(high)
+    if f_low == 0:
+        return low
+    if f_low * f_high > 0:
+        return None  # not bracketed -> undefined
+
+    for _ in range(max_iter):
+        mid = (low + high) / 2.0
+        f_mid = npv(mid)
+        if abs(f_mid) < tol or (high - low) < tol:
+            return mid
+        if f_low * f_mid < 0:
+            high, f_high = mid, f_mid
+        else:
+            low, f_low = mid, f_mid
+    return (low + high) / 2.0
+
+
+def _fill_twr(daily: List[DailyPerf]) -> None:
+    """Fill twr_index in place: base 100 anchored at the first day with value,
+    then compounded by r_D = (V_D − F_D) / V_{D−1} (flows land end-of-day)."""
+    prev_v: Optional[float] = None
+    twr: Optional[float] = None
+    for dp in daily:
+        v = dp.total_value
+        if twr is None:
+            if v != 0:
+                twr = 100.0  # anchor
+        elif prev_v:
+            twr = twr * (v - dp.external_flow) / prev_v
+        dp.twr_index = twr
+        prev_v = v
+
+
+def _holdings_value(timeline: Timeline, account: str, symbols,
+                    price_at: PriceAt, day: date) -> Tuple[float, bool]:
+    """Σ(quantity × forward-filled price) for the account on ``day``.
+
+    Returns (value, has_position) — has_position is True as soon as the account
+    holds anything (even a symbol without a price yet).
+    """
+    total = 0.0
+    has_position = False
+    for sym in symbols:
+        pos = timeline.position_at(account, sym, day)
+        if not pos:
+            continue
+        has_position = True
+        qty = pos['estate']['quantity']
+        if not qty:
+            continue
+        price = price_at(sym, day)
+        if price is not None:
+            total += qty * price
+    return total, has_position
+
+
+def _account_flows(timeline: Timeline, account: str, price_at: PriceAt):
+    """Return (cash_flows, grant_flows) for one account.
+
+    cash_flows: list of (date, amount) with amount signed (+deposit, −withdrawal).
+    grant_flows: list of (date, symbol, quantity).
+    """
+    cash_flows, grant_flows = [], []
+    for flow in timeline.flows:
+        if isinstance(flow, CashFlow) and flow.account == account:
+            cash_flows.append((flow.date, flow.amount))
+        elif isinstance(flow, InKindFlow) and flow.account == account:
+            grant_flows.append((flow.date, flow.symbol, flow.quantity))
+    return cash_flows, grant_flows
+
+
+def _external_flow_by_date(cash_flows, grant_flows, price_at: PriceAt) -> Dict[date, float]:
+    """Net external inflow value per date (deposits +, withdrawals −, grants
+    valued at the day's price). Unvalued grants (no price yet) are skipped."""
+    by_date: Dict[date, float] = defaultdict(float)
+    for d, amount in cash_flows:
+        by_date[d] += amount
+    for d, sym, qty in grant_flows:
+        price = price_at(sym, d)
+        if price is not None:
+            by_date[d] += qty * price
+    return by_date
+
+
+def _xirr_cashflows(cash_flows, grant_flows, price_at: PriceAt,
+                    terminal_value: float, today: date) -> List[Tuple[date, float]]:
+    """Build the investor-perspective cashflows for XIRR: contributions negative,
+    terminal value positive."""
+    cfs: List[Tuple[date, float]] = []
+    for d, amount in cash_flows:
+        cfs.append((d, -amount))               # deposit(+)→pay in(−); withdrawal(−)→receive(+)
+    for d, sym, qty in grant_flows:
+        price = price_at(sym, d)
+        if price is not None:
+            cfs.append((d, -qty * price))      # in-kind contribution
+    cfs.append((today, terminal_value))
+    return cfs
+
+
+def _base_contributed(cash_flows, grant_flows, price_at: PriceAt) -> float:
+    """Total external contribution (deposits − withdrawals + valued grants)."""
+    base = sum(amount for _, amount in cash_flows)
+    for d, sym, qty in grant_flows:
+        price = price_at(sym, d)
+        if price is not None:
+            base += qty * price
+    return base
+
+
+def _daily_range(start: date, today: date):
+    day = start
+    while day <= today:
+        yield day
+        day += timedelta(days=1)
+
+
+def compute_account(timeline: Timeline, account: Account, symbols,
+                    price_at: PriceAt, start: date, today: date) -> Performance:
+    """Compute one account's daily valuation series, TWR, XIRR and absolute gain."""
+    acc = account.id
+    cash_flows, grant_flows = _account_flows(timeline, acc, price_at)
+    flow_by_date = _external_flow_by_date(cash_flows, grant_flows, price_at)
+
+    daily: List[DailyPerf] = []
+    started = False
+    for day in _daily_range(start, today):
+        cash = timeline.cash_at(acc, day)
+        holdings, has_position = _holdings_value(timeline, acc, symbols, price_at, day)
+
+        if not started and cash is None and not has_position:
+            continue  # skip days before the account has any activity
+        started = True
+
+        cash_balance = cash.cash_balance if cash else 0.0
+        net_contributed = cash.net_contributed if cash else 0.0
+        daily.append(DailyPerf(
+            date=day,
+            cash_balance=cash_balance,
+            holdings_value=holdings,
+            total_value=cash_balance + holdings,
+            net_contributed=net_contributed,
+            external_flow=flow_by_date.get(day, 0.0),
+        ))
+
+    _fill_twr(daily)
+
+    perf = Performance(daily=daily, currency=account.currency)
+    has_external = bool(cash_flows or grant_flows)
+    if has_external and daily:
+        terminal = daily[-1].total_value
+        perf.xirr = xirr(_xirr_cashflows(cash_flows, grant_flows, price_at, terminal, today))
+        perf.gain_absolu = terminal - _base_contributed(cash_flows, grant_flows, price_at)
+    return perf
+
+
+def compute_portfolio_total(timeline: Timeline, accounts: List[Account], symbols,
+                            price_at: PriceAt, start: date, today: date,
+                            per_account: Dict[str, Performance]) -> Optional[Performance]:
+    """Aggregate all accounts into a global performance (no tag).
+
+    Returns None when there are no accounts or they don't all share the same
+    currency — pooling different currencies would need FX (out of scope).
+    """
+    if not accounts:
+        return None
+    currencies = {a.currency for a in accounts}
+    if len(currencies) > 1:
+        return None
+
+    # Sum the per-account daily series by date (accounts start on different days).
+    by_date: Dict[date, DailyPerf] = {}
+    for acc_id, perf in per_account.items():
+        for dp in perf.daily:
+            agg = by_date.get(dp.date)
+            if agg is None:
+                agg = DailyPerf(dp.date, 0.0, 0.0, 0.0, 0.0, 0.0)
+                by_date[dp.date] = agg
+            agg.cash_balance += dp.cash_balance
+            agg.holdings_value += dp.holdings_value
+            agg.total_value += dp.total_value
+            agg.net_contributed += dp.net_contributed
+            agg.external_flow += dp.external_flow
+
+    daily = [by_date[d] for d in sorted(by_date)]
+    _fill_twr(daily)
+
+    # Global XIRR / gain from all accounts' flows combined + one global terminal.
+    all_cash, all_grant = [], []
+    for account in accounts:
+        cf, gf = _account_flows(timeline, account.id, price_at)
+        all_cash.extend(cf)
+        all_grant.extend(gf)
+
+    total = Performance(daily=daily, currency=currencies.pop())
+    has_external = bool(all_cash or all_grant)
+    if has_external and daily:
+        terminal = daily[-1].total_value
+        total.xirr = xirr(_xirr_cashflows(all_cash, all_grant, price_at, terminal, today))
+        total.gain_absolu = terminal - _base_contributed(all_cash, all_grant, price_at)
+    return total

--- a/app/src/performance.py
+++ b/app/src/performance.py
@@ -240,7 +240,7 @@ def compute_portfolio_total(timeline: Timeline, accounts: List[Account], symbols
 
     # Sum the per-account daily series by date (accounts start on different days).
     by_date: Dict[date, DailyPerf] = {}
-    for acc_id, perf in per_account.items():
+    for perf in per_account.values():
         for dp in perf.daily:
             agg = by_date.get(dp.date)
             if agg is None:

--- a/app/src/prometheus_exporter.py
+++ b/app/src/prometheus_exporter.py
@@ -87,6 +87,35 @@ class PrometheusExporter:
             "sb_account_info", "Account informations as label",
             ['account', 'account_type', 'account_currency'],
             registry=self.registry)
+        # Money-weighted performance per account.
+        self.account_xirr = Gauge(
+            "sb_account_xirr", "Money-weighted return (XIRR, annualized) of the account",
+            ['account'], registry=self.registry)
+        self.account_gain_absolu = Gauge(
+            "sb_account_gain_absolu", "Absolute gain of the account",
+            ['account'], registry=self.registry)
+        self.account_twr_index = Gauge(
+            "sb_account_twr_index", "Time-weighted return index (base 100) of the account",
+            ['account'], registry=self.registry)
+
+        # Global portfolio perf gauges — NO account label (a single global series;
+        # an account label would double every aggregation).
+        self.portfolio_cash_balance = Gauge(
+            "sb_portfolio_cash_balance", "Global cash balance", registry=self.registry)
+        self.portfolio_holdings_value = Gauge(
+            "sb_portfolio_holdings_value", "Global holdings value", registry=self.registry)
+        self.portfolio_total_value = Gauge(
+            "sb_portfolio_total_value", "Global total value", registry=self.registry)
+        self.portfolio_net_contributed = Gauge(
+            "sb_portfolio_net_contributed", "Global net contributed", registry=self.registry)
+        self.portfolio_xirr = Gauge(
+            "sb_portfolio_xirr", "Global money-weighted return (XIRR, annualized)",
+            registry=self.registry)
+        self.portfolio_gain_absolu = Gauge(
+            "sb_portfolio_gain_absolu", "Global absolute gain", registry=self.registry)
+        self.portfolio_twr_index = Gauge(
+            "sb_portfolio_twr_index", "Global time-weighted return index (base 100)",
+            registry=self.registry)
 
     def start(self, port: int) -> None:
         """Start the HTTP server exposing this exporter's registry."""
@@ -148,3 +177,24 @@ class PrometheusExporter:
         self.account_net_contributed.labels(account).set(point.net_contributed)
         self.account_info.labels(
             account, point.account_type or '', point.account_currency or '').set(1)
+        # Performance fields: only when computable (absent otherwise).
+        if point.xirr is not None:
+            self.account_xirr.labels(account).set(point.xirr)
+        if point.gain_absolu is not None:
+            self.account_gain_absolu.labels(account).set(point.gain_absolu)
+        if point.twr_index is not None:
+            self.account_twr_index.labels(account).set(point.twr_index)
+
+    def update_portfolio(self, point) -> None:
+        """Update the global (untagged) portfolio gauges from a
+        :class:`~events.schemas.PortfolioTotalPoint`."""
+        self.portfolio_cash_balance.set(point.cash_balance)
+        self.portfolio_holdings_value.set(point.holdings_value)
+        self.portfolio_total_value.set(point.total_value)
+        self.portfolio_net_contributed.set(point.net_contributed)
+        if point.xirr is not None:
+            self.portfolio_xirr.set(point.xirr)
+        if point.gain_absolu is not None:
+            self.portfolio_gain_absolu.set(point.gain_absolu)
+        if point.twr_index is not None:
+            self.portfolio_twr_index.set(point.twr_index)

--- a/app/tests/test_cash.py
+++ b/app/tests/test_cash.py
@@ -19,7 +19,7 @@ import pytest
 
 from events import (
     EventAggregator, EventValidator, Event, EventType, CashFlow, Account, Portfolio,
-    AccountMetricPoint,
+    AccountMetricPoint, PortfolioTotalPoint,
 )
 
 
@@ -173,6 +173,25 @@ def test_get_price_series_queries_symbol_only_never_account(mocker):
     assert "account" not in sql
 
 
+def test_get_price_series_returns_full_history(mocker):
+    """No account filter -> pre-tag (account NULL) points come back in full."""
+    import pandas as pd
+    from influxdb_writer import InfluxDBWriter
+    writer = InfluxDBWriter(host="http://x", token="t", database="db")
+    fake_client = mocker.MagicMock()
+    table = mocker.MagicMock()
+    table.__len__.return_value = 2
+    table.to_pandas.return_value = pd.DataFrame({
+        "day": [pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-03")],
+        "price": [100.0, 110.0],
+    })
+    fake_client.query.return_value = table
+    writer._client = fake_client
+
+    series = writer.get_price_series("AAPL")
+    assert series == {date(2024, 1, 2): 100.0, date(2024, 1, 3): 110.0}
+
+
 def test_write_account_metrics_tags_and_fields(mocker):
     from influxdb_writer import InfluxDBWriter
     writer = InfluxDBWriter(host="http://x", token="t", database="db")
@@ -304,6 +323,125 @@ def test_update_account_metrics_is_idempotent(mock_influx, shares_validator, moc
 
     # Same timestamps, tags and values -> InfluxDB overwrites rather than dupes.
     assert first == second
+
+
+def test_write_portfolio_totals_is_untagged(mocker):
+    from influxdb_writer import InfluxDBWriter
+    writer = InfluxDBWriter(host="http://x", token="t", database="db")
+    fake_client = mocker.MagicMock()
+    writer._client = fake_client
+
+    ts = datetime(2024, 1, 15, tzinfo=timezone.utc)
+    n = writer.write_portfolio_totals([PortfolioTotalPoint(
+        timestamp=ts, cash_balance=100.0, holdings_value=900.0, total_value=1000.0,
+        net_contributed=800.0, xirr=0.12, gain_absolu=200.0, twr_index=120.0,
+    )])
+
+    assert n == 1
+    point = fake_client.write.call_args.kwargs["record"][0]
+    assert point._name == "portfolio_totals"
+    assert point._tags == {}  # no tag: a single global series
+    assert point._fields["total_value"] == 1000.0
+    assert point._fields["xirr"] == 0.12
+    assert point._fields["twr_index"] == 120.0
+
+
+def test_update_account_metrics_writes_portfolio_totals_single_currency(
+        mock_influx, shares_validator, mocker):
+    events = [Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA")]
+    portfolio = Portfolio([Account("PEA", "PEA", "EUR", "Mon PEA")])
+    mock_influx.get_price_series.return_value = {}
+
+    m = _metrics(mock_influx, shares_validator, shares=[], events=events, accounts=portfolio)
+
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2024, 1, 2, 12, 0, tzinfo=tz)
+    mocker.patch("main.datetime", _FixedDatetime)
+
+    m.update_account_metrics()
+
+    mock_influx.write_portfolio_totals.assert_called_once()
+    pts = mock_influx.write_portfolio_totals.call_args.args[0]
+    assert all(isinstance(p, PortfolioTotalPoint) for p in pts)
+
+
+def test_update_account_metrics_skips_portfolio_totals_mixed_currency(
+        mock_influx, shares_validator, mocker):
+    events = [
+        Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA"),
+        Event(date(2024, 1, 1), EventType.DEPOSIT, amount=500.0, account="CTO"),
+    ]
+    portfolio = Portfolio([
+        Account("PEA", "PEA", "EUR", "Mon PEA"),
+        Account("CTO", "CTO", "USD", "My CTO"),
+    ])
+    mock_influx.get_price_series.return_value = {}
+
+    m = _metrics(mock_influx, shares_validator, shares=[], events=events, accounts=portfolio)
+
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2024, 1, 2, 12, 0, tzinfo=tz)
+    mocker.patch("main.datetime", _FixedDatetime)
+
+    m.update_account_metrics()
+
+    # EUR + USD -> no global series.
+    mock_influx.write_portfolio_totals.assert_not_called()
+    # ...but per-account metrics are still written.
+    mock_influx.write_account_metrics.assert_called_once()
+
+
+def test_account_metrics_perf_fields_only_on_latest_point(
+        mock_influx, shares_validator, mocker):
+    events = [
+        Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA"),
+        Event(date(2024, 1, 1), EventType.BUY, "AAPL", "Apple", quantity=10,
+              unit_price=100.0, account="PEA"),
+    ]
+    shares = [{"name": "Apple", "symbol": "AAPL", "account": "PEA",
+               "purchase": {"quantity": 10, "cost_price": 100.0, "fee": 0.0},
+               "estate": {"quantity": 10, "received_dividend": 0.0}}]
+    portfolio = Portfolio([Account("PEA", "PEA", "EUR", "Mon PEA")])
+    mock_influx.get_price_series.return_value = {
+        date(2024, 1, 1): 100.0, date(2024, 1, 2): 110.0}
+
+    m = _metrics(mock_influx, shares_validator, shares, events, portfolio)
+
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2024, 1, 2, 12, 0, tzinfo=tz)
+    mocker.patch("main.datetime", _FixedDatetime)
+
+    m.update_account_metrics()
+
+    pts = sorted(mock_influx.write_account_metrics.call_args.args[0],
+                 key=lambda p: p.timestamp)
+    # twr_index present on every point; gain_absolu only on the latest.
+    assert all(p.twr_index is not None for p in pts)
+    assert pts[0].gain_absolu is None
+    assert pts[-1].gain_absolu == pytest.approx(100.0)   # 10*110 - 1000
+    assert pts[-1].twr_index == pytest.approx(110.0)
+
+
+def test_prometheus_update_portfolio_sets_unlabeled_gauges():
+    from prometheus_client import CollectorRegistry
+    from prometheus_exporter import PrometheusExporter
+
+    exp = PrometheusExporter(registry=CollectorRegistry())
+    exp.update_portfolio(PortfolioTotalPoint(
+        timestamp=datetime(2024, 1, 2, tzinfo=timezone.utc),
+        cash_balance=100.0, holdings_value=900.0, total_value=1000.0,
+        net_contributed=800.0, xirr=0.12, gain_absolu=200.0, twr_index=120.0,
+    ))
+    reg = exp.registry
+    assert reg.get_sample_value("sb_portfolio_total_value") == 1000.0
+    assert reg.get_sample_value("sb_portfolio_xirr") == 0.12
+    assert reg.get_sample_value("sb_portfolio_twr_index") == 120.0
 
 
 def test_prometheus_update_account_sets_gauges():

--- a/app/tests/test_performance.py
+++ b/app/tests/test_performance.py
@@ -1,0 +1,199 @@
+"""
+Unit tests for the money-weighted performance module (issue #577).
+
+Covers: XIRR bisection (known-rate reference), external vs internal flow
+classification, no-external-flow => no xirr/gain, daily valuation, TWR base 100,
+GRANT valued at the day's price, and portfolio-total currency gating.
+"""
+
+from datetime import date
+
+import pytest
+
+import performance
+from performance import xirr, compute_account, compute_portfolio_total
+from events import EventAggregator, Event, EventType, Account
+
+
+def _price_at(prices):
+    """Build a forward-filling price_at from {symbol: {date: price}}."""
+    sorted_by_symbol = {
+        sym: sorted(series.items()) for sym, series in prices.items()
+    }
+
+    def price_at(symbol, day):
+        pairs = sorted_by_symbol.get(symbol, [])
+        result = None
+        for d, p in pairs:
+            if d <= day:
+                result = p
+            else:
+                break
+        return result
+    return price_at
+
+
+PEA = Account("PEA", "PEA", "EUR", "Mon PEA")
+CTO = Account("CTO", "CTO", "USD", "My CTO")
+
+
+# --------------------------------------------------------------------------- #
+# XIRR bisection
+# --------------------------------------------------------------------------- #
+def test_xirr_known_rate():
+    # Invest 1000, worth 1100 exactly one year later -> 10% annualized.
+    r = xirr([(date(2023, 1, 1), -1000.0), (date(2024, 1, 1), 1100.0)])
+    assert r == pytest.approx(0.10, abs=1e-4)
+
+
+def test_xirr_none_without_sign_change():
+    # All contributions, no positive terminal -> undefined.
+    assert xirr([(date(2023, 1, 1), -1000.0), (date(2024, 1, 1), -500.0)]) is None
+
+
+def test_xirr_none_on_empty():
+    assert xirr([]) is None
+
+
+def test_xirr_none_on_zero_horizon():
+    # Deposit and terminal on the same day -> nothing to annualize.
+    assert xirr([(date(2024, 1, 1), -1000.0), (date(2024, 1, 1), 1000.0)]) is None
+
+
+# --------------------------------------------------------------------------- #
+# Daily valuation + TWR
+# --------------------------------------------------------------------------- #
+def test_daily_valuation_and_twr_base_100():
+    events = [
+        Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA"),
+        Event(date(2024, 1, 1), EventType.BUY, "AAPL", "Apple", quantity=10,
+              unit_price=100.0, account="PEA"),
+    ]
+    tl = EventAggregator().replay(events, accounts_declared=True)
+    price_at = _price_at({"AAPL": {date(2024, 1, 1): 100.0, date(2024, 1, 2): 110.0}})
+
+    perf = compute_account(tl, PEA, {"AAPL"}, price_at,
+                           start=date(2024, 1, 1), today=date(2024, 1, 2))
+
+    d0, d1 = perf.daily
+    # Day 0: cash 0 (1000 - 10*100), holdings 1000, V 1000, TWR anchored at 100.
+    assert d0.cash_balance == pytest.approx(0.0)
+    assert d0.holdings_value == pytest.approx(1000.0)
+    assert d0.total_value == pytest.approx(1000.0)
+    assert d0.twr_index == pytest.approx(100.0)
+    # Day 1: price 100 -> 110, holdings 1100, V 1100, TWR 100 * 1100/1000 = 110.
+    assert d1.holdings_value == pytest.approx(1100.0)
+    assert d1.twr_index == pytest.approx(110.0)
+
+    # gain_absolu = terminal 1100 - contributed 1000 = 100.
+    assert perf.gain_absolu == pytest.approx(100.0)
+
+
+def test_xirr_computed_over_realistic_horizon():
+    """A one-year 10% gain yields ~10% XIRR through compute_account."""
+    events = [
+        Event(date(2023, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA"),
+        Event(date(2023, 1, 1), EventType.BUY, "AAPL", "Apple", quantity=10,
+              unit_price=100.0, account="PEA"),
+    ]
+    tl = EventAggregator().replay(events, accounts_declared=True)
+    # Price 100 -> 110 over the year: terminal holdings 1100.
+    price_at = _price_at({"AAPL": {date(2023, 1, 1): 100.0, date(2024, 1, 1): 110.0}})
+    perf = compute_account(tl, PEA, {"AAPL"}, price_at,
+                           start=date(2023, 1, 1), today=date(2024, 1, 1))
+    assert perf.xirr == pytest.approx(0.10, abs=1e-3)
+    assert perf.gain_absolu == pytest.approx(100.0)
+
+
+def test_twr_neutral_to_external_flow():
+    """A pure deposit (no price move) must not change the TWR index."""
+    events = [
+        Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA"),
+        Event(date(2024, 1, 2), EventType.DEPOSIT, amount=500.0, account="PEA"),
+    ]
+    tl = EventAggregator().replay(events, accounts_declared=True)
+    perf = compute_account(tl, PEA, set(), _price_at({}),
+                           start=date(2024, 1, 1), today=date(2024, 1, 2))
+    d0, d1 = perf.daily
+    # V0=1000 (anchor 100). V1=1500 but F1=+500 -> (1500-500)/1000 = 1.0 -> still 100.
+    assert d0.twr_index == pytest.approx(100.0)
+    assert d1.twr_index == pytest.approx(100.0)
+
+
+# --------------------------------------------------------------------------- #
+# External vs internal classification
+# --------------------------------------------------------------------------- #
+def test_no_external_flow_no_xirr_no_gain():
+    """Only internal flows (BUY) => no external flow => no xirr, no gain_absolu."""
+    events = [
+        Event(date(2024, 1, 1), EventType.BUY, "AAPL", "Apple", quantity=1,
+              unit_price=100.0, account="PEA"),
+    ]
+    tl = EventAggregator().replay(events, accounts_declared=True)
+    price_at = _price_at({"AAPL": {date(2024, 1, 1): 100.0}})
+    perf = compute_account(tl, PEA, {"AAPL"}, price_at,
+                           start=date(2024, 1, 1), today=date(2024, 1, 1))
+    assert perf.xirr is None
+    assert perf.gain_absolu is None
+
+
+def test_grant_is_external_and_valued_at_day_price():
+    """GRANT is an external in-kind contribution valued at the day's price."""
+    events = [
+        Event(date(2024, 1, 1), EventType.GRANT, "AAPL", "Apple", quantity=10,
+              account="PEA"),
+    ]
+    tl = EventAggregator().replay(events, accounts_declared=True)
+    price_at = _price_at({"AAPL": {date(2024, 1, 1): 50.0}})
+    perf = compute_account(tl, PEA, {"AAPL"}, price_at,
+                           start=date(2024, 1, 1), today=date(2024, 1, 1))
+    # Contributed = 10 * 50 (in-kind); terminal = 10 * 50; gain = 0.
+    assert perf.gain_absolu == pytest.approx(0.0)  # GRANT counts as an external flow
+
+
+# --------------------------------------------------------------------------- #
+# Portfolio total: currency gating
+# --------------------------------------------------------------------------- #
+def test_portfolio_total_none_on_mixed_currencies():
+    tl = EventAggregator().replay([
+        Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA"),
+        Event(date(2024, 1, 1), EventType.DEPOSIT, amount=500.0, account="CTO"),
+    ], accounts_declared=True)
+    price_at = _price_at({})
+    per_account = {
+        "PEA": compute_account(tl, PEA, set(), price_at, date(2024, 1, 1), date(2024, 1, 1)),
+        "CTO": compute_account(tl, CTO, set(), price_at, date(2024, 1, 1), date(2024, 1, 1)),
+    }
+    total = compute_portfolio_total(tl, [PEA, CTO], set(), price_at,
+                                    date(2024, 1, 1), date(2024, 1, 1), per_account)
+    assert total is None  # EUR + USD -> no FX pooling
+
+
+def test_portfolio_total_aggregates_same_currency():
+    pea2 = Account("PEA2", "PEA", "EUR", "PEA 2")
+    tl = EventAggregator().replay([
+        Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA"),
+        Event(date(2024, 1, 1), EventType.DEPOSIT, amount=500.0, account="PEA2"),
+    ], accounts_declared=True)
+    price_at = _price_at({})
+    per_account = {
+        "PEA": compute_account(tl, PEA, set(), price_at, date(2024, 1, 1), date(2024, 1, 1)),
+        "PEA2": compute_account(tl, pea2, set(), price_at, date(2024, 1, 1), date(2024, 1, 1)),
+    }
+    total = compute_portfolio_total(tl, [PEA, pea2], set(), price_at,
+                                    date(2024, 1, 1), date(2024, 1, 1), per_account)
+    assert total is not None
+    assert total.currency == "EUR"
+    assert total.daily[-1].total_value == pytest.approx(1500.0)
+    assert total.gain_absolu == pytest.approx(0.0)  # 1500 terminal - 1500 contributed
+
+
+def test_performance_module_has_no_infra_imports():
+    import inspect
+    src = inspect.getsource(performance)
+    import_lines = "\n".join(
+        line for line in src.splitlines()
+        if line.strip().startswith(("import ", "from "))
+    ).lower()
+    assert "influxdb" not in import_lines
+    assert "yfinance" not in import_lines

--- a/docker-compose/grafana_provisioning/dashboards/accounts_performance.json
+++ b/docker-compose/grafana_provisioning/dashboards/accounts_performance.json
@@ -3,10 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -15,7 +12,7 @@
       }
     ]
   },
-  "description": "Per-account cash and value tracking (opt-in accounts).",
+  "description": "Per-account cash, value and money-weighted performance (opt-in accounts).",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
@@ -24,12 +21,232 @@
   "panels": [
     {
       "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 10,
+      "panels": [],
+      "title": "Portfolio — all accounts",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "description": "Perf globale indisponible — aucun compte configuré, ou comptes en devises différentes. Voir la doc Comptes & trésorerie. Montants en EUR (multi-devises/FX hors scope).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "noValue": "Perf globale indisponible — aucun compte configuré, ou comptes en devises différentes. Voir la doc Comptes & trésorerie.",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null } ] },
+          "unit": "currencyEUR"
+        },
+        "overrides": []
       },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
+      "id": 11,
+      "options": {
+        "colorMode": "none", "graphMode": "area", "justifyMode": "auto", "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "format": "table", "rawQuery": true,
+          "rawSql": "SELECT time, total_value as value FROM portfolio_totals WHERE $__timeFilter(time) AND total_value IS NOT NULL ORDER BY time DESC LIMIT 1",
+          "refId": "A"
+        }
+      ],
+      "title": "Total value (global)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "description": "Net external cash contributed across all accounts.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "noValue": "Perf globale indisponible — aucun compte configuré, ou comptes en devises différentes. Voir la doc Comptes & trésorerie.",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null } ] },
+          "unit": "currencyEUR"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 1 },
+      "id": 12,
+      "options": {
+        "colorMode": "none", "graphMode": "area", "justifyMode": "auto", "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "format": "table", "rawQuery": true,
+          "rawSql": "SELECT time, net_contributed as value FROM portfolio_totals WHERE $__timeFilter(time) AND net_contributed IS NOT NULL ORDER BY time DESC LIMIT 1",
+          "refId": "A"
+        }
+      ],
+      "title": "Net contributed (global)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "description": "Money-weighted return (XIRR, annualized), all accounts. Young portfolios annualize to wild figures — read it next to the absolute gain.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "noValue": "Perf globale indisponible — aucun compte configuré, ou comptes en devises différentes. Voir la doc Comptes & trésorerie.",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 0 } ] },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 1 },
+      "id": 13,
+      "options": {
+        "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "format": "table", "rawQuery": true,
+          "rawSql": "SELECT time, xirr as value FROM portfolio_totals WHERE $__timeFilter(time) AND xirr IS NOT NULL ORDER BY time DESC LIMIT 1",
+          "refId": "A"
+        }
+      ],
+      "title": "XIRR (global)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "description": "Absolute gain across all accounts (guard for a young XIRR). Amounts in EUR.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "noValue": "Perf globale indisponible — aucun compte configuré, ou comptes en devises différentes. Voir la doc Comptes & trésorerie.",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 0 } ] },
+          "unit": "currencyEUR"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 1 },
+      "id": 14,
+      "options": {
+        "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "format": "table", "rawQuery": true,
+          "rawSql": "SELECT time, gain_absolu as value FROM portfolio_totals WHERE $__timeFilter(time) AND gain_absolu IS NOT NULL ORDER BY time DESC LIMIT 1",
+          "refId": "A"
+        }
+      ],
+      "title": "Absolute gain (global)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "description": "Time-weighted return, base 100 (all accounts). The base 100 re-anchors as backfill fills earlier history.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text",
+            "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line",
+            "fillOpacity": 10, "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5,
+            "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "noValue": "Perf globale indisponible — aucun compte configuré, ou comptes en devises différentes. Voir la doc Comptes & trésorerie.",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 7 },
+      "id": 15,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "format": "table", "rawQuery": true,
+          "rawSql": "SELECT time, twr_index FROM portfolio_totals WHERE $__timeFilter(time) AND twr_index IS NOT NULL ORDER BY time",
+          "refId": "A"
+        }
+      ],
+      "title": "TWR index — global (base 100)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 15 },
+      "id": 19,
+      "panels": [],
+      "title": "TWR comparison",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "description": "Time-weighted return per account on the same base-100 scale (compare e.g. PEA vs CTO). The base 100 re-anchors as backfill fills earlier history.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text",
+            "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line",
+            "fillOpacity": 0, "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5,
+            "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "noValue": "Aucun compte configuré.",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "id": 20,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "format": "table", "rawQuery": true,
+          "rawSql": "SELECT time, account, twr_index FROM account_metrics WHERE $__timeFilter(time) AND twr_index IS NOT NULL ORDER BY time",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        { "id": "partitionByValues", "options": { "fields": [ "account" ], "keepFields": false } }
+      ],
+      "title": "TWR index by account (base 100)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 },
       "id": 1,
       "panels": [],
       "repeat": "account",
@@ -38,64 +255,29 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_INFLUXDB}"
-      },
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
       "description": "Cash currently sitting in the account. Amounts are formatted in EUR (the dashboard assumes EUR accounts; multi-currency formatting is out of scope).",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
+          "color": { "mode": "thresholds" },
           "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 0 } ] },
           "unit": "currencyEUR"
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 0,
-        "y": 1
-      },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 25 },
       "id": 2,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
+        "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
         "textMode": "auto"
       },
       "pluginVersion": "10.4.0",
       "targets": [
         {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_INFLUXDB}"
-          },
-          "format": "table",
-          "rawQuery": true,
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "format": "table", "rawQuery": true,
           "rawSql": "SELECT time, cash_balance as value FROM account_metrics WHERE account = '$account' AND $__timeFilter(time) AND cash_balance IS NOT NULL ORDER BY time DESC LIMIT 1",
           "refId": "A"
         }
@@ -104,120 +286,110 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "influxdb",
-        "uid": "${DS_INFLUXDB}"
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "description": "Money-weighted return (XIRR, annualized). Shown next to the absolute gain — on a young account the annualized figure gets wild.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "noValue": "Aucun flux externe (DEPOSIT/WITHDRAWAL) — XIRR non calculable. Voir le gain absolu.",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 0 } ] },
+          "unit": "percentunit"
+        },
+        "overrides": []
       },
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 25 },
+      "id": 4,
+      "options": {
+        "colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "format": "table", "rawQuery": true,
+          "rawSql": "SELECT time, xirr as value FROM account_metrics WHERE account = '$account' AND $__timeFilter(time) AND xirr IS NOT NULL ORDER BY time DESC LIMIT 1",
+          "refId": "A"
+        }
+      ],
+      "title": "XIRR",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "description": "Absolute gain of the account (guard for a young XIRR). Amounts in EUR.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "noValue": "Aucun flux externe (DEPOSIT/WITHDRAWAL) — gain non calculable.",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 0 } ] },
+          "unit": "currencyEUR"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 25 },
+      "id": 5,
+      "options": {
+        "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "format": "table", "rawQuery": true,
+          "rawSql": "SELECT time, gain_absolu as value FROM account_metrics WHERE account = '$account' AND $__timeFilter(time) AND gain_absolu IS NOT NULL ORDER BY time DESC LIMIT 1",
+          "refId": "A"
+        }
+      ],
+      "title": "Absolute gain",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
       "description": "cash_balance + holdings_value are stacked areas — their sum is total_value, so you read the portfolio value and its cash/holdings split at a glance. net_contributed is the thick line on top: the gap between the top of the areas and the line is the absolute gain. Amounts are formatted in EUR (the dashboard assumes EUR accounts; multi-currency formatting is out of scope).",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 25,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text",
+            "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line",
+            "fillOpacity": 25, "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5,
+            "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": true,
+            "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" }
           },
           "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
           "unit": "currencyEUR"
         },
         "overrides": [
           {
-            "matcher": {
-              "id": "byName",
-              "options": "net_contributed"
-            },
+            "matcher": { "id": "byName", "options": "net_contributed" },
             "properties": [
-              {
-                "id": "custom.stacking",
-                "value": {
-                  "group": "A",
-                  "mode": "none"
-                }
-              },
-              {
-                "id": "custom.fillOpacity",
-                "value": 0
-              },
-              {
-                "id": "custom.lineWidth",
-                "value": 3
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
-              }
+              { "id": "custom.stacking", "value": { "group": "A", "mode": "none" } },
+              { "id": "custom.fillOpacity", "value": 0 },
+              { "id": "custom.lineWidth", "value": 3 },
+              { "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }
             ]
           }
         ]
       },
-      "gridPos": {
-        "h": 8,
-        "w": 18,
-        "x": 6,
-        "y": 1
-      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 31 },
       "id": 3,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${DS_INFLUXDB}"
-          },
-          "format": "table",
-          "rawQuery": true,
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "format": "table", "rawQuery": true,
           "rawSql": "SELECT time, cash_balance, holdings_value, net_contributed FROM account_metrics WHERE account = '$account' AND $__timeFilter(time) ORDER BY time",
           "refId": "A"
         }
@@ -229,63 +401,30 @@
   "refresh": "5m",
   "revision": 1,
   "schemaVersion": 39,
-  "tags": [
-    "suivibourse",
-    "accounts"
-  ],
+  "tags": [ "suivibourse", "accounts" ],
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "InfluxDB",
-          "value": "InfluxDB"
-        },
-        "hide": 2,
-        "includeAll": false,
-        "multi": false,
-        "name": "DS_INFLUXDB",
-        "options": [],
-        "query": "influxdb",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
+        "current": { "selected": false, "text": "InfluxDB", "value": "InfluxDB" },
+        "hide": 2, "includeAll": false, "multi": false, "name": "DS_INFLUXDB",
+        "options": [], "query": "influxdb", "refresh": 1, "regex": "", "skipUrlSync": false,
         "type": "datasource"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
-        "datasource": {
-          "type": "influxdb",
-          "uid": "${DS_INFLUXDB}"
-        },
-        "definition": "",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Account",
-        "multi": true,
-        "name": "account",
-        "options": [],
+        "current": { "selected": false, "text": "All", "value": "$__all" },
+        "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+        "definition": "", "hide": 0, "includeAll": true, "label": "Account", "multi": true,
+        "name": "account", "options": [],
         "query": "SELECT DISTINCT account AS __text, account AS __value FROM account_metrics ORDER BY account",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
+        "refresh": 2, "regex": "", "skipUrlSync": false, "sort": 1, "type": "query"
       }
     ]
   },
-  "time": {
-    "from": "now-90d",
-    "to": "now"
-  },
+  "time": { "from": "now-90d", "to": "now" },
   "timepicker": {},
   "timezone": "",
   "title": "SuiviBourse - Accounts",
   "uid": "suivibourse-accounts",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/website/docs/configuration/events-mode.mdx
+++ b/website/docs/configuration/events-mode.mdx
@@ -212,6 +212,39 @@ These values feed the **Accounts** dashboard (`cash_balance`, `holdings_value`,
 `total_value`, `net_contributed`), written to the `account_metrics` measurement
 **only for opt-in users** (accounts declared in `settings.yaml`).
 
+## Performance: XIRR & TWR
+
+On top of the cash & value series, SuiviBourse computes **money-weighted
+performance** — answering *"am I making money, given **when** I put it in?"*
+
+**External vs internal flows** — this is the whole definition of the metric:
+
+- **External** (they are the *contribution*, they do **not** count as
+  performance): `DEPOSIT`, `WITHDRAWAL`, and `GRANT` (in-kind, valued at the
+  day's price).
+- **Internal** (they **do** count as performance): `BUY`, `SELL`, `DIVIDEND`,
+  and every `fee`.
+
+**XIRR** (`xirr`) — the annualized money-weighted rate of return, solved in
+Python by bisection (no SQL, no new dependency). It needs at least one external
+flow; an account **without any** external flow produces **no** `xirr` at all
+(the field is absent, not `0`).
+
+**TWR** (`twr_index`) — the time-weighted return as a **base-100 index**, which
+strips out the effect of *when* you contributed. Its base 100 **re-anchors** as
+backfill fills earlier history.
+
+**Absolute gain** (`gain_absolu`) — `current value − contributions`. It is the
+**guard for a young XIRR**: over a few weeks an annualized rate gives wild
+numbers, so the two are always shown side by side.
+
+:::note Why the global performance can be missing
+The global `portfolio_totals` series is written **only when all accounts share
+the same currency** — pooling different currencies would need FX conversion,
+which is out of scope. So the dashboard's global block is empty **both** when no
+account is configured **and** when accounts use different currencies.
+:::
+
 ## Accounts (opt-in)
 
 By default every position is tracked in a single implicit account named


### PR DESCRIPTION
## Résumé

Implémente **#577** (dernière tranche de la map [#559](https://github.com/pbrissaud/suivi-bourse/issues/559)) — la **performance money-weighted** : le chiffre (**XIRR** annualisé) et la courbe (**TWR** base 100). Répond à « est-ce que je gagne de l'argent, compte tenu de *quand* j'ai apporté cet argent ».

Closes #577

## Ce qui change

- **`performance.py`** — module **pur** : `Timeline` × callable de prix **injecté** → résultats. N'importe ni InfluxDB ni yfinance. Flux **externes** (DEPOSIT/WITHDRAWAL/GRANT valorisé au cours du jour) = l'apport ; **internes** (BUY/SELL/DIVIDEND/fees) = la performance. Valorisation journalière `cash + Σ(qty × price)` (forward-fill), **TWR base 100** (`r_D=(V_D−F_D)/V_{D−1}`), **XIRR par bissection maison** (sans dépendance), gain absolu.
- **`account_metrics`** gagne `xirr` / `gain_absolu` (dernier point seulement) / `twr_index` (journalier). `twr_cumule` n'existe pas.
- **`portfolio_totals`** (nouveau measurement, **sans aucun tag**) : les 7 fields au niveau global, écrit **uniquement si tous les comptes partagent une devise** (FX hors scope).
- **`get_price_series()`** = source de prix partagée, requêtée par `share_symbol` **uniquement** (jamais `account`) — un test garantit l'absence de filtre account **et** la remontée complète de l'historique pré-tag.
- **Prometheus** : `sb_portfolio_*` (sans label `account`) + `xirr`/`gain_absolu`/`twr_index` sur `sb_account_*`.
- **Dashboard 2** : row globale (stats + courbe `twr_index`), courbe **TWR multi-comptes**, stats `xirr`+`gain_absolu` par compte, messages `noValue`/`description` pour les cas dégradés (aucun flux externe, réancrage TWR, limite FX, perf globale indisponible nommant **les deux** causes).
- **Doc** à jour (XIRR/TWR, externes vs internes, pourquoi la perf globale peut être absente).

## Tests & qualité

- `302 passed` (dont `test_performance.py` : cas XIRR de référence 10 %, TWR neutre aux apports, no-external→no-xirr, GRANT valorisé, gating devise). `flake8` propre, docs build OK.
- Revue `/code-review` (Standards + Spec) : **17/17 critères** ; l'axe Spec (finance) confirme **aucune erreur mathématique** (signes XIRR, ancre TWR, cohérence gain_absolu). Les points Standards (signes moins Unicode, 2 duplications) sont corrigés dans le 2ᵉ commit.

## Chaîne

Dernière issue de la map **Comptes & trésorerie** : #574 → #575 → #576 → **#577** ✅. (Reste #578, doc de migration, non listée `ready-for-agents` ici.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added XIRR, TWR, and absolute gain performance metrics for individual accounts.
  - Added global portfolio performance totals for single-currency portfolios.
  - Exposed new performance metrics through Prometheus monitoring.
  - Expanded Grafana dashboards with portfolio and account performance panels.

- **Documentation**
  - Documented performance calculations, cash-flow treatment, currency requirements, and metric availability in events mode.

- **Bug Fixes**
  - Prevented global portfolio totals from being generated for mixed-currency portfolios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->