### PR TITLE
docs(website): document the account-tag migration seam & manual purge (#578)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,7 +271,7 @@ Gauges (prefix `sb_`, labels `share_name`/`share_symbol`/`account`): `sb_share_p
 |------|------|-------------|
 | Tag | `share_name` | Display name |
 | Tag | `share_symbol` | Yahoo Finance ticker |
-| Tag | `account` | Account bucket (`default` unless accounts are declared) |
+| Tag | `account` | Account bucket (`default` unless accounts are declared); on v4.1+ writes only — pre-v4.1 points have no tag (`NULL`), read with `COALESCE(account, 'default')` |
 | Tag | `share_currency` | Currency (USD, EUR, etc.) |
 | Tag | `share_exchange` | Exchange (NMS, PAR, etc.) |
 | Tag | `quote_type` | Type (EQUITY, ETF, etc.) |

--- a/website/docs/advanced/influxdb.mdx
+++ b/website/docs/advanced/influxdb.mdx
@@ -16,6 +16,7 @@ Tags identify the series and are used to filter/group in Grafana.
 |-----|-------------|---------|
 | `share_name` | Display name | `Apple` |
 | `share_symbol` | Yahoo! Finance ticker | `AAPL` |
+| `account` | Account bucket (`default` unless accounts are declared) | `PEA`, `default` |
 | `share_currency` | Currency | `USD` |
 | `share_exchange` | Exchange | `NMS`, `PAR` |
 | `quote_type` | Instrument type | `EQUITY`, `ETF` |
@@ -24,6 +25,14 @@ Tags identify the series and are used to filter/group in Grafana.
 `share_name` and `share_symbol` are always set. The currency/exchange/quote-type
 tags are only written when the ticker info was successfully fetched, so that
 historical and live points share the same series identity.
+:::
+
+:::warning The `account` tag is on v4.1+ writes only, not on history
+The `account` tag is carried by **100% of the points written from v4.1 onwards** —
+**not** by points written before the upgrade, which have no tag and are exposed
+as `NULL`. Always read it with `COALESCE(account, 'default')` and never with a
+bare `WHERE account = '…'` (which would silently drop the pre-v4.1 points). See
+[Upgrading to accounts](/docs/advanced/upgrading-accounts) for the full picture.
 :::
 
 ## Fields
@@ -48,6 +57,16 @@ historical and live points share the same series identity.
 Market fields such as `dividend_yield`, `pe_ratio` and `market_cap` may be
 missing for some instruments (e.g. ETFs or crypto). Fields are only written when
 a value is available.
+:::
+
+:::note Account measurements
+For opt-in [accounts](/docs/configuration/events-mode#accounts-opt-in),
+SuiviBourse also writes two daily measurements: **`account_metrics`** (tags
+`account` / `account_type` / `account_currency`; fields `cash_balance`,
+`holdings_value`, `total_value`, `net_contributed`, `xirr`, `gain_absolu`,
+`twr_index`) and **`portfolio_totals`** — the same performance fields at the
+global level, written with **no tag** (a synthetic account tag would double every
+`SUM()`), only when all accounts share one currency.
 :::
 
 ## Querying with SQL

--- a/website/docs/advanced/prometheus-legacy.mdx
+++ b/website/docs/advanced/prometheus-legacy.mdx
@@ -27,8 +27,8 @@ SB_PROMETHEUS_ENABLED=false
 
 ## Exposed gauges
 
-All gauges are prefixed with `sb_` and carry the labels `share_name` and
-`share_symbol`.
+All share gauges are prefixed with `sb_` and carry the labels `share_name`,
+`share_symbol` and `account`.
 
 | Metric | Description |
 |--------|-------------|
@@ -43,6 +43,28 @@ All gauges are prefixed with `sb_` and carry the labels `share_name` and
 | `sb_market_cap` | Market capitalization |
 | `sb_volume` | Trading volume |
 | `sb_share_info` | Always `1`; carries extra labels `share_currency`, `share_exchange`, `quote_type` |
+
+:::warning New `account` label (v4.1) — re-glue existing queries
+Since v4.1 the `sb_*` gauges carry an **`account`** label. A query that used to
+aggregate without it now splits by account; aggregate the label away to restore
+the old behaviour:
+
+```promql
+sum without(account) (sb_owned_quantity)
+```
+
+See [Upgrading to accounts](/docs/advanced/upgrading-accounts).
+:::
+
+For opt-in [accounts](/docs/configuration/events-mode#accounts-opt-in), extra
+per-account and global gauges are exposed:
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `sb_account_cash_balance` / `sb_account_holdings_value` / `sb_account_total_value` / `sb_account_net_contributed` | `account` | Per-account cash & value |
+| `sb_account_xirr` / `sb_account_gain_absolu` / `sb_account_twr_index` | `account` | Per-account money-weighted performance |
+| `sb_account_info` | `account`, `account_type`, `account_currency` | Always `1` |
+| `sb_portfolio_*` | _(none)_ | The same fields at the global level, **without** an `account` label |
 
 ## Scraping with Prometheus
 

--- a/website/docs/advanced/upgrading-accounts.mdx
+++ b/website/docs/advanced/upgrading-accounts.mdx
@@ -1,0 +1,112 @@
+---
+title: Upgrading to accounts (v4.1)
+description: What the account tag does to data already in InfluxDB, and the optional manual purge
+sidebar_position: 4
+---
+
+v4.1 introduces **first-class accounts**: every point written to
+`portfolio_metrics` now carries an `account` tag, and two new measurements
+(`account_metrics`, `portfolio_totals`) hold the per-account cash, value and
+money-weighted performance. This page explains the **seam** the `account` tag
+leaves on data that is already in your database — and what to do (and not do)
+about it.
+
+:::info No migration is run
+Upgrading performs **no** migration and **no** history rewrite. Nothing in your
+existing data is touched. Everything below is about *reading* the two regimes
+together, which just works.
+:::
+
+## What you'll see after upgrading
+
+Points written **before** the upgrade have no `account` tag. InfluxDB 3 is
+columnar (Parquet), not the old 1.x/2.x "series" model, so a missing tag is
+exposed as **`NULL`** rather than a distinct series. Read back with
+`COALESCE(account, 'default')` and the two regimes glue together seamlessly:
+
+```sql
+SELECT COALESCE(account, 'default') AS account, share_symbol, owned_quantity
+FROM portfolio_metrics
+WHERE share_name = 'Apple'
+```
+
+Your pre-upgrade points therefore appear under **`default`**, which is the honest
+label in both cases:
+
+- for a user who does **not** opt into accounts, there is only one (implicit)
+  account — `default` is exact;
+- for a user who **does** opt in, their events genuinely had no account before
+  the upgrade — `default` is honest.
+
+The shipped **dashboards read with `COALESCE(account, 'default')`** and never
+with a bare `WHERE account = '…'`, so your history stays visible and correctly
+aggregated.
+
+:::tip Performance is exact from day one
+Money-weighted performance (XIRR, TWR) is computed from the **price history**,
+which is read via `get_price_series()` — queried by `share_symbol` **only**,
+never filtered by `account`. Because a market price belongs to no account, the
+pre-tag (`NULL`) price history is read **in full**, so XIRR and TWR are exact
+over your **entire** history from the very first v4.1 write.
+:::
+
+## Why the history is not rewritten
+
+This is a **limitation, not a preference**:
+
+- InfluxDB 3 has **no `DELETE … WHERE`** — deletion granularity is the whole
+  table or the whole database.
+- Re-writing a point to add a tag produces a **second row** instead of replacing
+  the first, which would **double-count** every `SUM()`.
+- The backfill only ever works **backwards** in time; it can neither correct nor
+  corrupt points that already exist.
+
+So a bare `WHERE account = 'default'` **would** drop the untagged points — which
+is exactly why the read path uses `COALESCE(account, 'default')` everywhere.
+
+## Optional: start clean with a manual purge
+
+If you want a history that is 100% tagged, you can **manually** drop the
+`portfolio_metrics` table and let SuiviBourse recreate it on the next write:
+
+```bash
+curl -X DELETE "$INFLUXDB_HOST/api/v3/configure/table" \
+  -H "Authorization: Bearer $INFLUXDB_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"db": "suivi_bourse", "table": "portfolio_metrics"}'
+```
+
+The table is recreated cleanly on the next write (no grace period).
+
+:::danger This is **not** the recommended path — it destroys more than it repairs
+A purge throws away your real scrape history and can only be **rebuilt from
+backfill**, which is strictly worse:
+
+- backfill returns **daily closes only** — you lose the every-120s granularity of
+  live scraping;
+- `dividend_yield`, `pe_ratio` and `market_cap` are **never** rebuilt — they exist
+  only on live scrapes and are gone for good.
+
+Because of this, purging is a deliberate "I accept the loss" choice, never a
+default.
+:::
+
+:::caution Never automate destruction
+There is intentionally **no application flag or option** to purge data. A
+destructive flag combined with `restart: unless-stopped` would be a data
+shredder — the purge stays a manual, one-off `curl`.
+:::
+
+## Prometheus seam
+
+The same seam appears on the legacy Prometheus endpoint: the `sb_*` gauges now
+carry an **`account`** label. Any existing query that aggregated **without** it
+(e.g. `sum(sb_owned_quantity)`) will now split by account. Re-glue it by
+aggregating the label away:
+
+```promql
+sum without(account) (sb_owned_quantity)
+```
+
+See the [legacy Prometheus endpoint](/docs/advanced/prometheus-legacy) for the
+full gauge list.

--- a/website/docs/configuration/events-mode.mdx
+++ b/website/docs/configuration/events-mode.mdx
@@ -303,8 +303,10 @@ implicit `default` account. Manual mode is unaffected as well.
 
 ### How accounts appear downstream
 
-- **InfluxDB** — every point of `portfolio_metrics` carries an `account` tag
-  (`default` when accounts aren't declared).
+- **InfluxDB** — every point of `portfolio_metrics` **written from v4.1 onwards**
+  carries an `account` tag (`default` when accounts aren't declared). Points
+  written before the upgrade have no tag — see
+  [Upgrading to accounts](/docs/advanced/upgrading-accounts).
 - **Prometheus** — the `sb_*` gauges gain an `account` label, so the same
   symbol held in two accounts no longer overwrites itself.
 - **Grafana (dashboard 1)** — the "patrimoine total" dashboard **aggregates


### PR DESCRIPTION
## Résumé

Implémente **#578** (dernière issue de la map [#559](https://github.com/pbrissaud/suivi-bourse/issues/559)) — documenter la **couture** que laisse l'introduction du tag `account` sur les données déjà en base. **Aucun code de migration** n'est écrit : c'est précisément la décision.

Closes #578

## Ce qui change (doc uniquement)

- **Nouveau guide `Upgrading to accounts (v4.1)`** (`advanced/upgrading-accounts.mdx`) :
  - ce que voit un user qui upgrade : ses points antérieurs apparaissent sous `default`, et pourquoi c'est correct (tag absent → `NULL` en InfluxDB 3 colonnaire, recollé par `COALESCE(account, 'default')`) ;
  - la perf (XIRR/TWR) est **exacte sur tout l'historique dès la v4.1** — `get_price_series()` requête par `share_symbol` uniquement ;
  - pourquoi l'historique n'est **pas** réécrit (pas de `DELETE … WHERE`, retag → double-compte les `SUM()`, backfill en arrière seulement) ;
  - la **procédure de purge manuelle** (`DELETE /api/v3/configure/table`) **et** ce qu'elle détruit (clôtures journalières vs scraping 120 s ; `dividend_yield`/`pe_ratio`/`market_cap` perdus définitivement) — **non recommandée**, et **jamais un flag applicatif**.
- **Couture Prometheus** (release note) : le label `account` sur les `sb_*`, recollage `sum without(account)` — dans le guide et dans `prometheus-legacy.mdx`.
- **Amendement de la doc data-model #569** (`advanced/influxdb.mdx`) : le tag `account` est sur **100 % des points écrits en v4.1+**, pas sur l'historique ; ajout des measurements `account_metrics`/`portfolio_totals`.

## Notes

- **Aucun code touché** (critère : pas de flag/option de purge). `CHANGELOG.md` non modifié (géré par Release Please).
- **Séquencement** : cette PR référence les features de #577 (XIRR/TWR/`portfolio_totals`) — elle est **rebasée sur master après le merge de #577** (#591), donc les features décrites sont bien présentes.
- Revue `/code-review` : **Standards** ✅ (DCO, conventional commit, MDX, liens, pas de collision sidebar, plus aucun `v5`). **Spec** : les 7 critères couverts ; l'« inexactitude » relevée n'était due qu'au fait que #577 n'était pas encore mergée — résolue par le rebase.
- `pnpm build` OK (aucun lien cassé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)