### PR TITLE
feat(app): market-aware per-symbol scheduling (#616)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ The application runs independent scheduled jobs on a single APScheduler:
 Writes to InfluxDB measurement `portfolio_metrics` with fields: `share_price`, `purchased_quantity`, `purchased_price`, `purchased_fee`, `owned_quantity`, `received_dividend`, `dividend_yield`, `pe_ratio`, `market_cap`
 
 ### Scheduled Jobs
-```
+```text
 ┌──────────────────────────┐  ┌───────────────────┐  ┌──────────────────┐  ┌────────────────────┐
 │  SCRAPE  (per symbol,    │  │    INGESTION      │  │    BACKFILL      │  │   PERFORMANCE      │
 │  self-rescheduling)      │  │   (every 300s)    │  │   (every 60s)    │  │ (REGULAR cadence)  │

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,32 +55,44 @@ SB_CONFIG_MODE=events docker-compose -f docker-compose.dev.yaml up -d
 
 **Main entry point**: `app/src/main.py`
 
-The application runs three independent scheduled jobs:
-- **Scraping**: Fetches stock prices from Yahoo Finance (default: every 120s)
-- **Ingestion**: Reloads portfolio events from files (default: every 300s)
-- **Backfill**: Progressively fills historical price data (default: every 60s)
+The application runs independent scheduled jobs on a single APScheduler:
+- **Scraping**: one **self-rescheduling job per held symbol**, market-aware
+  (issue #616). Each job fetches its symbol from Yahoo Finance, writes a point
+  per account holding it, then re-arms on its own cadence: `REGULAR` markets
+  re-poll every `SB_REGULAR_INTERVAL` (default 120s); closed markets sleep to
+  the next open (capped 24h). There is no global scrape job.
+- **Ingestion**: Reloads portfolio events from files (default: every 300s) and
+  reconciles the per-symbol scrape jobs against the new symbol set (add / remove
+  / revive).
+- **Backfill**: Progressively fills historical price data (default: every 60s).
+- **Performance**: Recomputes the `account_metrics` / `portfolio_totals` series
+  (opt-in accounts only) on the `REGULAR` cadence, decoupled from scraping.
 
 Writes to InfluxDB measurement `portfolio_metrics` with fields: `share_price`, `purchased_quantity`, `purchased_price`, `purchased_fee`, `owned_quantity`, `received_dividend`, `dividend_yield`, `pe_ratio`, `market_cap`
 
-### Three Independent Schedules
+### Scheduled Jobs
 ```
-┌─────────────────────┐  ┌─────────────────────┐  ┌─────────────────────┐
-│     SCRAPING        │  │     INGESTION       │  │     BACKFILL        │
-│   (every 120s)      │  │   (every 300s)      │  │   (every 60s)       │
-│                     │  │                     │  │                     │
-│ • yfinance.Ticker() │  │ • Load events CSV   │  │ • Check gaps        │
-│ • Current prices    │  │ • Recalculate state │  │ • yfinance.history()│
-│ • Write InfluxDB    │  │ • Update shares[]   │  │ • Chunk 1 year/req  │
-│                     │  │                     │  │ • Rate limit 10s    │
-└─────────────────────┘  └─────────────────────┘  └─────────────────────┘
-         │                        │                        │
-         └────────────────────────┼────────────────────────┘
-                                  ▼
-                           ┌─────────────┐
-                           │  InfluxDB 3 │
-                           │  (database) │
-                           └─────────────┘
+┌──────────────────────────┐  ┌───────────────────┐  ┌──────────────────┐  ┌────────────────────┐
+│  SCRAPE  (per symbol,    │  │    INGESTION      │  │    BACKFILL      │  │   PERFORMANCE      │
+│  self-rescheduling)      │  │   (every 300s)    │  │   (every 60s)    │  │ (REGULAR cadence)  │
+│                          │  │                   │  │                  │  │                    │
+│ • yfinance.Ticker()      │  │ • Load events CSV │  │ • Check gaps     │  │ • Recompute perf   │
+│ • marketState → cadence  │  │ • Recalc state    │  │ • history()      │  │   series (opt-in   │
+│ • REGULAR: poll & write  │  │ • Update shares[] │  │ • Chunk 1 yr/req │  │   accounts only)   │
+│ • Closed: sleep to open  │  │ • Reconcile jobs  │  │ • Rate limit 10s │  │                    │
+└──────────────────────────┘  └───────────────────┘  └──────────────────┘  └────────────────────┘
+         │                            │                       │                       │
+         └────────────────────────────┴───────────┬───────────┴───────────────────────┘
+                                                   ▼
+                                            ┌─────────────┐
+                                            │  InfluxDB 3 │
+                                            │  (database) │
+                                            └─────────────┘
 ```
+
+The two pure modules `scheduling.py` (cadence/market-context decisions) and
+`performance.py` (money-weighted returns) hold the testable logic — no InfluxDB
+or yfinance, `now` injected.
 
 ## Configuration
 
@@ -221,7 +233,8 @@ If ingestion fails (invalid event, file error), the **previous valid configurati
 | `INFLUXDB_HOST` | `http://influxdb:8181` | InfluxDB 3 host URL |
 | `INFLUXDB_TOKEN` | (required) | InfluxDB API token |
 | `INFLUXDB_DATABASE` | `suivi_bourse` | InfluxDB database name |
-| `SB_SCRAPING_INTERVAL` | `120` | Price scraping interval (seconds) |
+| `SB_REGULAR_INTERVAL` | `120` | Poll interval (seconds) for a symbol whose market is in `REGULAR` state (per-symbol scheduling). Closed markets sleep to next open instead. |
+| `SB_SCRAPING_INTERVAL` | — | **Deprecated** heir of the removed global scrape interval. Honored as a fallback for `SB_REGULAR_INTERVAL` when the latter is unset; logs a warning whenever present. |
 | `SB_INGESTION_INTERVAL` | `300` | Event ingestion interval (seconds) |
 | `SB_BACKFILL_INTERVAL` | `60` | Backfill check interval (seconds) |
 | `SB_BACKFILL_DELAY` | `10` | Delay between yfinance requests (seconds) |

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -715,16 +715,25 @@ class SuiviBourseMetrics:
             now = datetime.now(timezone.utc)
             held = self._held_symbols()
             scheduled = self._scheduled_symbols()
-            # Add new + revive missing in one pass: any held symbol without a
-            # live job fires immediately.
-            for symbol in held - scheduled:
-                self._arm_symbol(symbol, 0, now)
-            # Remove departed symbols' idle jobs (belt-and-braces with the
-            # in-flight membership re-check in _scrape_symbol).
-            for symbol in scheduled - held:
-                self.scheduler.remove_job(_scrape_job_id(symbol))
         except Exception as e:
             app_logger.error(f"Failed to reconcile per-symbol jobs: {e}")
+            return
+        # Add new + revive missing in one pass: any held symbol without a live
+        # job fires immediately. Remove departed symbols' idle jobs (belt-and-
+        # braces with the in-flight membership re-check in _scrape_symbol).
+        # Each op is guarded on its own so one failure — e.g. a JobLookupError
+        # from a self-re-arming date job that just fired and vanished — never
+        # aborts the rest of the reconcile pass.
+        for symbol in held - scheduled:
+            try:
+                self._arm_symbol(symbol, 0, now)
+            except Exception as e:
+                app_logger.error(f"Failed to arm scrape job for {symbol}: {e}")
+        for symbol in scheduled - held:
+            try:
+                self.scheduler.remove_job(_scrape_job_id(symbol))
+            except Exception as e:
+                app_logger.debug(f"Job for {symbol} already gone, skipping: {e}")
 
     def _scrape_symbol(self, symbol: str, now: Optional[datetime] = None) -> None:
         """Scrape one symbol, gate the write, and re-arm the job (design #602).

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -21,6 +21,7 @@ from urllib3 import exceptions as u_exceptions
 from yfinance.exceptions import YFRateLimitError
 
 import performance
+import scheduling
 from events import (
     EventLoader, EventValidator, EventAggregator, EventWatcher,
     AccountMetricPoint, PortfolioTotalPoint,
@@ -56,6 +57,41 @@ ACCOUNTS_SCHEMA = {
         },
     },
 }
+
+
+# Per-symbol scrape jobs are keyed ``scrape:<symbol>`` in the APScheduler
+# jobstore (issue #616). One job per symbol — scraping is account-independent.
+SCRAPE_JOB_PREFIX = 'scrape:'
+
+
+def _scrape_job_id(symbol: str) -> str:
+    return f'{SCRAPE_JOB_PREFIX}{symbol}'
+
+
+def resolve_regular_interval() -> int:
+    """Resolve the REGULAR-state poll interval (``base_interval``) from the env.
+
+    Precedence (design #607): ``SB_REGULAR_INTERVAL`` > ``SB_SCRAPING_INTERVAL``
+    (deprecated fallback) > ``120``. ``SB_SCRAPING_INTERVAL`` is the direct heir
+    of the removed global scrape interval, so it is still honored as a fallback
+    but a warning is logged whenever it is present — whether used or ignored.
+    """
+    new_val = os.getenv('SB_REGULAR_INTERVAL')
+    old_val = os.getenv('SB_SCRAPING_INTERVAL')
+    if old_val is not None:
+        if new_val is not None:
+            app_logger.warning(
+                "SB_SCRAPING_INTERVAL is deprecated and ignored because "
+                "SB_REGULAR_INTERVAL is set; remove SB_SCRAPING_INTERVAL.")
+        else:
+            app_logger.warning(
+                "SB_SCRAPING_INTERVAL is deprecated; prefer SB_REGULAR_INTERVAL. "
+                "Honoring it as a fallback for now.")
+    if new_val is not None:
+        return int(new_val)
+    if old_val is not None:
+        return int(old_val)
+    return 120
 
 
 class InvalidConfigFile(Exception):
@@ -389,6 +425,17 @@ class SuiviBourseMetrics:
         self.backfill_delay = int(os.getenv('SB_BACKFILL_DELAY', '10'))
         self.backfill_chunk_days = int(os.getenv('SB_BACKFILL_CHUNK_DAYS', '365'))
 
+        # Market-aware per-symbol scheduling (issue #616). Each held symbol runs
+        # as its own self-rescheduling APScheduler job; the scheduler is injected
+        # from __main__ (None until then, so unit tests that never wire it skip
+        # reconciliation). `regular_interval` is the REGULAR-state poll cadence
+        # (base_interval), overridden from the environment in __main__.
+        # `_failure_counts` is threaded through scheduling.decide per symbol
+        # (backoff growth itself is a later slice).
+        self.scheduler: Optional[BlockingScheduler] = None
+        self.regular_interval = 120
+        self._failure_counts: Dict[str, int] = {}
+
         # Cache for share info (to avoid repeated API calls during backfill)
         self._share_info_cache: Dict[str, Dict] = {}
 
@@ -460,7 +507,15 @@ class SuiviBourseMetrics:
                     'dividendYield': ticker_info.get('dividendYield'),
                     'peRatio': ticker_info.get('trailingPE') or ticker_info.get('forwardPE'),
                     'marketCap': ticker_info.get('marketCap'),
-                    'volume': int(last_volume) if pd.notna(last_volume) else None
+                    'volume': int(last_volume) if pd.notna(last_volume) else None,
+                    # Market-context fields feed the per-symbol scheduler
+                    # (scheduling.extract_market_context). They ride on `info`
+                    # so _fetch_ticker_data keeps its (last_quote, info) shape;
+                    # _history_meta carries currentTradingPeriod for the exact
+                    # next-open. Extra keys are ignored by the write path.
+                    'marketState': ticker_info.get('marketState'),
+                    'exchangeTimezoneName': ticker_info.get('exchangeTimezoneName'),
+                    '_history_meta': getattr(ticker, 'history_metadata', None),
                 }
                 # Cache the info for backfill use
                 self._share_info_cache[symbol] = info
@@ -548,25 +603,65 @@ class SuiviBourseMetrics:
 
         return None
 
+    def _update_share_prometheus(self, share, last_quote, info) -> None:
+        """Update the legacy Prometheus ``sb_share_*`` gauges for one share.
+
+        Kept independent of the InfluxDB write so ``/metrics`` stays populated
+        even if InfluxDB errors, and gated by the caller on **fetch success**
+        (price present) rather than the write/REGULAR gate — a closed-market
+        restart must still leave the share gauges populated (design #609).
+        """
+        if self.prometheus is None:
+            return
+        try:
+            self.prometheus.update_share(share, last_quote, info)
+        except Exception as e:
+            app_logger.error(
+                f"Failed to update Prometheus metrics for {share['symbol']}: {e}")
+
+    def _write_share_metrics(self, share, last_quote, info) -> None:
+        """Write one share's live metrics point to InfluxDB.
+
+        Guarded so a transient InfluxDB error on one share does not abort the
+        surrounding cycle. Callers only invoke this once the fetch succeeded, so
+        currency/exchange/quote_type tags are always present and the point lands
+        in the same enriched series as its history.
+        """
+        try:
+            self.influxdb.write_metrics(
+                share_name=share['name'],
+                share_symbol=share['symbol'],
+                account=share.get('account', DEFAULT_ACCOUNT),
+                share_price=last_quote,
+                purchased_quantity=share['purchase']['quantity'],
+                purchased_price=share['purchase']['cost_price'],
+                purchased_fee=share['purchase']['fee'],
+                owned_quantity=share['estate']['quantity'],
+                received_dividend=share['estate']['received_dividend'],
+                share_currency=info['currency'],
+                share_exchange=info['exchange'],
+                quote_type=info['quoteType'],
+                dividend_yield=info['dividendYield'] * 100 if info['dividendYield'] is not None else None,
+                pe_ratio=info['peRatio'],
+                market_cap=info['marketCap'],
+                volume=info['volume']
+            )
+        except Exception as e:
+            app_logger.error(
+                f"Failed to write metrics for {share['symbol']}: {e}")
+
     def expose_metrics(self):
         """
         Expose the metrics for each stock share to InfluxDB.
+
+        Synchronous whole-portfolio scrape kept for the manual/backward-compat
+        path; the scheduled runtime drives per-symbol jobs via ``_scrape_symbol``.
         """
-        for i, share in enumerate(self.shares):
-            share_name = share['name']
+        for share in self.shares:
             share_symbol = share['symbol']
-            share_account = share.get('account', DEFAULT_ACCOUNT)
 
             last_quote, info = self._fetch_ticker_data(share_symbol)
-
-            # Update the legacy Prometheus gauges independently of the InfluxDB
-            # write so the /metrics endpoint stays populated even if InfluxDB errors.
-            if self.prometheus is not None:
-                try:
-                    self.prometheus.update_share(share, last_quote, info)
-                except Exception as e:
-                    app_logger.error(
-                        f"Failed to update Prometheus metrics for {share_symbol}: {e}")
+            self._update_share_prometheus(share, last_quote, info)
 
             # Skip writing when the fetch failed: writing portfolio fields with
             # missing currency/exchange/quote_type tags would land them in a
@@ -575,33 +670,130 @@ class SuiviBourseMetrics:
                 app_logger.warning(
                     f"No data fetched for {share_symbol}, skipping metrics write")
             else:
-                # Guard the write so a transient InfluxDB error on one share does
-                # not abort the whole scrape cycle and drop the remaining shares.
-                try:
-                    self.influxdb.write_metrics(
-                        share_name=share_name,
-                        share_symbol=share_symbol,
-                        account=share_account,
-                        share_price=last_quote,
-                        purchased_quantity=share['purchase']['quantity'],
-                        purchased_price=share['purchase']['cost_price'],
-                        purchased_fee=share['purchase']['fee'],
-                        owned_quantity=share['estate']['quantity'],
-                        received_dividend=share['estate']['received_dividend'],
-                        share_currency=info['currency'],
-                        share_exchange=info['exchange'],
-                        quote_type=info['quoteType'],
-                        dividend_yield=info['dividendYield'] * 100 if info['dividendYield'] is not None else None,
-                        pe_ratio=info['peRatio'],
-                        market_cap=info['marketCap'],
-                        volume=info['volume']
-                    )
-                except Exception as e:
-                    app_logger.error(
-                        f"Failed to write metrics for {share_symbol}: {e}")
+                self._write_share_metrics(share, last_quote, info)
 
-            if i < len(self.shares) - 1:
-                time.sleep(1)
+    # ------------------------------------------------------------------ #
+    # Market-aware per-symbol scheduling (issue #616)
+    # ------------------------------------------------------------------ #
+
+    def _held_symbols(self) -> set:
+        """The set of symbols currently held across all accounts."""
+        return {s['symbol'] for s in self.shares if s.get('symbol')}
+
+    def _scheduled_symbols(self) -> set:
+        """Symbols that currently have a live per-symbol scrape job."""
+        out = set()
+        for job in (self.scheduler.get_jobs() or []):
+            jid = getattr(job, 'id', '') or ''
+            if jid.startswith(SCRAPE_JOB_PREFIX):
+                out.add(jid[len(SCRAPE_JOB_PREFIX):])
+        return out
+
+    def _arm_symbol(self, symbol: str, delay: float, now: datetime) -> None:
+        """(Re)schedule a symbol's scrape job to fire ``delay`` seconds from now.
+
+        A single ``date`` trigger — the job re-arms itself each cycle, so this is
+        both the immediate bootstrap (``delay=0``) and the self-reschedule.
+        """
+        run_date = now + timedelta(seconds=delay)
+        self.scheduler.add_job(
+            self._scrape_symbol, 'date', run_date=run_date,
+            args=[symbol], id=_scrape_job_id(symbol),
+            name=f'Scrape {symbol}', replace_existing=True)
+
+    def _reconcile_jobs(self) -> None:
+        """Diff the held-symbol set against the scheduled jobs (design #604).
+
+        New **and** revived (missing) symbols are armed to fire immediately (the
+        first fire is the bootstrap); departed symbols are ``remove_job``'d;
+        unchanged symbols keep their existing timers untouched. Guarded so a
+        scheduler hiccup never aborts ingestion.
+        """
+        if self.scheduler is None:
+            return
+        try:
+            now = datetime.now(timezone.utc)
+            held = self._held_symbols()
+            scheduled = self._scheduled_symbols()
+            # Add new + revive missing in one pass: any held symbol without a
+            # live job fires immediately.
+            for symbol in held - scheduled:
+                self._arm_symbol(symbol, 0, now)
+            # Remove departed symbols' idle jobs (belt-and-braces with the
+            # in-flight membership re-check in _scrape_symbol).
+            for symbol in scheduled - held:
+                self.scheduler.remove_job(_scrape_job_id(symbol))
+        except Exception as e:
+            app_logger.error(f"Failed to reconcile per-symbol jobs: {e}")
+
+    def _scrape_symbol(self, symbol: str, now: Optional[datetime] = None) -> None:
+        """Scrape one symbol, gate the write, and re-arm the job (design #602).
+
+        Fetch once, then apply ``scheduling.decide`` to split the two gates:
+        the write gate (not-closed AND price present) and the reschedule gate
+        (closed → sleep to next open, else ``base_interval``). Writes one point
+        per account holding this symbol. Re-arms only while the symbol is still
+        held (the in-flight half of the self-reschedule↔removal race guard).
+        """
+        injected_now = now is not None
+        now = now or datetime.now(timezone.utc)
+        last_quote, info = self._fetch_ticker_data(symbol)
+        price_present = last_quote is not None and info is not None
+
+        holdings = [s for s in self.shares if s.get('symbol') == symbol]
+
+        # Prometheus sb_share_* gauges stay on the fetch-success gate (#609),
+        # never the write/REGULAR gate.
+        if price_present:
+            for share in holdings:
+                self._update_share_prometheus(share, last_quote, info)
+
+        if info is not None:
+            state, next_open = scheduling.extract_market_context(
+                info, info.get('_history_meta'), now)
+        else:
+            # Fetch failed outright: no state to read, fail-open as REGULAR so a
+            # transient failure keeps the job polling rather than sleeping it.
+            state, next_open = None, None
+
+        should_write, next_delay, new_failure_count, _mark_dirty = scheduling.decide(
+            state, price_present, next_open, now,
+            self._failure_counts.get(symbol, 0), self.regular_interval)
+        self._failure_counts[symbol] = new_failure_count
+
+        if should_write:
+            for share in holdings:
+                self._write_share_metrics(share, last_quote, info)
+        else:
+            app_logger.debug(
+                f"Skipping write for {symbol} (state={state}, "
+                f"price_present={price_present})")
+
+        # Re-arm only if still held — the in-flight guard against a job that was
+        # removed mid-cycle re-adding itself after reconcile's remove_job.
+        if self.scheduler is not None and symbol in self._held_symbols():
+            # Schedule from a fresh wall-clock, not the decision `now` captured
+            # before the fetch: _fetch_ticker_data can sleep on rate-limit
+            # retries, which for a small next_delay would otherwise put run_date
+            # in the past and let APScheduler drop the job, breaking the
+            # self-reschedule chain. Tests inject `now` to keep run_date
+            # deterministic; production recomputes it here.
+            arm_now = now if injected_now else datetime.now(timezone.utc)
+            self._arm_symbol(symbol, next_delay, arm_now)
+
+    def recompute_perf(self) -> None:
+        """Recompute the perf series on its own interval (design #605 seam).
+
+        Now that per-symbol jobs replaced the global scrape loop, the
+        account_metrics/portfolio_totals recompute runs as its own scheduled
+        job. Guarded so an error never kills the scheduler thread. (Dirty-flag
+        gating of this job is a later slice; the write itself is already
+        incremental, so cadence-driven recomputes stay cheap.)
+        """
+        try:
+            self.update_account_metrics()
+        except Exception as e:
+            app_logger.error(f"Failed to update account metrics: {e}")
 
     def ingest(self):
         """
@@ -626,6 +818,12 @@ class SuiviBourseMetrics:
                 app_logger.debug("No changes in shares configuration")
         except Exception as e:
             app_logger.error(f"Error during ingestion (keeping previous config): {e}")
+
+        # Reconcile the per-symbol scrape jobs against the (possibly unchanged)
+        # held-symbol set. Idempotent and always run — on the first ingest it
+        # arms every symbol, later it only touches the diff. No-op until the
+        # scheduler is wired in __main__.
+        self._reconcile_jobs()
 
     def backfill(self):
         """
@@ -811,20 +1009,18 @@ class SuiviBourseMetrics:
     def scrape(self):
         """
         Scrape stock prices from Yahoo Finance and expose metrics.
-        This is called on a separate schedule from ingestion.
+
+        Synchronous whole-portfolio path kept for the manual/backward-compat and
+        e2e harness; the scheduled runtime drives per-symbol jobs + the perf job.
         """
         if not self.shares:
             app_logger.warning("No shares configured, skipping scrape")
             return
 
         self.expose_metrics()
-
-        # Recompute the per-account cash & value series after prices are fresh.
-        # Guarded so an account_metrics error never aborts the scrape cycle.
-        try:
-            self.update_account_metrics()
-        except Exception as e:
-            app_logger.error(f"Failed to update account metrics: {e}")
+        # Recompute the per-account cash & value series after prices are fresh
+        # (shares the guarded recompute_perf helper).
+        self.recompute_perf()
 
     @staticmethod
     def _midnight(day) -> datetime:
@@ -1040,8 +1236,10 @@ if __name__ == "__main__":
         dataSchema = yaml.safe_load(f)
     shares_validator = Validator(dataSchema)
 
-    # Get intervals from environment
-    scraping_interval = int(os.getenv('SB_SCRAPING_INTERVAL', default='120'))
+    # Get intervals from environment. SB_REGULAR_INTERVAL is the heir of the
+    # removed global SB_SCRAPING_INTERVAL (design #607); resolve_regular_interval
+    # applies the precedence + deprecation warning.
+    regular_interval = resolve_regular_interval()
     ingestion_interval = int(os.getenv('SB_INGESTION_INTERVAL', default='300'))
     backfill_interval = int(os.getenv('SB_BACKFILL_INTERVAL', default='60'))
 
@@ -1049,6 +1247,7 @@ if __name__ == "__main__":
     try:
         # Init SuiviBourseMetrics (connects to InfluxDB)
         sb_metrics = SuiviBourseMetrics(config_manager, shares_validator)
+        sb_metrics.regular_interval = regular_interval
         # Expose the legacy Prometheus /metrics endpoint if enabled (default on)
         if sb_metrics.prometheus is not None:
             metrics_port = int(os.getenv('SB_METRICS_PORT', default='8081'))
@@ -1057,17 +1256,16 @@ if __name__ == "__main__":
                 f"Prometheus metrics available on :{metrics_port}/metrics")
         # Start file watcher for hot-reload if in events mode
         config_manager.start_watcher(sb_metrics.ingest)
-        # Run initial ingestion and scrape on startup
-        sb_metrics.run()
-        # Start scheduler with three separate jobs
+        # Wire the scheduler before bootstrapping so ingest() can arm the
+        # per-symbol scrape jobs (issue #616). Their immediate first fire IS the
+        # bootstrap — no separate initial scrape.
         scheduler = BlockingScheduler()
-        # Scraping job: fetches prices from Yahoo Finance
-        scheduler.add_job(
-            sb_metrics.scrape, 'interval',
-            seconds=scraping_interval,
-            id='scrape',
-            name='Price scraping')
-        # Ingestion job: reloads events from files (with caching)
+        sb_metrics.scheduler = scheduler
+        # Bootstrap: load shares + arm one self-rescheduling scrape job per
+        # symbol (each fires immediately, then re-arms on its market cadence).
+        sb_metrics.ingest()
+        # Ingestion job: reloads events from files (with caching) and reconciles
+        # the per-symbol scrape jobs against the new symbol set.
         scheduler.add_job(
             sb_metrics.ingest, 'interval',
             seconds=ingestion_interval,
@@ -1079,9 +1277,17 @@ if __name__ == "__main__":
             seconds=backfill_interval,
             id='backfill',
             name='Historical backfill')
+        # Performance job: recomputes the account/portfolio perf series (opt-in
+        # accounts only) on the REGULAR cadence, decoupled from the per-symbol
+        # scrape jobs.
+        scheduler.add_job(
+            sb_metrics.recompute_perf, 'interval',
+            seconds=regular_interval,
+            id='perf',
+            name='Performance recompute')
         app_logger.info(
-            f"Scheduler started: scraping every {scraping_interval}s, "
-            f"ingestion every {ingestion_interval}s, "
+            f"Scheduler started: per-symbol scraping (REGULAR every "
+            f"{regular_interval}s), ingestion every {ingestion_interval}s, "
             f"backfill every {backfill_interval}s")
         scheduler.start()
     except ConfuseExceptions.NotFoundError as e:

--- a/app/src/scheduling.py
+++ b/app/src/scheduling.py
@@ -1,0 +1,145 @@
+"""
+Market-aware per-symbol scheduling — pure cadence & context decisions.
+
+Mirror of ``performance.py``: no InfluxDB, no yfinance, ``now`` injected. The
+two functions here drive the self-rescheduling per-symbol scrape jobs in
+``main.py`` without touching the outside world, so they are exhaustively
+testable against dicts and an injected clock (issue #616, design #602-#609).
+
+  * ``decide`` — one scrape cycle's write gate + next re-arm delay.
+  * ``extract_market_context`` — parse ``marketState`` + the next regular open
+    from the ticker ``info`` and ``history()`` metadata.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Tuple
+
+try:  # zoneinfo is stdlib on 3.9+; no new dependency (design #602/#603).
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+except ImportError:  # pragma: no cover - defensive, py<3.9 unsupported anyway
+    ZoneInfo = None
+    ZoneInfoNotFoundError = Exception
+
+# The closed-family ``marketState`` values (design #608). Only these quiet a
+# job; anything else — unknown, missing, or garbage — is coerced to ``REGULAR``
+# (fail-open) so an unparseable state never sleeps a symbol indefinitely.
+CLOSED_STATES = frozenset({'CLOSED', 'POST', 'POSTPOST', 'PRE', 'PREPRE'})
+
+# Hardcoded safety constants (design #607) — not operator dials.
+SHORT_RETRY = 60           # s: re-probe when woken but still not REGULAR
+MAX_SLEEP = 24 * 60 * 60   # s: hard cap on a single deep-sleep to next open
+
+# Approximate local open used only when the exact next-open is unavailable.
+# ``marketState`` remains the authority on wake, so an early guess is fine.
+_APPROX_OPEN_HOUR = 8
+
+
+def is_closed(state) -> bool:
+    """True only for a recognized closed-family state (fail-open coercion)."""
+    return state in CLOSED_STATES
+
+
+def decide(state, price_present: bool, next_open: Optional[datetime],
+           now: datetime, failure_count: int,
+           base_interval: int) -> Tuple[bool, float, int, bool]:
+    """Decide one scrape cycle's write gate and next re-arm delay.
+
+    Two-gate split (design #608): the **reschedule** gate keys on ``state``
+    alone, the **write** gate on ``not-closed AND price_present`` — so a
+    transient price failure keeps a job polling while only a recognized-closed
+    state quiets it.
+
+    Two-tier cadence (design #607): ``REGULAR`` re-arms in ``base_interval``;
+    every closed-family state sleeps to the exact ``next_open`` (capped at
+    ``MAX_SLEEP``, no lead-in margin), short-retrying at ``SHORT_RETRY`` when
+    ``next_open`` is unknown or already past (self-resolves holidays/half-days
+    forward once the job wakes and re-reads ``marketState``).
+
+    ``failure_count`` is threaded through unchanged here; consecutive-failure
+    backoff is deferred to the dead-ticker-guard slice.
+
+    Returns ``(should_write, next_delay, new_failure_count, mark_dirty)``.
+    """
+    closed = is_closed(state)
+
+    should_write = (not closed) and price_present
+    mark_dirty = should_write  # a REGULAR write makes the perf series stale
+
+    if not closed:
+        next_delay: float = base_interval
+    elif next_open is None:
+        next_delay = SHORT_RETRY
+    else:
+        delta = (next_open - now).total_seconds()
+        # No lead-in margin: target exactly next_open. A non-positive delta
+        # means we woke on/after the expected open but the state is still
+        # closed (holiday / half-day) — short-retry and re-read next time.
+        next_delay = min(delta, MAX_SLEEP) if delta > 0 else SHORT_RETRY
+
+    return should_write, next_delay, failure_count, mark_dirty
+
+
+def extract_market_context(info: Optional[dict], history_meta: Optional[dict],
+                           now: datetime) -> Tuple[Optional[str], Optional[datetime]]:
+    """Extract ``(marketState, next_open)`` from ticker data.
+
+    Prefers the exact next regular open from ``history()`` metadata
+    ``currentTradingPeriod.regular.start`` (design #603 amendment). Falls back
+    to ``exchangeTimezoneName`` + stdlib ``zoneinfo`` at ~08:00 local on the
+    next day (DST handled by ``zoneinfo``; an approximate open is fine — the
+    freshly-read ``marketState`` is the authority on wake). ``now`` is injected
+    and must be timezone-aware. Returns ``(state, next_open|None)``.
+    """
+    info = info or {}
+    state = info.get('marketState')
+
+    next_open = _exact_next_open(history_meta)
+    if next_open is None:
+        next_open = _approx_next_open(info, now)
+    return state, next_open
+
+
+def _exact_next_open(history_meta: Optional[dict]) -> Optional[datetime]:
+    """The exact regular-session open from ``history()`` metadata, or None.
+
+    Reads ``currentTradingPeriod.regular.start`` (a Unix timestamp) defensively
+    — any missing/garbage layer yields None so the caller falls back.
+    """
+    if not isinstance(history_meta, dict):
+        return None
+    ctp = history_meta.get('currentTradingPeriod')
+    if not isinstance(ctp, dict):
+        return None
+    regular = ctp.get('regular')
+    if not isinstance(regular, dict):
+        return None
+    start = regular.get('start')
+    if start is None:
+        return None
+    try:
+        return datetime.fromtimestamp(start, tz=timezone.utc)
+    except (OSError, ValueError, OverflowError, TypeError):
+        return None
+
+
+def _approx_next_open(info: dict, now: datetime) -> Optional[datetime]:
+    """~08:00 local on the next day in the exchange timezone, or None.
+
+    Used only when the exact next-open is unavailable. Returns a UTC datetime.
+    """
+    tz_name = info.get('exchangeTimezoneName')
+    if not tz_name or ZoneInfo is None:
+        return None
+    try:
+        tz = ZoneInfo(tz_name)
+    except (ZoneInfoNotFoundError, ValueError, KeyError):
+        return None
+
+    local_now = now.astimezone(tz)
+    candidate = local_now.replace(
+        hour=_APPROX_OPEN_HOUR, minute=0, second=0, microsecond=0)
+    # Always land strictly in the future; marketState resolves weekends/holidays
+    # forward one wake at a time.
+    if candidate <= local_now:
+        candidate = candidate + timedelta(days=1)
+    return candidate.astimezone(timezone.utc)

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -163,6 +163,15 @@ def fake_ticker():
     - ``start``: first date of the default DatetimeIndex (daily frequency).
     - ``info``: dict to merge over the default ``.info`` (override any key).
     - ``history_df``: supply a fully custom DataFrame, bypassing default generation.
+
+    Market-aware scheduling fields (issue #616) also ride on ``.info``
+    (``marketState``, ``exchangeTimezoneName``, ``regularMarketTime``) — pass
+    them via ``info=``. The ``history()`` metadata (``currentTradingPeriod``,
+    read by ``main`` as ``ticker.history_metadata``) is supplied separately:
+
+    - ``market_state``: convenience for ``info["marketState"]``.
+    - ``history_metadata``: dict exposed as ``ticker.history_metadata`` (defaults
+      to ``None`` so, absent an override, the exact next-open is unavailable).
     """
     def _build_df(close, rows, start):
         idx = pd.date_range(start=start, periods=rows, freq="D", tz=timezone.utc)
@@ -176,7 +185,8 @@ def fake_ticker():
         }
         return pd.DataFrame(data, index=idx)
 
-    def _make(close=185.0, rows=3, start="2024-01-02", info=None, history_df=None):
+    def _make(close=185.0, rows=3, start="2024-01-02", info=None, history_df=None,
+              market_state=None, history_metadata=None):
         df = history_df if history_df is not None else _build_df(close, rows, start)
         default_info = {
             "currency": "USD",
@@ -188,17 +198,20 @@ def fake_ticker():
             "marketCap": 3_000_000_000_000,
             "volume": 50_000_000,
         }
+        if market_state is not None:
+            default_info["marketState"] = market_state
         if info:
             default_info.update(info)
 
         class _FakeTicker:
-            def __init__(self, frame, info_dict):
+            def __init__(self, frame, info_dict, hist_meta):
                 self._frame = frame
                 self.info = info_dict
+                self.history_metadata = hist_meta
 
             def history(self, *args, **kwargs):
                 return self._frame
 
-        return _FakeTicker(df, default_info)
+        return _FakeTicker(df, default_info, history_metadata)
 
     return _make

--- a/app/tests/test_scheduling.py
+++ b/app/tests/test_scheduling.py
@@ -1,0 +1,225 @@
+"""
+Tests for the pure ``scheduling`` module (issue #616 / testing plan #614).
+
+Everything here is network-free and clock-free: ``decide`` and
+``extract_market_context`` take an injected ``now`` and plain dicts, so no mock
+clock or real market is required. ``zoneinfo`` is exercised for real (no new
+dependency) to prove DST handling.
+"""
+
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+import scheduling
+from scheduling import decide, extract_market_context, SHORT_RETRY, MAX_SLEEP
+
+
+UTC = timezone.utc
+NOW = datetime(2024, 1, 15, 12, 0, tzinfo=UTC)
+BASE = 120
+
+
+# ---------------------------------------------------------------------------
+# decide — write gate (two-gate split #608) + coercion
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("state", ["REGULAR", None, "", "GARBAGE", "regular", 42])
+def test_decide_non_closed_states_write_when_price_present(state):
+    """Anything outside the closed-family is coerced to REGULAR (fail-open)."""
+    should_write, next_delay, _fc, mark_dirty = decide(
+        state, True, None, NOW, 0, BASE)
+    assert should_write is True
+    assert mark_dirty is True
+    assert next_delay == BASE  # REGULAR-tier cadence
+
+
+@pytest.mark.parametrize("state", ["CLOSED", "POST", "POSTPOST", "PRE", "PREPRE"])
+def test_decide_closed_states_never_write(state):
+    """Only the five closed-family states quiet a job."""
+    next_open = NOW + timedelta(hours=2)
+    should_write, next_delay, _fc, mark_dirty = decide(
+        state, True, next_open, NOW, 0, BASE)
+    assert should_write is False
+    assert mark_dirty is False
+    assert next_delay == pytest.approx(2 * 3600)  # sleep to next open
+
+
+def test_decide_non_closed_without_price_does_not_write_but_keeps_polling():
+    """A transient price failure keeps polling at base_interval (write gate off,
+    reschedule gate still REGULAR)."""
+    should_write, next_delay, _fc, mark_dirty = decide(
+        "REGULAR", False, None, NOW, 0, BASE)
+    assert should_write is False
+    assert mark_dirty is False
+    assert next_delay == BASE
+
+
+# ---------------------------------------------------------------------------
+# decide — cadence tiers (#607)
+# ---------------------------------------------------------------------------
+
+def test_decide_closed_sleeps_to_exact_next_open_no_margin():
+    next_open = NOW + timedelta(seconds=3600)
+    _, next_delay, _, _ = decide("CLOSED", False, next_open, NOW, 0, BASE)
+    assert next_delay == 3600
+
+
+def test_decide_closed_caps_deep_sleep_at_max_sleep():
+    next_open = NOW + timedelta(hours=48)
+    _, next_delay, _, _ = decide("POST", False, next_open, NOW, 0, BASE)
+    assert next_delay == MAX_SLEEP
+
+
+def test_decide_closed_with_unknown_next_open_short_retries():
+    _, next_delay, _, _ = decide("CLOSED", False, None, NOW, 0, BASE)
+    assert next_delay == SHORT_RETRY
+
+
+def test_decide_closed_with_past_next_open_short_retries():
+    """Woken on/after the expected open but still closed (holiday/half-day)."""
+    next_open = NOW - timedelta(seconds=10)
+    _, next_delay, _, _ = decide("PRE", False, next_open, NOW, 0, BASE)
+    assert next_delay == SHORT_RETRY
+
+
+# ---------------------------------------------------------------------------
+# decide — failure_count passthrough (backoff deferred to a later slice)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("state,price", [
+    ("REGULAR", True), ("REGULAR", False), ("CLOSED", False), (None, True)])
+def test_decide_threads_failure_count_unchanged(state, price):
+    _, _, new_fc, _ = decide(state, price, None, NOW, 7, BASE)
+    assert new_fc == 7
+
+
+# ---------------------------------------------------------------------------
+# decide — looped sequences (re-inject the returned clock/counter)
+# ---------------------------------------------------------------------------
+
+def test_decide_sequence_pre_regular_post():
+    """PRE (sleep to open) -> REGULAR (poll+write) -> POST (sleep to next open)."""
+    open1 = NOW + timedelta(hours=1)
+    w, d, _, _ = decide("PRE", True, open1, NOW, 0, BASE)
+    assert (w, d) == (False, 3600)
+
+    # Woken at the open, now REGULAR.
+    at_open = open1
+    w, d, _, dirty = decide("REGULAR", True, None, at_open, 0, BASE)
+    assert (w, d, dirty) == (True, BASE, True)
+
+    # Market closes for the day.
+    next_open = at_open + timedelta(hours=20)
+    w, d, _, _ = decide("POST", True, next_open, at_open, 0, BASE)
+    assert (w, d) == (False, 20 * 3600)
+
+
+def test_decide_sequence_closed_then_short_retry_resolves_forward():
+    """A closed wake with a stale (past) next-open short-retries until REGULAR."""
+    stale_open = NOW - timedelta(minutes=5)
+    w, d, _, _ = decide("CLOSED", False, stale_open, NOW, 0, BASE)
+    assert (w, d) == (False, SHORT_RETRY)
+
+    # 60s later it flips to REGULAR.
+    later = NOW + timedelta(seconds=SHORT_RETRY)
+    w, d, _, _ = decide("REGULAR", True, None, later, 0, BASE)
+    assert (w, d) == (True, BASE)
+
+
+# ---------------------------------------------------------------------------
+# extract_market_context — state passthrough
+# ---------------------------------------------------------------------------
+
+def test_extract_returns_raw_market_state():
+    state, _ = extract_market_context({"marketState": "POST"}, None, NOW)
+    assert state == "POST"
+
+
+def test_extract_missing_state_is_none():
+    state, _ = extract_market_context({}, None, NOW)
+    assert state is None
+
+
+# ---------------------------------------------------------------------------
+# extract_market_context — exact next-open from history metadata (#603)
+# ---------------------------------------------------------------------------
+
+def test_extract_prefers_exact_next_open_from_history_meta():
+    ts = 1_700_000_000
+    meta = {"currentTradingPeriod": {"regular": {"start": ts, "end": ts + 23400}}}
+    # exchangeTimezoneName present too — exact must win over the ~08:00 guess.
+    info = {"marketState": "CLOSED", "exchangeTimezoneName": "America/New_York"}
+    _, next_open = extract_market_context(info, meta, NOW)
+    assert next_open == datetime.fromtimestamp(ts, tz=UTC)
+
+
+@pytest.mark.parametrize("meta", [
+    None,
+    {},
+    {"currentTradingPeriod": None},
+    {"currentTradingPeriod": {}},
+    {"currentTradingPeriod": {"regular": {}}},
+    {"currentTradingPeriod": {"regular": {"start": None}}},
+    {"currentTradingPeriod": "garbage"},
+])
+def test_extract_falls_back_when_history_meta_incomplete(meta):
+    info = {"exchangeTimezoneName": "America/New_York"}
+    _, next_open = extract_market_context(info, meta, NOW)
+    # Falls back to the ~08:00 local guess -> a real datetime, not the exact one.
+    assert next_open is not None
+    assert next_open.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# extract_market_context — zoneinfo ~08:00 fallback + DST (#603)
+# ---------------------------------------------------------------------------
+
+def test_extract_fallback_same_day_open():
+    # 06:00 UTC = 01:00 EST -> next open 08:00 EST today = 13:00 UTC.
+    now = datetime(2024, 1, 15, 6, 0, tzinfo=UTC)
+    _, next_open = extract_market_context(
+        {"exchangeTimezoneName": "America/New_York"}, None, now)
+    assert next_open == datetime(2024, 1, 15, 13, 0, tzinfo=UTC)
+
+
+def test_extract_fallback_rolls_to_next_day_when_past_open():
+    # 20:00 UTC = 15:00 EST, already past 08:00 -> next day 08:00 EST = 13:00 UTC.
+    now = datetime(2024, 1, 15, 20, 0, tzinfo=UTC)
+    _, next_open = extract_market_context(
+        {"exchangeTimezoneName": "America/New_York"}, None, now)
+    assert next_open == datetime(2024, 1, 16, 13, 0, tzinfo=UTC)
+
+
+def test_extract_fallback_handles_dst_offset_shift():
+    """Same 08:00 local wall-clock maps to a different UTC across DST."""
+    winter = datetime(2024, 1, 15, 6, 0, tzinfo=UTC)      # EST, UTC-5
+    summer = datetime(2024, 7, 15, 6, 0, tzinfo=UTC)      # EDT, UTC-4
+    tz = {"exchangeTimezoneName": "America/New_York"}
+    _, w_open = extract_market_context(tz, None, winter)
+    _, s_open = extract_market_context(tz, None, summer)
+    assert w_open == datetime(2024, 1, 15, 13, 0, tzinfo=UTC)  # 08:00-05:00
+    assert s_open == datetime(2024, 7, 15, 12, 0, tzinfo=UTC)  # 08:00-04:00
+
+
+def test_extract_no_next_open_without_meta_or_timezone():
+    _, next_open = extract_market_context({"marketState": "CLOSED"}, None, NOW)
+    assert next_open is None
+
+
+def test_extract_unknown_timezone_yields_no_next_open():
+    _, next_open = extract_market_context(
+        {"exchangeTimezoneName": "Mars/Olympus_Mons"}, None, NOW)
+    assert next_open is None
+
+
+def test_extract_none_info_is_safe():
+    state, next_open = extract_market_context(None, None, NOW)
+    assert state is None and next_open is None
+
+
+def test_is_closed_whitelist():
+    for s in ("CLOSED", "POST", "POSTPOST", "PRE", "PREPRE"):
+        assert scheduling.is_closed(s) is True
+    for s in ("REGULAR", None, "", "unknown"):
+        assert scheduling.is_closed(s) is False

--- a/app/tests/test_scheduling_wiring.py
+++ b/app/tests/test_scheduling_wiring.py
@@ -11,6 +11,7 @@ reschedule-gate split, and the Prometheus fetch-success gate (#609).
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
+from apscheduler.jobstores.base import JobLookupError
 from apscheduler.schedulers.background import BackgroundScheduler
 
 import main
@@ -221,6 +222,25 @@ def test_reconcile_leaves_unchanged_jobs_untouched(
 
     m.scheduler.add_job.assert_not_called()
     m.scheduler.remove_job.assert_not_called()
+
+
+def test_reconcile_one_remove_failure_does_not_abort_the_pass(
+        mock_influx, shares_validator, mocker):
+    """A JobLookupError from one vanished job (a self-re-armed date job that
+    just fired) must not skip the remaining removals or arms."""
+    m = _metrics([_share("AAPL"), _share("TSLA", "Tesla")],
+                 mock_influx, shares_validator, mocker)
+    m.scheduler.get_jobs.return_value = [
+        _job(_scrape_job_id("MSFT")), _job(_scrape_job_id("GOOG"))]
+    # First removal raises (job already gone); the second must still run.
+    m.scheduler.remove_job.side_effect = [JobLookupError("gone"), None]
+
+    m._reconcile_jobs()
+
+    armed = {c.kwargs["id"] for c in m.scheduler.add_job.call_args_list}
+    assert armed == {_scrape_job_id("AAPL"), _scrape_job_id("TSLA")}
+    removed = {c.args[0] for c in m.scheduler.remove_job.call_args_list}
+    assert removed == {_scrape_job_id("MSFT"), _scrape_job_id("GOOG")}
 
 
 def test_scrape_symbol_does_not_rearm_when_symbol_no_longer_held(

--- a/app/tests/test_scheduling_wiring.py
+++ b/app/tests/test_scheduling_wiring.py
@@ -1,0 +1,293 @@
+"""
+Tests for the per-symbol scheduler wiring in ``main`` (issue #616 / #614).
+
+The scheduler is a ``MagicMock(spec=BackgroundScheduler)`` spy — no real
+scheduler runs. yfinance and InfluxDB are mocked. These cover the runtime glue
+that the pure ``scheduling`` module can't: re-arm delay, ingest() reconciliation
+(add / remove / revive / untouched + the race guard), the write-gate vs
+reschedule-gate split, and the Prometheus fetch-success gate (#609).
+"""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+import main
+from main import SuiviBourseMetrics, _scrape_job_id, resolve_regular_interval
+
+
+UTC = timezone.utc
+NOW = datetime(2024, 1, 15, 15, 0, tzinfo=UTC)
+
+
+def _share(symbol="AAPL", name="Apple", account="default"):
+    return {
+        "name": name,
+        "symbol": symbol,
+        "account": account,
+        "purchase": {"quantity": 10, "fee": 2.5, "cost_price": 150.0},
+        "estate": {"quantity": 10, "received_dividend": 2.4},
+    }
+
+
+class _FakeConfigManager:
+    def __init__(self, shares):
+        self._shares = shares
+
+    def load_shares(self, force=False):
+        return self._shares
+
+    def get_mode(self):
+        return "manual"
+
+    def load_accounts(self):
+        return None
+
+    def get_events(self):
+        return None
+
+
+def _metrics(shares, mock_influx, shares_validator, mocker, prometheus=None):
+    cfg = _FakeConfigManager(shares)
+    m = SuiviBourseMetrics(cfg, shares_validator, influxdb_writer=mock_influx,
+                           prometheus_exporter=prometheus or mocker.MagicMock())
+    m.scheduler = mocker.MagicMock(spec=BackgroundScheduler)
+    m.regular_interval = 120
+    return m
+
+
+def _job(job_id):
+    return SimpleNamespace(id=job_id)
+
+
+# ---------------------------------------------------------------------------
+# _scrape_symbol — write gate vs reschedule gate
+# ---------------------------------------------------------------------------
+
+def test_scrape_symbol_regular_writes_and_rearms_at_base_interval(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch):
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    monkeypatch.setattr(main.yf, "Ticker", lambda s: fake_ticker(market_state="REGULAR"))
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    mock_influx.write_metrics.assert_called_once()
+    # Re-armed as a one-shot 'date' job, base_interval from now.
+    call = m.scheduler.add_job.call_args
+    assert call.args[1] == "date"            # trigger (positional)
+    assert call.kwargs["id"] == _scrape_job_id("AAPL")
+    assert call.kwargs["run_date"] == NOW + timedelta(seconds=120)
+    assert call.kwargs["args"] == ["AAPL"]
+
+
+def test_scrape_symbol_coerces_unknown_state_to_regular_and_writes(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch):
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    # Default fake_ticker has no marketState -> coerced REGULAR (fail-open).
+    monkeypatch.setattr(main.yf, "Ticker", lambda s: fake_ticker())
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    mock_influx.write_metrics.assert_called_once()
+    assert m.scheduler.add_job.call_args.kwargs["run_date"] == NOW + timedelta(seconds=120)
+
+
+def test_scrape_symbol_closed_skips_write_and_sleeps_to_next_open(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch):
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    next_open_ts = (NOW + timedelta(hours=2)).timestamp()
+    meta = {"currentTradingPeriod": {"regular": {"start": next_open_ts}}}
+    monkeypatch.setattr(
+        main.yf, "Ticker",
+        lambda s: fake_ticker(market_state="CLOSED", history_metadata=meta))
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    mock_influx.write_metrics.assert_not_called()
+    # Slept to the exact next open (no lead-in margin).
+    assert m.scheduler.add_job.call_args.kwargs["run_date"] == NOW + timedelta(hours=2)
+
+
+def test_scrape_symbol_price_failure_keeps_polling_without_writing(
+        mock_influx, shares_validator, mocker):
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    mocker.patch.object(m, "_fetch_ticker_data", return_value=(None, None))
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    mock_influx.write_metrics.assert_not_called()
+    # Reschedule gate still REGULAR (fail-open) -> keeps polling at base_interval.
+    assert m.scheduler.add_job.call_args.kwargs["run_date"] == NOW + timedelta(seconds=120)
+
+
+def test_scrape_symbol_writes_one_point_per_account_holding_symbol(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch):
+    shares = [_share(account="pea"), _share(account="cto")]
+    m = _metrics(shares, mock_influx, shares_validator, mocker)
+    monkeypatch.setattr(main.yf, "Ticker", lambda s: fake_ticker(market_state="REGULAR"))
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    assert mock_influx.write_metrics.call_count == 2
+    accounts = {c.kwargs["account"] for c in mock_influx.write_metrics.call_args_list}
+    assert accounts == {"pea", "cto"}
+    # One fetch feeds both account points.
+    m.scheduler.add_job.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Prometheus fetch-success gate (#609)
+# ---------------------------------------------------------------------------
+
+def test_prometheus_updates_on_closed_market_probe(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch):
+    prom = mocker.MagicMock()
+    m = _metrics([_share()], mock_influx, shares_validator, mocker, prometheus=prom)
+    monkeypatch.setattr(main.yf, "Ticker", lambda s: fake_ticker(market_state="CLOSED"))
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    # Closed -> no write, but the sb_share_* gauges still update (fetch success).
+    mock_influx.write_metrics.assert_not_called()
+    prom.update_share.assert_called_once()
+
+
+def test_prometheus_not_updated_when_fetch_fails(
+        mock_influx, shares_validator, mocker):
+    prom = mocker.MagicMock()
+    m = _metrics([_share()], mock_influx, shares_validator, mocker, prometheus=prom)
+    mocker.patch.object(m, "_fetch_ticker_data", return_value=(None, None))
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    prom.update_share.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _reconcile_jobs — add / remove / revive / untouched + race guard
+# ---------------------------------------------------------------------------
+
+def test_reconcile_adds_new_symbols_firing_immediately(
+        mock_influx, shares_validator, mocker):
+    m = _metrics([_share("AAPL"), _share("MSFT", "Microsoft")],
+                 mock_influx, shares_validator, mocker)
+    m.scheduler.get_jobs.return_value = [_job(_scrape_job_id("AAPL"))]
+
+    before = datetime.now(UTC)
+    m._reconcile_jobs()
+
+    added = {c.kwargs["id"] for c in m.scheduler.add_job.call_args_list}
+    assert added == {_scrape_job_id("MSFT")}          # AAPL untouched
+    m.scheduler.remove_job.assert_not_called()
+    # New symbol fires immediately (~now).
+    run_date = m.scheduler.add_job.call_args.kwargs["run_date"]
+    assert before <= run_date <= datetime.now(UTC) + timedelta(seconds=1)
+
+
+def test_reconcile_removes_departed_symbols(
+        mock_influx, shares_validator, mocker):
+    m = _metrics([_share("AAPL")], mock_influx, shares_validator, mocker)
+    m.scheduler.get_jobs.return_value = [
+        _job(_scrape_job_id("AAPL")), _job(_scrape_job_id("MSFT"))]
+
+    m._reconcile_jobs()
+
+    m.scheduler.add_job.assert_not_called()            # AAPL untouched
+    m.scheduler.remove_job.assert_called_once_with(_scrape_job_id("MSFT"))
+
+
+def test_reconcile_revives_missing_job(mock_influx, shares_validator, mocker):
+    # Held symbol whose job vanished (e.g. a misfire death) is re-armed. Foreign
+    # (non-scrape) jobs in the store are ignored by the prefix filter.
+    m = _metrics([_share("AAPL")], mock_influx, shares_validator, mocker)
+    m.scheduler.get_jobs.return_value = [_job("ingest"), _job("backfill")]
+
+    m._reconcile_jobs()
+
+    m.scheduler.add_job.assert_called_once()
+    assert m.scheduler.add_job.call_args.kwargs["id"] == _scrape_job_id("AAPL")
+    m.scheduler.remove_job.assert_not_called()
+
+
+def test_reconcile_leaves_unchanged_jobs_untouched(
+        mock_influx, shares_validator, mocker):
+    m = _metrics([_share("AAPL"), _share("MSFT", "Microsoft")],
+                 mock_influx, shares_validator, mocker)
+    m.scheduler.get_jobs.return_value = [
+        _job(_scrape_job_id("AAPL")), _job(_scrape_job_id("MSFT"))]
+
+    m._reconcile_jobs()
+
+    m.scheduler.add_job.assert_not_called()
+    m.scheduler.remove_job.assert_not_called()
+
+
+def test_scrape_symbol_does_not_rearm_when_symbol_no_longer_held(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch):
+    """In-flight half of the race guard: a job removed mid-cycle must not
+    re-add itself after reconcile's remove_job."""
+    m = _metrics([_share("AAPL")], mock_influx, shares_validator, mocker)
+    monkeypatch.setattr(main.yf, "Ticker", lambda s: fake_ticker(market_state="REGULAR"))
+    # Symbol departs between fetch and re-arm.
+    m.shares = []
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    m.scheduler.add_job.assert_not_called()
+
+
+def test_ingest_reconciles_against_scheduler(
+        mock_influx, shares_validator, mocker):
+    m = _metrics([_share("AAPL")], mock_influx, shares_validator, mocker)
+    m.scheduler.get_jobs.return_value = []  # nothing scheduled yet
+
+    m.ingest()
+
+    # First ingest arms the held symbol (bootstrap via immediate fire).
+    m.scheduler.add_job.assert_called_once()
+    assert m.scheduler.add_job.call_args.kwargs["id"] == _scrape_job_id("AAPL")
+
+
+def test_reconcile_noop_without_scheduler(mock_influx, shares_validator, mocker):
+    cfg = _FakeConfigManager([_share("AAPL")])
+    m = SuiviBourseMetrics(cfg, shares_validator, influxdb_writer=mock_influx,
+                           prometheus_exporter=mocker.MagicMock())
+    # scheduler is None -> reconcile is a safe no-op (unit tests that never wire
+    # a scheduler still exercise ingest()).
+    assert m.scheduler is None
+    m._reconcile_jobs()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# resolve_regular_interval — precedence + deprecation warning (#607)
+# ---------------------------------------------------------------------------
+
+def test_regular_interval_defaults_to_120(monkeypatch):
+    monkeypatch.delenv("SB_REGULAR_INTERVAL", raising=False)
+    monkeypatch.delenv("SB_SCRAPING_INTERVAL", raising=False)
+    assert resolve_regular_interval() == 120
+
+
+def test_regular_interval_prefers_new_var(monkeypatch, mocker):
+    monkeypatch.setenv("SB_REGULAR_INTERVAL", "60")
+    monkeypatch.setenv("SB_SCRAPING_INTERVAL", "300")
+    warn = mocker.patch.object(main.app_logger, "warning")
+    assert resolve_regular_interval() == 60          # new wins
+    warn.assert_called_once()                        # deprecated var flagged
+
+
+def test_regular_interval_falls_back_to_old_var_with_warning(monkeypatch, mocker):
+    monkeypatch.delenv("SB_REGULAR_INTERVAL", raising=False)
+    monkeypatch.setenv("SB_SCRAPING_INTERVAL", "90")
+    warn = mocker.patch.object(main.app_logger, "warning")
+    assert resolve_regular_interval() == 90          # honored as fallback
+    warn.assert_called_once()
+
+
+def test_regular_interval_no_warning_when_old_var_absent(monkeypatch, mocker):
+    monkeypatch.setenv("SB_REGULAR_INTERVAL", "45")
+    monkeypatch.delenv("SB_SCRAPING_INTERVAL", raising=False)
+    warn = mocker.patch.object(main.app_logger, "warning")
+    assert resolve_regular_interval() == 45
+    warn.assert_not_called()


### PR DESCRIPTION
## Résumé

Remplace le job de scrape global unique par **un job APScheduler auto-reprogrammé par symbole détenu**, piloté par le `marketState` de chaque position. Tranche cœur (tracer bullet) de l'épopée scraping market-aware (#602) : moins d'appels yfinance et d'écritures Parquet quand les marchés sont fermés (#597).

Closes #616.

## Ce qui change

**Nouveau module pur `app/src/scheduling.py`** (miroir de `performance.py` — pas d'InfluxDB/yfinance, `now` injecté) :
- `decide()` : split à deux portes (reschedule sur l'état seul ; write sur `not-closed ET prix présent`) + cadence à deux tiers (`REGULAR` → `base_interval` ; famille fermée → sommeil jusqu'à l'ouverture exacte, plafond 24 h, short-retry 60 s si inconnue/passée). Coercition fail-open : état inconnu/manquant/invalide → `REGULAR`. `failure_count` propagé inchangé (backoff reporté à une tranche ultérieure).
- `extract_market_context()` : ouverture exacte via `currentTradingPeriod.regular.start`, repli `exchangeTimezoneName` + `zoneinfo` ~08 h local (DST géré). **Aucune dépendance ajoutée.**

**Câblage `main.py`** :
- Un job par symbole ; fetch une fois, un point par compte détenteur, ré-armement avec `next_delay` (depuis une horloge fraîche pour qu'un fetch lent rate-limité ne place pas `run_date` dans le passé et ne casse pas la chaîne).
- `ingest()` réconcilie l'ensemble des symboles : ajout (tir immédiat), `remove_job` des partants, réanimation des manquants, timers inchangés laissés tels quels ; course auto-reprogrammation ↔ suppression gardée des deux côtés.
- Les gauges Prometheus `sb_share_*` restent sur la porte fetch-success, pas la porte d'écriture (#609) — un redémarrage marché fermé peuple toujours `/metrics`.
- Suppression du job scrape global et du `time.sleep(1)` inter-symboles ; le recalcul perf tourne comme son propre job sur la cadence `REGULAR`.
- `SB_REGULAR_INTERVAL` (défaut 120) avec précédence nouveau > `SB_SCRAPING_INTERVAL` (repli déprécié, warning dès qu'il est présent) > 120.

## Tests

`decide` cycle unique + séquences bouclées, `extract_market_context` par dicts (exact vs repli `zoneinfo`, DST) avec `zoneinfo` réel, câblage scheduler via espion `MagicMock(spec=BackgroundScheduler)`. `fake_ticker` étendu (`marketState` / `history_metadata`). **364 tests passent, flake8 clean.** Aucune dépendance ajoutée.

## Revue

Revue deux axes (Standards + Spec) passée : les 7 critères d'acceptation sont remplis. Corrections appliquées suite à la revue — bug de ré-armement (horloge périmée), doc Architecture obsolète dans `CLAUDE.md`, garde dupliquée dédupliquée.

## Hors périmètre (tranches ultérieures)

Gating dirty-flag du job perf (#605), jitter/pool d'exécuteurs/misfire (#611), backoff dead-ticker, et la page de doc dédiée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Scraping now adapts to each market’s trading status, polling during open hours and pausing until the next expected opening when markets are closed.
  - Portfolio changes automatically update the set of actively monitored symbols.
  - Performance metrics are recalculated independently on the regular schedule.

- **Configuration**
  - Added `SB_REGULAR_INTERVAL` for regular polling cadence.
  - Marked `SB_SCRAPING_INTERVAL` as deprecated, retaining it as a fallback.

- **Documentation**
  - Updated scheduling and environment variable documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->