### PR TITLE
feat(app): consecutive-failure backoff dead-ticker guard (#617)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,12 @@ The application runs independent scheduled jobs on a single APScheduler:
   (issue #616). Each job fetches its symbol from Yahoo Finance, writes a point
   per account holding it, then re-arms on its own cadence: `REGULAR` markets
   re-poll every `SB_REGULAR_INTERVAL` (default 120s); closed markets sleep to
-  the next open (capped 24h). There is no global scrape job.
+  the next open (capped 24h). A **dead-ticker guard** (issue #617) backs a
+  symbol off when non-closed cycles keep producing no writable price: the first
+  3 failures still re-arm at `base_interval`, then the delay grows
+  `base_interval × 2^(n−3)` capped at 24h, resetting to 0 on the first
+  successful write. Closed cycles never count as failures. There is no global
+  scrape job.
 - **Ingestion**: Reloads portfolio events from files (default: every 300s) and
   reconciles the per-symbol scrape jobs against the new symbol set (add / remove
   / revive).

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -433,9 +433,14 @@ class SuiviBourseMetrics:
         # `_failure_counts` holds the per-symbol consecutive-failure count fed to
         # scheduling.decide for the dead-ticker backoff (issue #617); it is
         # dropped in _reconcile_jobs when a symbol departs so state is per-job.
+        # Written by the scrape thread and popped by the ingest/reconcile thread
+        # (APScheduler's default ThreadPoolExecutor runs jobs concurrently), so
+        # guarded by `_failure_counts_lock`: without it, an in-flight scrape of a
+        # just-departed symbol could resurrect its counter after cleanup.
         self.scheduler: Optional[BlockingScheduler] = None
         self.regular_interval = 120
         self._failure_counts: Dict[str, int] = {}
+        self._failure_counts_lock = threading.Lock()
 
         # Cache for share info (to avoid repeated API calls during backfill)
         self._share_info_cache: Dict[str, Dict] = {}
@@ -738,8 +743,11 @@ class SuiviBourseMetrics:
             finally:
                 # Failure-backoff state is per-job (issue #617): drop it when the
                 # symbol departs so a later revival starts fresh at base_interval
-                # rather than inheriting a stale dead-ticker backoff.
-                self._failure_counts.pop(symbol, None)
+                # rather than inheriting a stale dead-ticker backoff. Under the
+                # shared lock so a concurrent in-flight scrape (which re-checks
+                # membership under the same lock) can't write the entry back.
+                with self._failure_counts_lock:
+                    self._failure_counts.pop(symbol, None)
 
     def _scrape_symbol(self, symbol: str, now: Optional[datetime] = None) -> None:
         """Scrape one symbol, gate the write, and re-arm the job (design #602).
@@ -771,10 +779,20 @@ class SuiviBourseMetrics:
             # transient failure keeps the job polling rather than sleeping it.
             state, next_open = None, None
 
-        should_write, next_delay, new_failure_count, _mark_dirty = scheduling.decide(
-            state, price_present, next_open, now,
-            self._failure_counts.get(symbol, 0), self.regular_interval)
-        self._failure_counts[symbol] = new_failure_count
+        with self._failure_counts_lock:
+            should_write, next_delay, new_failure_count, _mark_dirty = scheduling.decide(
+                state, price_present, next_open, now,
+                self._failure_counts.get(symbol, 0), self.regular_interval)
+            # Persist the backoff counter only while the symbol is still held. A
+            # concurrent ingest() reconcile may have removed it (and popped its
+            # entry) between this cycle's fetch and here; the held-recheck under
+            # the shared lock stops this write from resurrecting a departed
+            # symbol's counter after cleanup (issue #617 race). Both branches run
+            # under the lock so the reconcile pop can't interleave mid-decision.
+            if symbol in self._held_symbols():
+                self._failure_counts[symbol] = new_failure_count
+            else:
+                self._failure_counts.pop(symbol, None)
 
         if should_write:
             for share in holdings:

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -430,8 +430,9 @@ class SuiviBourseMetrics:
         # from __main__ (None until then, so unit tests that never wire it skip
         # reconciliation). `regular_interval` is the REGULAR-state poll cadence
         # (base_interval), overridden from the environment in __main__.
-        # `_failure_counts` is threaded through scheduling.decide per symbol
-        # (backoff growth itself is a later slice).
+        # `_failure_counts` holds the per-symbol consecutive-failure count fed to
+        # scheduling.decide for the dead-ticker backoff (issue #617); it is
+        # dropped in _reconcile_jobs when a symbol departs so state is per-job.
         self.scheduler: Optional[BlockingScheduler] = None
         self.regular_interval = 120
         self._failure_counts: Dict[str, int] = {}
@@ -734,6 +735,11 @@ class SuiviBourseMetrics:
                 self.scheduler.remove_job(_scrape_job_id(symbol))
             except Exception as e:
                 app_logger.debug(f"Job for {symbol} already gone, skipping: {e}")
+            finally:
+                # Failure-backoff state is per-job (issue #617): drop it when the
+                # symbol departs so a later revival starts fresh at base_interval
+                # rather than inheriting a stale dead-ticker backoff.
+                self._failure_counts.pop(symbol, None)
 
     def _scrape_symbol(self, symbol: str, now: Optional[datetime] = None) -> None:
         """Scrape one symbol, gate the write, and re-arm the job (design #602).

--- a/app/src/scheduling.py
+++ b/app/src/scheduling.py
@@ -29,6 +29,15 @@ CLOSED_STATES = frozenset({'CLOSED', 'POST', 'POSTPOST', 'PRE', 'PREPRE'})
 SHORT_RETRY = 60           # s: re-probe when woken but still not REGULAR
 MAX_SLEEP = 24 * 60 * 60   # s: hard cap on a single deep-sleep to next open
 
+# Dead-ticker guard (design #608, issue #617) — hardcoded, not operator dials.
+# A symbol whose non-closed fetches keep producing no writable price backs off
+# progressively instead of hammering yfinance every base_interval forever.
+FAILURE_GRACE = 3          # K: first K failures still re-arm at base_interval
+_BACKOFF_FACTOR = 2        # geometric growth per failure beyond the grace window
+# Cap the exponent so a ticker dead for years never builds an astronomical int
+# from FACTOR**n; MAX_SLEEP bounds the resulting delay anyway.
+_MAX_BACKOFF_EXP = 32
+
 # Approximate local open used only when the exact next-open is unavailable.
 # ``marketState`` remains the authority on wake, so an early guess is fine.
 _APPROX_OPEN_HOUR = 8
@@ -37,6 +46,21 @@ _APPROX_OPEN_HOUR = 8
 def is_closed(state) -> bool:
     """True only for a recognized closed-family state (fail-open coercion)."""
     return state in CLOSED_STATES
+
+
+def _backoff_delay(base_interval: int, failure_count: int) -> float:
+    """Re-arm delay for ``failure_count`` consecutive failures (design #608).
+
+    ``base_interval`` for the first ``FAILURE_GRACE`` failures, then geometric
+    ``base_interval × FACTOR^(n − FAILURE_GRACE)`` growth, capped at
+    ``MAX_SLEEP``. ``failure_count == 0`` (a fresh reset / success) yields
+    ``base_interval``.
+    """
+    excess = failure_count - FAILURE_GRACE
+    if excess <= 0:
+        return base_interval
+    exponent = min(excess, _MAX_BACKOFF_EXP)
+    return min(base_interval * (_BACKOFF_FACTOR ** exponent), MAX_SLEEP)
 
 
 def decide(state, price_present: bool, next_open: Optional[datetime],
@@ -55,8 +79,14 @@ def decide(state, price_present: bool, next_open: Optional[datetime],
     ``next_open`` is unknown or already past (self-resolves holidays/half-days
     forward once the job wakes and re-reads ``marketState``).
 
-    ``failure_count`` is threaded through unchanged here; consecutive-failure
-    backoff is deferred to the dead-ticker-guard slice.
+    Dead-ticker guard (design #608, issue #617): a **failure** is one
+    non-closed cycle with no writable price. A closed cycle is *never* a
+    failure (the market being shut is not a ticker fault) — the counter is
+    passed through untouched. ``new_failure_count`` increments on each failure
+    and resets to 0 on a successful write. While failing, the non-closed re-arm
+    grows from ``base_interval`` (first ``FAILURE_GRACE`` failures) to
+    ``base_interval × 2^(n − FAILURE_GRACE)`` capped at ``MAX_SLEEP``, so a dead
+    ticker stops hammering yfinance instead of polling every ``base_interval``.
 
     Returns ``(should_write, next_delay, new_failure_count, mark_dirty)``.
     """
@@ -65,18 +95,27 @@ def decide(state, price_present: bool, next_open: Optional[datetime],
     should_write = (not closed) and price_present
     mark_dirty = should_write  # a REGULAR write makes the perf series stale
 
-    if not closed:
-        next_delay: float = base_interval
-    elif next_open is None:
-        next_delay = SHORT_RETRY
+    if closed:
+        # Market shut: sleep to the next open, counter frozen (not a failure).
+        new_failure_count = failure_count
+        if next_open is None:
+            next_delay: float = SHORT_RETRY
+        else:
+            delta = (next_open - now).total_seconds()
+            # No lead-in margin: target exactly next_open. A non-positive delta
+            # means we woke on/after the expected open but the state is still
+            # closed (holiday / half-day) — short-retry and re-read next time.
+            next_delay = min(delta, MAX_SLEEP) if delta > 0 else SHORT_RETRY
+    elif should_write:
+        # Success: reset the failure counter and resume the base cadence.
+        new_failure_count = 0
+        next_delay = base_interval
     else:
-        delta = (next_open - now).total_seconds()
-        # No lead-in margin: target exactly next_open. A non-positive delta
-        # means we woke on/after the expected open but the state is still
-        # closed (holiday / half-day) — short-retry and re-read next time.
-        next_delay = min(delta, MAX_SLEEP) if delta > 0 else SHORT_RETRY
+        # Non-closed cycle with no writable price: a failure — back off.
+        new_failure_count = failure_count + 1
+        next_delay = _backoff_delay(base_interval, new_failure_count)
 
-    return should_write, next_delay, failure_count, mark_dirty
+    return should_write, next_delay, new_failure_count, mark_dirty
 
 
 def extract_market_context(info: Optional[dict], history_meta: Optional[dict],

--- a/app/tests/test_scheduling.py
+++ b/app/tests/test_scheduling.py
@@ -12,7 +12,8 @@ from datetime import datetime, timezone, timedelta
 import pytest
 
 import scheduling
-from scheduling import decide, extract_market_context, SHORT_RETRY, MAX_SLEEP
+from scheduling import (
+    decide, extract_market_context, SHORT_RETRY, MAX_SLEEP, FAILURE_GRACE)
 
 
 UTC = timezone.utc
@@ -84,14 +85,94 @@ def test_decide_closed_with_past_next_open_short_retries():
 
 
 # ---------------------------------------------------------------------------
-# decide — failure_count passthrough (backoff deferred to a later slice)
+# decide — dead-ticker guard: consecutive-failure backoff (#617, design #608)
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("state,price", [
-    ("REGULAR", True), ("REGULAR", False), ("CLOSED", False), (None, True)])
-def test_decide_threads_failure_count_unchanged(state, price):
-    _, _, new_fc, _ = decide(state, price, None, NOW, 7, BASE)
-    assert new_fc == 7
+def test_decide_write_resets_failure_count():
+    """A successful write clears the counter regardless of its prior value."""
+    _, next_delay, new_fc, _ = decide("REGULAR", True, None, NOW, 7, BASE)
+    assert new_fc == 0
+    assert next_delay == BASE            # reset -> back to base cadence
+
+
+def test_decide_non_closed_no_price_increments_failure_count():
+    """A non-closed cycle with no writable price is a failure."""
+    _, _, new_fc, _ = decide("REGULAR", False, None, NOW, 0, BASE)
+    assert new_fc == 1
+
+
+@pytest.mark.parametrize("state", ["CLOSED", "POST", "POSTPOST", "PRE", "PREPRE"])
+def test_decide_closed_cycle_never_counts_as_failure(state):
+    """A closed -> sleep-to-open cycle leaves the counter untouched (passthrough),
+    neither incrementing (market shut is not a ticker fault) nor resetting."""
+    _, _, new_fc, _ = decide(state, False, None, NOW, 5, BASE)
+    assert new_fc == 5
+
+
+def test_decide_grace_then_backoff_progression():
+    """K=3 failures at base_interval, then base×2^(n-K) capped at MAX_SLEEP.
+
+    Loops the non-closed no-price failure branch, re-injecting the returned
+    counter each cycle with a simple injected clock, and records the delay.
+    """
+    K = FAILURE_GRACE
+    assert K == 3
+    fc = 0
+    delays = []
+    for _ in range(15):
+        _, next_delay, fc, _ = decide("REGULAR", False, None, NOW, fc, BASE)
+        delays.append(next_delay)
+
+    # Failures 1..K all re-arm at base_interval (grace window).
+    assert delays[:K] == [BASE, BASE, BASE]
+    # From the K-th failure onward, geometric ×2 growth: base×2^(n-K).
+    assert delays[3] == BASE * 2       # n=4
+    assert delays[4] == BASE * 4       # n=5
+    assert delays[5] == BASE * 8       # n=6
+    # Every delay is capped at MAX_SLEEP and the tail is pinned there.
+    assert all(d <= MAX_SLEEP for d in delays)
+    assert delays[-1] == MAX_SLEEP
+
+
+def test_decide_success_mid_backoff_resets_to_base():
+    """A successful write in the middle of a backoff drops cadence back to base."""
+    fc = 0
+    for _ in range(6):                                  # build up a deep backoff
+        _, delay, fc, _ = decide("REGULAR", False, None, NOW, fc, BASE)
+    assert delay > BASE and fc == 6
+
+    # The market prints a price -> write, reset.
+    should_write, delay, fc, dirty = decide("REGULAR", True, None, NOW, fc, BASE)
+    assert (should_write, delay, fc, dirty) == (True, BASE, 0, True)
+
+
+def test_decide_closed_cycles_interleaved_do_not_advance_backoff():
+    """closed cycles between failures must not increment the counter, so the
+    backoff resumes exactly where the failures left it."""
+    fc = 0
+    # Two failures.
+    _, _, fc, _ = decide("REGULAR", False, None, NOW, fc, BASE)
+    _, _, fc, _ = decide("REGULAR", False, None, NOW, fc, BASE)
+    assert fc == 2
+
+    # A closed stretch: counter frozen, sleeps to next open (not backoff).
+    next_open = NOW + timedelta(hours=1)
+    _, closed_delay, fc, _ = decide("CLOSED", False, next_open, NOW, fc, BASE)
+    assert (fc, closed_delay) == (2, 3600)
+
+    # Failures resume: n=3 still grace, n=4 first backoff step.
+    _, delay3, fc, _ = decide("REGULAR", False, None, NOW, fc, BASE)
+    assert (fc, delay3) == (3, BASE)
+    _, delay4, fc, _ = decide("REGULAR", False, None, NOW, fc, BASE)
+    assert (fc, delay4) == (4, BASE * 2)
+
+
+def test_decide_backoff_never_overflows_for_a_long_dead_ticker():
+    """A ticker dead for a very long run stays pinned at MAX_SLEEP without
+    building an astronomical delay from 2^n."""
+    _, next_delay, new_fc, _ = decide("REGULAR", False, None, NOW, 100_000, BASE)
+    assert next_delay == MAX_SLEEP
+    assert new_fc == 100_001
 
 
 # ---------------------------------------------------------------------------

--- a/app/tests/test_scheduling_wiring.py
+++ b/app/tests/test_scheduling_wiring.py
@@ -138,6 +138,56 @@ def test_scrape_symbol_writes_one_point_per_account_holding_symbol(
 
 
 # ---------------------------------------------------------------------------
+# Dead-ticker backoff wiring (#617) — per-job failure state
+# ---------------------------------------------------------------------------
+
+def test_scrape_symbol_failure_increments_and_backs_off(
+        mock_influx, shares_validator, mocker):
+    """A run of non-closed no-price cycles grows the re-arm delay past base."""
+    m = _metrics([_share("AAPL")], mock_influx, shares_validator, mocker)
+    mocker.patch.object(m, "_fetch_ticker_data", return_value=(None, None))
+
+    # First three failures stay at base_interval (grace window).
+    for _ in range(3):
+        m._scrape_symbol("AAPL", now=NOW)
+    assert m._failure_counts["AAPL"] == 3
+    assert m.scheduler.add_job.call_args.kwargs["run_date"] == NOW + timedelta(seconds=120)
+
+    # Fourth failure backs off to base×2.
+    m._scrape_symbol("AAPL", now=NOW)
+    assert m._failure_counts["AAPL"] == 4
+    assert m.scheduler.add_job.call_args.kwargs["run_date"] == NOW + timedelta(seconds=240)
+
+
+def test_scrape_symbol_success_resets_failure_count(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch):
+    """A successful write clears an accumulated backoff back to base_interval."""
+    m = _metrics([_share("AAPL")], mock_influx, shares_validator, mocker)
+    m._failure_counts["AAPL"] = 5
+    monkeypatch.setattr(main.yf, "Ticker", lambda s: fake_ticker(market_state="REGULAR"))
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    assert m._failure_counts["AAPL"] == 0
+    assert m.scheduler.add_job.call_args.kwargs["run_date"] == NOW + timedelta(seconds=120)
+
+
+def test_reconcile_removes_departed_symbol_failure_state(
+        mock_influx, shares_validator, mocker):
+    """Failure state must not survive symbol removal (per-job lifetime)."""
+    m = _metrics([_share("AAPL")], mock_influx, shares_validator, mocker)
+    m._failure_counts = {"AAPL": 1, "MSFT": 9}
+    m.scheduler.get_jobs.return_value = [
+        _job(_scrape_job_id("AAPL")), _job(_scrape_job_id("MSFT"))]
+
+    m._reconcile_jobs()  # MSFT departed (only AAPL held)
+
+    m.scheduler.remove_job.assert_called_once_with(_scrape_job_id("MSFT"))
+    assert "MSFT" not in m._failure_counts
+    assert m._failure_counts == {"AAPL": 1}
+
+
+# ---------------------------------------------------------------------------
 # Prometheus fetch-success gate (#609)
 # ---------------------------------------------------------------------------
 

--- a/app/tests/test_scheduling_wiring.py
+++ b/app/tests/test_scheduling_wiring.py
@@ -8,6 +8,7 @@ that the pure ``scheduling`` module can't: re-arm delay, ingest() reconciliation
 reschedule-gate split, and the Prometheus fetch-success gate (#609).
 """
 
+import threading
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
@@ -185,6 +186,61 @@ def test_reconcile_removes_departed_symbol_failure_state(
     m.scheduler.remove_job.assert_called_once_with(_scrape_job_id("MSFT"))
     assert "MSFT" not in m._failure_counts
     assert m._failure_counts == {"AAPL": 1}
+
+
+def test_scrape_symbol_departed_does_not_persist_failure_count(
+        mock_influx, shares_validator, mocker):
+    """A scrape whose symbol has already departed must not (re)write its
+    backoff counter — the held-recheck guards the persist (issue #617)."""
+    m = _metrics([_share("AAPL")], mock_influx, shares_validator, mocker)
+    m._failure_counts["AAPL"] = 3
+    mocker.patch.object(m, "_fetch_ticker_data", return_value=(None, None))
+    m.shares = []  # departed between the last reconcile and this cycle
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    assert "AAPL" not in m._failure_counts     # not resurrected
+    m.scheduler.add_job.assert_not_called()    # and not re-armed
+
+
+def test_inflight_scrape_racing_with_cleanup_does_not_resurrect_counter(
+        mock_influx, shares_validator, mocker):
+    """The named race: a scrape in-flight when reconcile removes its symbol
+    must not write the failure counter back after cleanup popped it.
+
+    The fetch blocks the scrape thread *before* its lock-guarded persist, so the
+    reconcile pop is forced to win the shared lock first; when the scrape then
+    resumes it sees the symbol no longer held and skips the write. Without the
+    lock + held-recheck this would leave a stale 'AAPL' entry (resurrection)."""
+    m = _metrics([_share("AAPL")], mock_influx, shares_validator, mocker)
+    m._failure_counts["AAPL"] = 2  # a backoff already building
+
+    fetch_started = threading.Event()
+    release_fetch = threading.Event()
+
+    def blocking_fetch(symbol):
+        fetch_started.set()
+        assert release_fetch.wait(timeout=5)
+        return (None, None)  # failure -> decide would increment + persist
+
+    mocker.patch.object(m, "_fetch_ticker_data", side_effect=blocking_fetch)
+
+    scrape_thread = threading.Thread(target=m._scrape_symbol, args=("AAPL",))
+    scrape_thread.start()
+    assert fetch_started.wait(timeout=5)  # scrape is in-flight, pre-persist
+
+    # Symbol departs: ingest updates shares, reconcile removes the job + pops.
+    m.shares = []
+    m.scheduler.get_jobs.return_value = [_job(_scrape_job_id("AAPL"))]
+    m._reconcile_jobs()
+    assert "AAPL" not in m._failure_counts  # cleanup popped it
+
+    # Let the in-flight scrape finish; it must NOT restore the counter.
+    release_fetch.set()
+    scrape_thread.join(timeout=5)
+    assert not scrape_thread.is_alive()
+    assert "AAPL" not in m._failure_counts
+    m.scheduler.add_job.assert_not_called()  # also does not re-arm
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Résumé

Implémente le **dead-ticker guard** (issue #617, design #608/#602) : un symbole dont les cycles non-closed continuent de ne produire aucun prix écrivable applique désormais un backoff progressif au lieu de solliciter yfinance tous les `base_interval` indéfiniment.

## Ce qui change

- **`scheduling.decide()`** (fonction pure) porte toute la logique :
  - Un **échec** = un cycle non-closed sans prix écrivable. Un cycle `closed → sleep-to-open` ne compte **jamais** comme un échec (compteur gelé).
  - **Grâce** : les `K=3` premiers échecs se re-arment à `base_interval`.
  - **Backoff** : à partir du K-ième, le délai croît `base_interval × 2^(n−K)`, plafonné à `MAX_SLEEP` (24h).
  - **Reset** : le compteur repasse à 0 à la première écriture réussie.
- **`main._reconcile_jobs`** supprime `_failure_counts[symbol]` au retrait d'un symbole → état **par-job**, pas d'accumulation entre symboles.
- `K`, le facteur de croissance et le plafond sont des **constantes en dur** (aucune nouvelle variable d'environnement).

## Tests

Séquences bouclées ré-injectant `new_failure_count` avec une horloge injectée : progression `K=3 → ×2 → plafond 24h → reset`, cycles closed intercalés qui n'incrémentent pas, et écriture réussie en plein backoff qui réinitialise ; plus le câblage (incrément/reset + nettoyage par-job).

- ✅ 375 tests passent, `flake8` clean, aucune nouvelle dépendance.

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Added adaptive scheduling for symbols that repeatedly produce no new price, progressively extending retry intervals up to 24 hours.
  - Successful price updates restore the normal scheduling cadence.
  - Closed-market periods no longer increase failure counts or backoff delays.
  - Failure state is cleared when a symbol leaves scheduling, ensuring normal scheduling when it returns.

- **Documentation**
  - Updated scheduling architecture documentation to describe the dead-ticker guard and per-symbol behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->