### PR TITLE
feat(app): perf recompute as its own gated interval job (#618)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,16 @@ The application runs independent scheduled jobs on a single APScheduler:
   / revive).
 - **Backfill**: Progressively fills historical price data (default: every 60s).
 - **Performance**: Recomputes the `account_metrics` / `portfolio_totals` series
-  (opt-in accounts only) on the `REGULAR` cadence, decoupled from scraping.
+  (opt-in accounts only) as its **own gated interval job** at `SB_PERF_INTERVAL`
+  (default 120s), decoupled from the per-symbol scrape jobs (issue #618). Each
+  run is gated by the pure predicate `scheduling.perf_should_run()` — it runs
+  only when something changed since the last run: the events cache reloaded, a
+  backfill watermark is pending, or a `REGULAR` write occurred. The live-write
+  signal is a single global bool set on the `REGULAR` write path in
+  `_scrape_symbol`, checked-and-cleared up front under `_perf_lock` and seeded
+  `True` at boot (so today's point is fresh after an overnight restart). A
+  fully-closed market wave writes nothing — the non-trading-day gap is by design
+  (#606) and there is no closed-day Parquet drip (#597).
 
 Writes to InfluxDB measurement `portfolio_metrics` with fields: `share_price`, `purchased_quantity`, `purchased_price`, `purchased_fee`, `owned_quantity`, `received_dividend`, `dividend_yield`, `pe_ratio`, `market_cap`
 
@@ -79,12 +88,12 @@ Writes to InfluxDB measurement `portfolio_metrics` with fields: `share_price`, `
 ```text
 ┌──────────────────────────┐  ┌───────────────────┐  ┌──────────────────┐  ┌────────────────────┐
 │  SCRAPE  (per symbol,    │  │    INGESTION      │  │    BACKFILL      │  │   PERFORMANCE      │
-│  self-rescheduling)      │  │   (every 300s)    │  │   (every 60s)    │  │ (REGULAR cadence)  │
+│  self-rescheduling)      │  │   (every 300s)    │  │   (every 60s)    │  │ (SB_PERF_INTERVAL) │
 │                          │  │                   │  │                  │  │                    │
-│ • yfinance.Ticker()      │  │ • Load events CSV │  │ • Check gaps     │  │ • Recompute perf   │
-│ • marketState → cadence  │  │ • Recalc state    │  │ • history()      │  │   series (opt-in   │
-│ • REGULAR: poll & write  │  │ • Update shares[] │  │ • Chunk 1 yr/req │  │   accounts only)   │
-│ • Closed: sleep to open  │  │ • Reconcile jobs  │  │ • Rate limit 10s │  │                    │
+│ • yfinance.Ticker()      │  │ • Load events CSV │  │ • Check gaps     │  │ • perf_should_run? │
+│ • marketState → cadence  │  │ • Recalc state    │  │ • history()      │  │ • Recompute perf   │
+│ • REGULAR: poll & write  │  │ • Update shares[] │  │ • Chunk 1 yr/req │  │   series (opt-in   │
+│ • Closed: sleep to open  │  │ • Reconcile jobs  │  │ • Rate limit 10s │  │   accounts only)   │
 └──────────────────────────┘  └───────────────────┘  └──────────────────┘  └────────────────────┘
          │                            │                       │                       │
          └────────────────────────────┴───────────┬───────────┴───────────────────────┘
@@ -240,6 +249,7 @@ If ingestion fails (invalid event, file error), the **previous valid configurati
 | `INFLUXDB_DATABASE` | `suivi_bourse` | InfluxDB database name |
 | `SB_REGULAR_INTERVAL` | `120` | Poll interval (seconds) for a symbol whose market is in `REGULAR` state (per-symbol scheduling). Closed markets sleep to next open instead. |
 | `SB_SCRAPING_INTERVAL` | — | **Deprecated** heir of the removed global scrape interval. Honored as a fallback for `SB_REGULAR_INTERVAL` when the latter is unset; logs a warning whenever present. |
+| `SB_PERF_INTERVAL` | `120` | Perf-recompute interval (seconds) for the gated `account_metrics`/`portfolio_totals` job (issue #618) |
 | `SB_INGESTION_INTERVAL` | `300` | Event ingestion interval (seconds) |
 | `SB_BACKFILL_INTERVAL` | `60` | Backfill check interval (seconds) |
 | `SB_BACKFILL_DELAY` | `10` | Delay between yfinance requests (seconds) |

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -94,6 +94,33 @@ def resolve_regular_interval() -> int:
     return 120
 
 
+def register_interval_jobs(scheduler, sb_metrics, ingestion_interval: int,
+                           backfill_interval: int, perf_interval: int) -> None:
+    """Register the three fixed-cadence interval jobs on ``scheduler``.
+
+    Kept separate from the per-symbol scrape jobs (issue #616), which are ``date``
+    triggers armed by ``ingest``/``_reconcile_jobs`` under the ``scrape:`` id
+    prefix. The perf recompute is its own job at ``SB_PERF_INTERVAL`` (issue
+    #618), never piggybacked on the scrape. Extracted from ``__main__`` so the
+    wiring is unit-testable against a spy scheduler.
+    """
+    scheduler.add_job(
+        sb_metrics.ingest, 'interval',
+        seconds=ingestion_interval,
+        id='ingest',
+        name='Event ingestion')
+    scheduler.add_job(
+        sb_metrics.backfill, 'interval',
+        seconds=backfill_interval,
+        id='backfill',
+        name='Historical backfill')
+    scheduler.add_job(
+        sb_metrics.recompute_perf, 'interval',
+        seconds=perf_interval,
+        id='perf',
+        name='Performance recompute')
+
+
 class InvalidConfigFile(Exception):
     def __init__(self, errors_):
         self.errors = errors_
@@ -460,11 +487,18 @@ class SuiviBourseMetrics:
         #     _perf_lock.
         #   _perf_last_events — the events list object fed to the last write; a
         #     new object means the events cache was reloaded (files changed) and
-        #     the whole series must be rewritten. Touched only on the scrape
-        #     thread (update_account_metrics), so it needs no lock.
+        #     the whole series must be rewritten. Touched only on the perf-job
+        #     thread (recompute_perf/update_account_metrics), so it needs no lock.
+        #   _perf_dirty_live — a single global bool set on the REGULAR write path
+        #     in _scrape_symbol (issue #618): the live-write trigger for the
+        #     gated perf job, alongside the two above. Written by the scrape
+        #     threads and checked-and-cleared by the perf-job thread, so guarded
+        #     by _perf_lock. Seeded True at boot so today's point is always fresh
+        #     after a weekend/overnight restart.
         self._perf_lock = threading.Lock()
         self._perf_dirty_from: Optional[date] = None
         self._perf_last_events: Optional[List] = None
+        self._perf_dirty_live: bool = True
 
     def validate(self) -> bool:
         """
@@ -780,7 +814,7 @@ class SuiviBourseMetrics:
             state, next_open = None, None
 
         with self._failure_counts_lock:
-            should_write, next_delay, new_failure_count, _mark_dirty = scheduling.decide(
+            should_write, next_delay, new_failure_count, mark_dirty = scheduling.decide(
                 state, price_present, next_open, now,
                 self._failure_counts.get(symbol, 0), self.regular_interval)
             # Persist the backoff counter only while the symbol is still held. A
@@ -797,6 +831,13 @@ class SuiviBourseMetrics:
         if should_write:
             for share in holdings:
                 self._write_share_metrics(share, last_quote, info)
+            # A REGULAR write makes today's perf series stale: raise the global
+            # live-write dirty bool so the gated perf job (issue #618) runs its
+            # next cycle. One flag for the whole market-open wave — it coalesces
+            # N symbols' writes into a single recompute by construction.
+            if mark_dirty:
+                with self._perf_lock:
+                    self._perf_dirty_live = True
         else:
             app_logger.debug(
                 f"Skipping write for {symbol} (state={state}, "
@@ -815,17 +856,47 @@ class SuiviBourseMetrics:
             self._arm_symbol(symbol, next_delay, arm_now)
 
     def recompute_perf(self) -> None:
-        """Recompute the perf series on its own interval (design #605 seam).
+        """Recompute the perf series as its own gated interval job (#605, #618).
 
         Now that per-symbol jobs replaced the global scrape loop, the
         account_metrics/portfolio_totals recompute runs as its own scheduled
-        job. Guarded so an error never kills the scheduler thread. (Dirty-flag
-        gating of this job is a later slice; the write itself is already
-        incremental, so cadence-driven recomputes stay cheap.)
+        job at ``SB_PERF_INTERVAL`` — never inside the scrape, which would fire N
+        recomputes per market-open wave.
+
+        Read the three dirty signals up front and gate on
+        ``scheduling.perf_should_run`` so a fully-closed market wave writes
+        nothing (no closed-day Parquet drip, #597/#606):
+          * the live-write bool ``_perf_dirty_live`` — set on the REGULAR write
+            path in ``_scrape_symbol``; **checked-and-cleared here** under
+            ``_perf_lock`` (seeded True at boot so today's point is fresh after
+            an overnight restart).
+          * the backfill watermark ``_perf_dirty_from`` — merely *checked* here;
+            its consume/clear stays in ``update_account_metrics``.
+          * ``events_changed`` — a reloaded events cache (a new list object).
+
+        Guarded so an error never kills the scheduler thread.
         """
+        with self._perf_lock:
+            live_write = self._perf_dirty_live
+            self._perf_dirty_live = False
+            backfill_pending = self._perf_dirty_from is not None
+        events = self.config_manager.get_events()
+        events_changed = events is not self._perf_last_events
+        if not scheduling.perf_should_run(events_changed, backfill_pending, live_write):
+            app_logger.debug(
+                "Perf recompute skipped: nothing changed since last run")
+            return
         try:
             self.update_account_metrics()
         except Exception as e:
+            # The live-write signal was consumed up front (for concurrency), so a
+            # failed write would otherwise drop today's fresh point until the next
+            # REGULAR scrape re-sets the flag. Re-arm it on error so the next
+            # cycle retries, mirroring the _perf_dirty_from re-arm inside
+            # update_account_metrics.
+            if live_write:
+                with self._perf_lock:
+                    self._perf_dirty_live = True
             app_logger.error(f"Failed to update account metrics: {e}")
 
     def ingest(self):
@@ -1045,15 +1116,14 @@ class SuiviBourseMetrics:
 
         Synchronous whole-portfolio path kept for the manual/backward-compat and
         e2e harness; the scheduled runtime drives per-symbol jobs + the perf job.
+        The perf recompute is **detached** from scrape (issue #618): it is its
+        own gated interval job, never piggybacked here.
         """
         if not self.shares:
             app_logger.warning("No shares configured, skipping scrape")
             return
 
         self.expose_metrics()
-        # Recompute the per-account cash & value series after prices are fresh
-        # (shares the guarded recompute_perf helper).
-        self.recompute_perf()
 
     @staticmethod
     def _midnight(day) -> datetime:
@@ -1275,6 +1345,7 @@ if __name__ == "__main__":
     regular_interval = resolve_regular_interval()
     ingestion_interval = int(os.getenv('SB_INGESTION_INTERVAL', default='300'))
     backfill_interval = int(os.getenv('SB_BACKFILL_INTERVAL', default='60'))
+    perf_interval = int(os.getenv('SB_PERF_INTERVAL', default='120'))
 
     sb_metrics = None
     try:
@@ -1297,31 +1368,16 @@ if __name__ == "__main__":
         # Bootstrap: load shares + arm one self-rescheduling scrape job per
         # symbol (each fires immediately, then re-arms on its market cadence).
         sb_metrics.ingest()
-        # Ingestion job: reloads events from files (with caching) and reconciles
-        # the per-symbol scrape jobs against the new symbol set.
-        scheduler.add_job(
-            sb_metrics.ingest, 'interval',
-            seconds=ingestion_interval,
-            id='ingest',
-            name='Event ingestion')
-        # Backfill job: progressively fills historical data
-        scheduler.add_job(
-            sb_metrics.backfill, 'interval',
-            seconds=backfill_interval,
-            id='backfill',
-            name='Historical backfill')
-        # Performance job: recomputes the account/portfolio perf series (opt-in
-        # accounts only) on the REGULAR cadence, decoupled from the per-symbol
-        # scrape jobs.
-        scheduler.add_job(
-            sb_metrics.recompute_perf, 'interval',
-            seconds=regular_interval,
-            id='perf',
-            name='Performance recompute')
+        # Register the three fixed-cadence interval jobs (ingestion, backfill,
+        # perf recompute). Per-symbol scrape jobs are armed by ingest() above and
+        # kept separate; the perf recompute is its own gated job (issue #618).
+        register_interval_jobs(
+            scheduler, sb_metrics, ingestion_interval, backfill_interval,
+            perf_interval)
         app_logger.info(
             f"Scheduler started: per-symbol scraping (REGULAR every "
             f"{regular_interval}s), ingestion every {ingestion_interval}s, "
-            f"backfill every {backfill_interval}s")
+            f"backfill every {backfill_interval}s, perf every {perf_interval}s")
         scheduler.start()
     except ConfuseExceptions.NotFoundError as e:
         app_logger.fatal(

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -659,13 +659,16 @@ class SuiviBourseMetrics:
             app_logger.error(
                 f"Failed to update Prometheus metrics for {share['symbol']}: {e}")
 
-    def _write_share_metrics(self, share, last_quote, info) -> None:
+    def _write_share_metrics(self, share, last_quote, info) -> bool:
         """Write one share's live metrics point to InfluxDB.
 
         Guarded so a transient InfluxDB error on one share does not abort the
         surrounding cycle. Callers only invoke this once the fetch succeeded, so
         currency/exchange/quote_type tags are always present and the point lands
-        in the same enriched series as its history.
+        in the same enriched series as its history. Returns whether the point
+        was actually persisted, so callers can tell a real write from a
+        swallowed failure (issue #618 — an all-failed wave must not raise the
+        perf dirty flag).
         """
         try:
             self.influxdb.write_metrics(
@@ -686,9 +689,11 @@ class SuiviBourseMetrics:
                 market_cap=info['marketCap'],
                 volume=info['volume']
             )
+            return True
         except Exception as e:
             app_logger.error(
                 f"Failed to write metrics for {share['symbol']}: {e}")
+            return False
 
     def expose_metrics(self):
         """
@@ -829,13 +834,17 @@ class SuiviBourseMetrics:
                 self._failure_counts.pop(symbol, None)
 
         if should_write:
+            wrote_live_data = False
             for share in holdings:
-                self._write_share_metrics(share, last_quote, info)
+                wrote = self._write_share_metrics(share, last_quote, info)
+                wrote_live_data = wrote_live_data or wrote
             # A REGULAR write makes today's perf series stale: raise the global
             # live-write dirty bool so the gated perf job (issue #618) runs its
             # next cycle. One flag for the whole market-open wave — it coalesces
-            # N symbols' writes into a single recompute by construction.
-            if mark_dirty:
+            # N symbols' writes into a single recompute by construction. Only
+            # when a point actually persisted — an all-failed Influx outage
+            # must not trigger a perf recompute with nothing new to read.
+            if mark_dirty and wrote_live_data:
                 with self._perf_lock:
                     self._perf_dirty_live = True
         else:

--- a/app/src/scheduling.py
+++ b/app/src/scheduling.py
@@ -118,6 +118,30 @@ def decide(state, price_present: bool, next_open: Optional[datetime],
     return should_write, next_delay, new_failure_count, mark_dirty
 
 
+def perf_should_run(events_changed: bool, backfill_pending: bool,
+                    live_write: bool) -> bool:
+    """Gate one run of the perf-recompute interval job (design #605, issue #618).
+
+    Now that ``update_account_metrics`` is its own interval job (it can no longer
+    piggyback on the per-symbol scrape without firing N recomputes per market-open
+    wave), it must stay as quiet as prices do overnight. Run **only when something
+    changed** since the last recompute; skip ⟺ events unchanged **and** no
+    backfill watermark **and** no live ``REGULAR`` write since the last run:
+
+      * ``events_changed`` — the events cache reloaded (a new list object): the
+        whole series is rewritten.
+      * ``backfill_pending`` — a backfill watermark (``_perf_dirty_from``) is set:
+        earlier prices were filled, so the stale tail must be rewritten.
+      * ``live_write`` — a ``REGULAR`` write landed since the last run (the
+        boot-seeded live-write bool): today's close is fresh.
+
+    All-quiet skips, so a fully-closed market wave writes no ``account_metrics`` /
+    ``portfolio_totals`` point — the non-trading-day gap is by design (#606) and
+    there is no closed-day Parquet drip (#597).
+    """
+    return events_changed or backfill_pending or live_write
+
+
 def extract_market_context(info: Optional[dict], history_meta: Optional[dict],
                            now: datetime) -> Tuple[Optional[str], Optional[datetime]]:
     """Extract ``(marketState, next_open)`` from ticker data.

--- a/app/tests/test_scheduling.py
+++ b/app/tests/test_scheduling.py
@@ -13,7 +13,8 @@ import pytest
 
 import scheduling
 from scheduling import (
-    decide, extract_market_context, SHORT_RETRY, MAX_SLEEP, FAILURE_GRACE)
+    decide, extract_market_context, perf_should_run,
+    SHORT_RETRY, MAX_SLEEP, FAILURE_GRACE)
 
 
 UTC = timezone.utc
@@ -206,6 +207,27 @@ def test_decide_sequence_closed_then_short_retry_resolves_forward():
     later = NOW + timedelta(seconds=SHORT_RETRY)
     w, d, _, _ = decide("REGULAR", True, None, later, 0, BASE)
     assert (w, d) == (True, BASE)
+
+
+# ---------------------------------------------------------------------------
+# perf_should_run — gate the perf-recompute interval job (#618, design #605)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("events_changed,backfill_pending,live_write,expected", [
+    # All quiet -> skip (a fully-closed market wave, no closed-day Parquet drip).
+    (False, False, False, False),
+    # Any single dirty signal -> run.
+    (True, False, False, True),     # events cache reloaded (full rewrite)
+    (False, True, False, True),     # backfill watermark pending
+    (False, False, True, True),     # live REGULAR write since last run (boot seed)
+    # Combinations still run.
+    (True, True, False, True),
+    (True, False, True, True),
+    (False, True, True, True),
+    (True, True, True, True),
+])
+def test_perf_should_run_truth_table(events_changed, backfill_pending, live_write, expected):
+    assert perf_should_run(events_changed, backfill_pending, live_write) is expected
 
 
 # ---------------------------------------------------------------------------

--- a/app/tests/test_scheduling_wiring.py
+++ b/app/tests/test_scheduling_wiring.py
@@ -288,6 +288,21 @@ def test_scrape_symbol_price_failure_does_not_set_perf_dirty_live(
     assert m._perf_dirty_live is False
 
 
+def test_scrape_symbol_failed_influx_write_does_not_set_perf_dirty_live(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch):
+    """write_metrics raising (Influx outage) must not raise the dirty flag —
+    no point persisted, so there is nothing new for perf to read (#618)."""
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    m._perf_dirty_live = False
+    mock_influx.write_metrics.side_effect = Exception("influx unreachable")
+    monkeypatch.setattr(main.yf, "Ticker", lambda s: fake_ticker(market_state="REGULAR"))
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    mock_influx.write_metrics.assert_called_once()
+    assert m._perf_dirty_live is False
+
+
 def test_recompute_perf_skips_when_all_quiet(
         mock_influx, shares_validator, mocker):
     """No dirty signal -> update_account_metrics is not called (no Parquet drip)."""

--- a/app/tests/test_scheduling_wiring.py
+++ b/app/tests/test_scheduling_wiring.py
@@ -9,14 +9,16 @@ reschedule-gate split, and the Prometheus fetch-success gate (#609).
 """
 
 import threading
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from types import SimpleNamespace
 
 from apscheduler.jobstores.base import JobLookupError
 from apscheduler.schedulers.background import BackgroundScheduler
 
 import main
-from main import SuiviBourseMetrics, _scrape_job_id, resolve_regular_interval
+from main import (
+    SuiviBourseMetrics, _scrape_job_id, resolve_regular_interval,
+    register_interval_jobs, SCRAPE_JOB_PREFIX)
 
 
 UTC = timezone.utc
@@ -241,6 +243,166 @@ def test_inflight_scrape_racing_with_cleanup_does_not_resurrect_counter(
     assert not scrape_thread.is_alive()
     assert "AAPL" not in m._failure_counts
     m.scheduler.add_job.assert_not_called()  # also does not re-arm
+
+
+# ---------------------------------------------------------------------------
+# Perf recompute — gated interval job (#618)
+# ---------------------------------------------------------------------------
+
+def test_scrape_symbol_regular_write_sets_perf_dirty_live(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch):
+    """A REGULAR write raises the global live-write dirty bool (issue #618)."""
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    m._perf_dirty_live = False  # start clean to prove the write sets it
+    monkeypatch.setattr(main.yf, "Ticker", lambda s: fake_ticker(market_state="REGULAR"))
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    mock_influx.write_metrics.assert_called_once()
+    assert m._perf_dirty_live is True
+
+
+def test_scrape_symbol_closed_does_not_set_perf_dirty_live(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch):
+    """A closed-market probe writes nothing and leaves the flag clean, so a
+    fully-closed wave produces no perf point (non-trading-day gap #606)."""
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    m._perf_dirty_live = False
+    monkeypatch.setattr(main.yf, "Ticker", lambda s: fake_ticker(market_state="CLOSED"))
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    mock_influx.write_metrics.assert_not_called()
+    assert m._perf_dirty_live is False
+
+
+def test_scrape_symbol_price_failure_does_not_set_perf_dirty_live(
+        mock_influx, shares_validator, mocker):
+    """A non-closed cycle with no writable price writes nothing -> flag stays."""
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    m._perf_dirty_live = False
+    mocker.patch.object(m, "_fetch_ticker_data", return_value=(None, None))
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    assert m._perf_dirty_live is False
+
+
+def test_recompute_perf_skips_when_all_quiet(
+        mock_influx, shares_validator, mocker):
+    """No dirty signal -> update_account_metrics is not called (no Parquet drip)."""
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    # Clear the boot seed and align _perf_last_events with current events so
+    # events_changed is False (get_events() returns None for the fake manager).
+    m._perf_dirty_live = False
+    m._perf_last_events = m.config_manager.get_events()
+    spy = mocker.patch.object(m, "update_account_metrics")
+
+    m.recompute_perf()
+
+    spy.assert_not_called()
+
+
+def test_recompute_perf_boot_seed_runs_first_cycle(
+        mock_influx, shares_validator, mocker):
+    """Seeded True at boot -> the first cycle always runs (fresh restart point)."""
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    assert m._perf_dirty_live is True          # boot seed
+    spy = mocker.patch.object(m, "update_account_metrics")
+
+    m.recompute_perf()
+
+    spy.assert_called_once()
+
+
+def test_recompute_perf_runs_and_clears_live_flag_under_lock(
+        mock_influx, shares_validator, mocker):
+    """A live REGULAR write triggers a run; the flag is checked-and-cleared."""
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    m._perf_dirty_live = False
+    m._perf_last_events = m.config_manager.get_events()
+    spy = mocker.patch.object(m, "update_account_metrics")
+
+    # A live write lands (as _scrape_symbol would set it).
+    with m._perf_lock:
+        m._perf_dirty_live = True
+
+    m.recompute_perf()
+    spy.assert_called_once()
+    assert m._perf_dirty_live is False         # cleared
+
+    # Next quiet cycle skips — the flag was consumed, not sticky.
+    spy.reset_mock()
+    m.recompute_perf()
+    spy.assert_not_called()
+
+
+def test_recompute_perf_runs_when_backfill_watermark_pending(
+        mock_influx, shares_validator, mocker):
+    """A pending backfill watermark alone triggers a run (checked, not consumed
+    here — update_account_metrics consumes it)."""
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    m._perf_dirty_live = False
+    m._perf_last_events = m.config_manager.get_events()
+    m._mark_perf_dirty(date(2024, 1, 2))
+    spy = mocker.patch.object(m, "update_account_metrics")
+
+    m.recompute_perf()
+
+    spy.assert_called_once()
+    # Watermark is only *checked* in the gate; consumption stays downstream.
+    assert m._perf_dirty_from == date(2024, 1, 2)
+
+
+def test_recompute_perf_runs_when_events_changed(
+        mock_influx, shares_validator, mocker):
+    """A reloaded events cache (new list object) alone triggers a run."""
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    m._perf_dirty_live = False
+    # _perf_last_events differs from get_events() (None) -> events_changed True.
+    m._perf_last_events = ["stale"]
+    spy = mocker.patch.object(m, "update_account_metrics")
+
+    m.recompute_perf()
+
+    spy.assert_called_once()
+
+
+def test_recompute_perf_error_does_not_propagate_and_rearms_live_flag(
+        mock_influx, shares_validator, mocker):
+    """An update_account_metrics failure is logged (never killing the thread) and
+    the consumed live-write signal is re-armed so the next cycle retries."""
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    m._perf_dirty_live = True  # a live write triggered this cycle
+    mocker.patch.object(m, "update_account_metrics", side_effect=RuntimeError("boom"))
+
+    m.recompute_perf()  # must not raise
+
+    assert m._perf_dirty_live is True  # re-armed for the next cycle
+
+
+# ---------------------------------------------------------------------------
+# register_interval_jobs — perf job at SB_PERF_INTERVAL, separate from scrape
+# ---------------------------------------------------------------------------
+
+def test_register_interval_jobs_registers_perf_at_its_own_interval(
+        mock_influx, shares_validator, mocker):
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    scheduler = mocker.MagicMock(spec=BackgroundScheduler)
+
+    register_interval_jobs(
+        scheduler, m, ingestion_interval=300, backfill_interval=60,
+        perf_interval=90)
+
+    by_id = {c.kwargs["id"]: c for c in scheduler.add_job.call_args_list}
+    assert set(by_id) == {"ingest", "backfill", "perf"}
+    perf = by_id["perf"]
+    # perf is an interval job at SB_PERF_INTERVAL, bound to recompute_perf.
+    assert perf.args[0].__func__ is SuiviBourseMetrics.recompute_perf
+    assert perf.args[1] == "interval"
+    assert perf.kwargs["seconds"] == 90
+    # Separate from the per-symbol scrape jobs (no scrape: prefixed id here).
+    assert not any(jid.startswith(SCRAPE_JOB_PREFIX) for jid in by_id)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Detaches `update_account_metrics` from the scrape and makes perf recompute its **own gated interval job** — a 4th scheduler job that coalesces by construction and stays as quiet as prices do overnight (no closed-market Parquet drip, #597). Implements #618.

- Register perf recompute as an interval job at **`SB_PERF_INTERVAL`** (default 120s), no longer inside `scrape()`.
- Gate each run on a pure predicate `perf_should_run()` in `scheduling.py`: run only when something changed — skip ⟺ events unchanged **and** no backfill watermark **and** no live `REGULAR` write since the last run.
- Live-write signal = a single global bool `_perf_dirty_live`, set on the `REGULAR` write path in `_scrape_symbol`, **checked-and-cleared up front under `_perf_lock`**, seeded `True` at boot so today's point is fresh after a weekend/overnight restart.
- Composes with the existing `_perf_dirty_from` watermark (checked in the gate, consumed in `update_account_metrics`) and the `events_changed` full-rewrite path — no regression to #597's incremental-tail write.
- A fully-closed market wave writes nothing (non-trading-day gap by design, #606). On a perf write error the consumed live-write flag is re-armed so the next cycle retries, mirroring the watermark re-arm.
- Extract `register_interval_jobs()` from `__main__` as a testable seam.

## Tests
- `perf_should_run()` truth table (events-changed / backfill-watermark / live-REGULAR-write / all-quiet / boot-seed) as a pure predicate.
- Wiring: live-write bool set/cleared under `_perf_lock`, boot-seed runs first cycle, watermark & events-changed triggers, error re-arm, and `register_interval_jobs` registers perf at `SB_PERF_INTERVAL` separate from per-symbol jobs.
- Full suite: **395 passed**; `flake8 --ignore=E501` clean; no new dependency.

Closes #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated, configurable interval for performance metric updates through `SB_PERF_INTERVAL` (default: 120 seconds).
  * Performance metrics now update when relevant activity occurs, such as new data, event changes, or pending backfills.
  * Separated performance updates from per-symbol scraping schedules.

* **Documentation**
  * Updated scheduling documentation and configuration references to describe the new performance update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->