### PR TITLE
feat(app): executor pool sizing, anti-herd jitter & misfire policy (#619)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,20 @@ The application runs independent scheduled jobs on a single APScheduler:
   3 failures still re-arm at `base_interval`, then the delay grows
   `base_interval × 2^(n−3)` capped at 24h, resetting to 0 on the first
   successful write. Closed cycles never count as failures. There is no global
-  scrape job.
+  scrape job. **Anti-herd (issue #619):** every arming offsets its `run_date` by
+  a fresh `uniform(0, 30s)` jitter (the heir of the removed inter-share
+  `time.sleep(1)`; a `date` trigger can't carry APScheduler's own `jitter`), so a
+  same-exchange cohort sharing one next-open spreads over `[open, open+30s]` and
+  the `REGULAR`-poll lockstep is re-randomized each cycle. Jobs carry
+  `misfire_grace_time=None` (run however late — a skipped run would permanently
+  kill a self-rescheduling job; the on-wake `marketState` re-read self-corrects)
+  and `max_instances=1`. The APScheduler **executor pool** is sized at boot from
+  two dials: `SB_DYNAMIC_EXECUTOR_POOL` (default `false` → fixed
+  `SB_EXECUTOR_POOL`, default 10) or, when `true`, the pure
+  `scheduling.compute_pool_size(mode, shares, exchange_of)` =
+  `min(reserved + ceil(largest_cohort × 5 / 30), 50)` with `reserved` 3 (events)
+  / 1 (manual). `exchange_of` is captured by a pre-scheduler fetch
+  (`capture_exchange_of`) only on the auto path.
 - **Ingestion**: Reloads portfolio events from files (default: every 300s) and
   reconciles the per-symbol scrape jobs against the new symbol set (add / remove
   / revive).
@@ -250,6 +263,8 @@ If ingestion fails (invalid event, file error), the **previous valid configurati
 | `SB_REGULAR_INTERVAL` | `120` | Poll interval (seconds) for a symbol whose market is in `REGULAR` state (per-symbol scheduling). Closed markets sleep to next open instead. |
 | `SB_SCRAPING_INTERVAL` | — | **Deprecated** heir of the removed global scrape interval. Honored as a fallback for `SB_REGULAR_INTERVAL` when the latter is unset; logs a warning whenever present. |
 | `SB_PERF_INTERVAL` | `120` | Perf-recompute interval (seconds) for the gated `account_metrics`/`portfolio_totals` job (issue #618) |
+| `SB_DYNAMIC_EXECUTOR_POOL` | `false` | Opt-in: auto-size the APScheduler thread pool from the largest same-exchange cohort (issue #619). Off = fixed pool, zero change from today. |
+| `SB_EXECUTOR_POOL` | `10` | Fixed executor pool size when `SB_DYNAMIC_EXECUTOR_POOL=false`. Enforced `≥1`. Ignored (warns) when auto sizing is on (issue #619). |
 | `SB_INGESTION_INTERVAL` | `300` | Event ingestion interval (seconds) |
 | `SB_BACKFILL_INTERVAL` | `60` | Backfill check interval (seconds) |
 | `SB_BACKFILL_DELAY` | `10` | Delay between yfinance requests (seconds) |

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -3,6 +3,7 @@ SuiviBourse
 Paul Brissaud
 """
 import os
+import random
 import sys
 import threading
 import time
@@ -13,6 +14,7 @@ from typing import List, Dict, Optional, Tuple
 import pandas as pd
 import yaml
 import yfinance as yf
+from apscheduler.executors.pool import ThreadPoolExecutor
 from apscheduler.schedulers.blocking import BlockingScheduler
 from cerberus import Validator
 from confuse import Configuration, exceptions as ConfuseExceptions
@@ -92,6 +94,37 @@ def resolve_regular_interval() -> int:
     if old_val is not None:
         return int(old_val)
     return 120
+
+
+def resolve_executor_pool_size(mode: str, shares: List[dict],
+                               capture_exchange_of) -> int:
+    """Resolve the APScheduler executor-pool size from the two dials (issue #619).
+
+    ``SB_DYNAMIC_EXECUTOR_POOL`` (default ``false``) picks fixed vs auto:
+
+      * ``false`` → a fixed pool of ``SB_EXECUTOR_POOL`` (default ``10``) —
+        identical to today's behaviour on upgrade (APScheduler's default pool is
+        also 10).
+      * ``true``  → ``scheduling.compute_pool_size`` over same-exchange cohorts.
+        ``capture_exchange_of`` (a zero-arg callable → ``{symbol: exchange}``,
+        e.g. the ``SuiviBourseMetrics`` method of the same name) is invoked
+        **only** on this path, so the fixed default never triggers the
+        pre-scheduler exchange fetch. If ``SB_EXECUTOR_POOL`` is also set it is
+        ignored, with a warning (convention of #607).
+
+    Always ``>= 1``. ``POOL_CAP`` bounds only the auto formula, never the fixed
+    dial (operator freedom, design #611).
+    """
+    auto = os.getenv('SB_DYNAMIC_EXECUTOR_POOL', 'false').lower() == 'true'
+    fixed_raw = os.getenv('SB_EXECUTOR_POOL')
+    if not auto:
+        fixed = int(fixed_raw) if fixed_raw is not None else 10
+        return max(1, fixed)
+    if fixed_raw is not None:
+        app_logger.warning(
+            "SB_EXECUTOR_POOL is ignored because SB_DYNAMIC_EXECUTOR_POOL is "
+            "enabled; the executor pool is sized automatically.")
+    return scheduling.compute_pool_size(mode, shares, capture_exchange_of())
 
 
 def register_interval_jobs(scheduler, sb_metrics, ingestion_interval: int,
@@ -725,6 +758,31 @@ class SuiviBourseMetrics:
         """The set of symbols currently held across all accounts."""
         return {s['symbol'] for s in self.shares if s.get('symbol')}
 
+    def capture_exchange_of(self) -> Dict[str, Optional[str]]:
+        """Map each held symbol to its exchange for auto pool sizing (#619, #611).
+
+        Same-exchange cohorts drive ``scheduling.compute_pool_size``, but the
+        exchange lives only in the yfinance ``info`` — not the config — so we fetch
+        it once up front, before the scheduler's executor is fixed at construction
+        (the design's "pre-scheduler scrape"). Reuses the shared
+        ``_share_info_cache`` so a symbol already fetched isn't fetched twice. A
+        symbol whose fetch fails, or that reports the ``'undefined'`` sentinel
+        (yfinance's default for a missing exchange), maps to ``None`` —
+        ``compute_pool_size`` then treats it as a solo market rather than grouping
+        every unknown into one giant cohort.
+
+        Only called on the auto path (``SB_DYNAMIC_EXECUTOR_POOL=true``), so the
+        fixed-pool default never pays this fetch cost.
+        """
+        exchange_of: Dict[str, Optional[str]] = {}
+        for symbol in sorted(self._held_symbols()):
+            info = self._share_info_cache.get(symbol)
+            if info is None:
+                _, info = self._fetch_ticker_data(symbol)
+            exchange = (info or {}).get('exchange')
+            exchange_of[symbol] = exchange if exchange and exchange != 'undefined' else None
+        return exchange_of
+
     def _scheduled_symbols(self) -> set:
         """Symbols that currently have a live per-symbol scrape job."""
         out = set()
@@ -739,12 +797,29 @@ class SuiviBourseMetrics:
 
         A single ``date`` trigger — the job re-arms itself each cycle, so this is
         both the immediate bootstrap (``delay=0``) and the self-reschedule.
+
+        Anti-herd jitter (issue #619): offset every arming by a fresh
+        ``uniform(0, JITTER_SECONDS)`` — the heir of the removed inter-share
+        ``time.sleep(1)``. A same-exchange cohort sharing one next-open thus
+        spreads over ``[open, open + JITTER_SECONDS]``, and the ``REGULAR``-poll
+        lockstep is re-randomized each cycle. A ``date`` trigger can't carry
+        APScheduler's own ``jitter`` (only interval/cron can), so we apply it to
+        ``run_date`` directly, mirroring APScheduler's ``uniform(0, jitter)``.
+
+        ``misfire_grace_time=None`` (run however late): under per-symbol jobs each
+        job *is* its own scheduler (it re-arms inside ``_scrape_symbol``), so a
+        misfired-and-skipped run would permanently kill the symbol and ingest()'s
+        set-diff wouldn't revive it. Running late is safe — the on-wake
+        ``marketState`` re-read (#608/#616) self-corrects. ``max_instances=1``
+        (no overlap; ``coalesce`` is moot with one pending run per job).
         """
-        run_date = now + timedelta(seconds=delay)
+        jitter = random.uniform(0, scheduling.JITTER_SECONDS)
+        run_date = now + timedelta(seconds=delay + jitter)
         self.scheduler.add_job(
             self._scrape_symbol, 'date', run_date=run_date,
             args=[symbol], id=_scrape_job_id(symbol),
-            name=f'Scrape {symbol}', replace_existing=True)
+            name=f'Scrape {symbol}', replace_existing=True,
+            misfire_grace_time=None, max_instances=1)
 
     def _reconcile_jobs(self) -> None:
         """Diff the held-symbol set against the scheduled jobs (design #604).
@@ -1369,10 +1444,20 @@ if __name__ == "__main__":
                 f"Prometheus metrics available on :{metrics_port}/metrics")
         # Start file watcher for hot-reload if in events mode
         config_manager.start_watcher(sb_metrics.ingest)
+        # Size the executor pool from the two dials (issue #619). Default
+        # (SB_DYNAMIC_EXECUTOR_POOL=false) is a fixed pool of SB_EXECUTOR_POOL
+        # (10) — identical to today. Auto sizing groups the held symbols into
+        # same-exchange cohorts, so capture_exchange_of() is invoked only on that
+        # path (a pre-scheduler fetch; the executor is fixed once at
+        # construction, no hot resize).
+        pool_size = resolve_executor_pool_size(
+            config_manager.get_mode(), sb_metrics.shares,
+            sb_metrics.capture_exchange_of)
         # Wire the scheduler before bootstrapping so ingest() can arm the
         # per-symbol scrape jobs (issue #616). Their immediate first fire IS the
         # bootstrap — no separate initial scrape.
-        scheduler = BlockingScheduler()
+        scheduler = BlockingScheduler(
+            executors={'default': ThreadPoolExecutor(pool_size)})
         sb_metrics.scheduler = scheduler
         # Bootstrap: load shares + arm one self-rescheduling scrape job per
         # symbol (each fires immediately, then re-arms on its market cadence).
@@ -1386,7 +1471,8 @@ if __name__ == "__main__":
         app_logger.info(
             f"Scheduler started: per-symbol scraping (REGULAR every "
             f"{regular_interval}s), ingestion every {ingestion_interval}s, "
-            f"backfill every {backfill_interval}s, perf every {perf_interval}s")
+            f"backfill every {backfill_interval}s, perf every {perf_interval}s, "
+            f"executor pool: {pool_size} workers")
         scheduler.start()
     except ConfuseExceptions.NotFoundError as e:
         app_logger.fatal(

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -2,6 +2,7 @@
 SuiviBourse
 Paul Brissaud
 """
+import concurrent.futures
 import os
 import random
 import sys
@@ -68,6 +69,15 @@ SCRAPE_JOB_PREFIX = 'scrape:'
 
 def _scrape_job_id(symbol: str) -> str:
     return f'{SCRAPE_JOB_PREFIX}{symbol}'
+
+
+# Pre-scheduler exchange capture for auto pool sizing (issue #619). At boot the
+# whole app blocks on this before ``BlockingScheduler`` is even built, so the
+# fetch is fanned out over a small bounded pool and hard-capped by an overall
+# deadline — a slow / rate-limited yfinance session must not delay startup
+# indefinitely. Symbols unresolved within the deadline fall back to solo markets.
+_EXCHANGE_CAPTURE_WORKERS = 8
+_EXCHANGE_CAPTURE_TIMEOUT_SECONDS = 30
 
 
 def resolve_regular_interval() -> int:
@@ -758,6 +768,18 @@ class SuiviBourseMetrics:
         """The set of symbols currently held across all accounts."""
         return {s['symbol'] for s in self.shares if s.get('symbol')}
 
+    @staticmethod
+    def _exchange_from_info(info: Optional[dict]) -> Optional[str]:
+        """The exchange from a ticker ``info`` dict, or ``None``.
+
+        ``None`` for a failed fetch or the ``'undefined'`` sentinel (yfinance's
+        default for a missing exchange), so ``compute_pool_size`` treats the
+        symbol as a solo market rather than grouping every unknown into one giant
+        cohort.
+        """
+        exchange = (info or {}).get('exchange')
+        return exchange if exchange and exchange != 'undefined' else None
+
     def capture_exchange_of(self) -> Dict[str, Optional[str]]:
         """Map each held symbol to its exchange for auto pool sizing (#619, #611).
 
@@ -765,22 +787,57 @@ class SuiviBourseMetrics:
         exchange lives only in the yfinance ``info`` — not the config — so we fetch
         it once up front, before the scheduler's executor is fixed at construction
         (the design's "pre-scheduler scrape"). Reuses the shared
-        ``_share_info_cache`` so a symbol already fetched isn't fetched twice. A
-        symbol whose fetch fails, or that reports the ``'undefined'`` sentinel
-        (yfinance's default for a missing exchange), maps to ``None`` —
-        ``compute_pool_size`` then treats it as a solo market rather than grouping
-        every unknown into one giant cohort.
+        ``_share_info_cache`` so a symbol already fetched isn't fetched twice.
+
+        The whole app blocks here at boot, so the uncached symbols are fetched
+        concurrently over a bounded pool (``_EXCHANGE_CAPTURE_WORKERS``) and the
+        collection is hard-capped by ``_EXCHANGE_CAPTURE_TIMEOUT_SECONDS``: a slow
+        or rate-limited yfinance session can't delay scheduler startup
+        indefinitely. Any symbol that fails or doesn't resolve in time maps to
+        ``None`` — a solo market (see ``_exchange_from_info``).
 
         Only called on the auto path (``SB_DYNAMIC_EXECUTOR_POOL=true``), so the
         fixed-pool default never pays this fetch cost.
         """
         exchange_of: Dict[str, Optional[str]] = {}
+        to_fetch = []
         for symbol in sorted(self._held_symbols()):
             info = self._share_info_cache.get(symbol)
             if info is None:
-                _, info = self._fetch_ticker_data(symbol)
-            exchange = (info or {}).get('exchange')
-            exchange_of[symbol] = exchange if exchange and exchange != 'undefined' else None
+                to_fetch.append(symbol)
+                exchange_of[symbol] = None  # solo unless the fetch resolves below
+            else:
+                exchange_of[symbol] = self._exchange_from_info(info)
+
+        if not to_fetch:
+            return exchange_of
+
+        pool = concurrent.futures.ThreadPoolExecutor(
+            max_workers=min(_EXCHANGE_CAPTURE_WORKERS, len(to_fetch)))
+        futures = {pool.submit(self._fetch_ticker_data, s): s for s in to_fetch}
+        try:
+            for future in concurrent.futures.as_completed(
+                    futures, timeout=_EXCHANGE_CAPTURE_TIMEOUT_SECONDS):
+                symbol = futures[future]
+                try:
+                    _, info = future.result()
+                except Exception as e:
+                    app_logger.warning(
+                        f"Exchange capture failed for {symbol}, treating as a "
+                        f"solo market: {e}")
+                    continue
+                exchange_of[symbol] = self._exchange_from_info(info)
+        except concurrent.futures.TimeoutError:
+            unresolved = sorted(s for f, s in futures.items() if not f.done())
+            app_logger.warning(
+                f"Exchange capture timed out after "
+                f"{_EXCHANGE_CAPTURE_TIMEOUT_SECONDS}s; treating "
+                f"{len(unresolved)} symbol(s) as solo markets: "
+                f"{', '.join(unresolved)}")
+        finally:
+            # Don't block startup joining slow/hung in-flight fetches; cancel what
+            # hasn't started yet (cancel_futures: py3.9+).
+            pool.shutdown(wait=False, cancel_futures=True)
         return exchange_of
 
     def _scheduled_symbols(self) -> set:

--- a/app/src/scheduling.py
+++ b/app/src/scheduling.py
@@ -12,7 +12,8 @@ testable against dicts and an injected clock (issue #616, design #602-#609).
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import Optional, Tuple
+from math import ceil
+from typing import Dict, List, Optional, Tuple
 
 try:  # zoneinfo is stdlib on 3.9+; no new dependency (design #602/#603).
     from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -41,6 +42,21 @@ _MAX_BACKOFF_EXP = 32
 # Approximate local open used only when the exact next-open is unavailable.
 # ``marketState`` remains the authority on wake, so an early guess is fine.
 _APPROX_OPEN_HOUR = 8
+
+# Anti-herd jitter (issue #619, design #611) — the heir of the removed
+# inter-share ``time.sleep(1)``. Hardcoded, not an operator dial (like
+# ``SHORT_RETRY`` / ``MAX_SLEEP``). Every per-symbol job arming (main.py) offsets
+# its ``run_date`` by a fresh ``uniform(0, JITTER_SECONDS)`` so a same-exchange
+# cohort sharing one next-open spreads over ``[open, open + JITTER_SECONDS]`` and
+# the ``REGULAR``-poll lockstep is re-randomized each cycle. A ``date`` trigger
+# can't carry APScheduler's own ``jitter``, so main applies it to ``run_date``.
+JITTER_SECONDS = 30
+
+# Executor pool auto-sizing (issue #619, design #611) — see ``compute_pool_size``.
+POOL_CAP = 50              # hard bound on the *auto* formula only (not the dial)
+FETCH_EST_SECONDS = 5      # rough wall-clock of one _fetch_ticker_data cycle
+RESERVED_EVENTS = 3        # backfill + perf (+ headroom) exist in events mode
+RESERVED_MANUAL = 1        # backfill only in manual mode
 
 
 def is_closed(state) -> bool:
@@ -140,6 +156,48 @@ def perf_should_run(events_changed: bool, backfill_pending: bool,
     there is no closed-day Parquet drip (#597).
     """
     return events_changed or backfill_pending or live_write
+
+
+def compute_pool_size(mode: str, shares: List[dict],
+                      exchange_of: Dict[str, Optional[str]]) -> int:
+    """Auto executor-pool size for ``SB_DYNAMIC_EXECUTOR_POOL`` (#619, #611).
+
+    Under one self-rescheduling job per symbol (#616), every symbol on the same
+    exchange gets the same next-open timestamp, so at market open a whole cohort
+    fires together. Size the pool to the busiest wave: the **largest same-exchange
+    cohort** drives the scrape workers. Each cohort of ``N`` is spread over the
+    ``JITTER_SECONDS`` window, so ``ceil(N × FETCH_EST_SECONDS / JITTER_SECONDS)``
+    workers keep up::
+
+        min(reserved + ceil(largest_cohort × FETCH_EST / JITTER), POOL_CAP)
+
+    ``reserved`` covers the non-scrape jobs — ``RESERVED_EVENTS`` (backfill + perf
+    + headroom) in events mode, ``RESERVED_MANUAL`` (backfill only) otherwise.
+    ``exchange_of`` maps each held symbol to its exchange; a symbol with no known
+    exchange (``None``/missing/falsy) is its own **solo market** (cohort of 1),
+    never grouped — so an all-unknown portfolio never inflates into one giant
+    cohort. The result is clamped to ``[1, POOL_CAP]``: ``POOL_CAP`` bounds only
+    this auto formula, never the fixed ``SB_EXECUTOR_POOL`` dial.
+    """
+    reserved = RESERVED_EVENTS if mode == 'events' else RESERVED_MANUAL
+
+    symbols = {s['symbol'] for s in shares if s.get('symbol')}
+    cohorts: Dict[str, int] = {}
+    solo = 0
+    for symbol in symbols:
+        exchange = exchange_of.get(symbol)
+        if exchange:
+            cohorts[exchange] = cohorts.get(exchange, 0) + 1
+        else:
+            solo += 1  # unknown exchange: a solo market, its own cohort of 1
+
+    cohort_sizes = list(cohorts.values())
+    if solo:
+        cohort_sizes.append(1)
+    largest = max(cohort_sizes, default=0)
+
+    scrape_workers = ceil(largest * FETCH_EST_SECONDS / JITTER_SECONDS)
+    return max(1, min(reserved + scrape_workers, POOL_CAP))
 
 
 def extract_market_context(info: Optional[dict], history_meta: Optional[dict],

--- a/app/tests/test_scheduling.py
+++ b/app/tests/test_scheduling.py
@@ -13,8 +13,8 @@ import pytest
 
 import scheduling
 from scheduling import (
-    decide, extract_market_context, perf_should_run,
-    SHORT_RETRY, MAX_SLEEP, FAILURE_GRACE)
+    decide, extract_market_context, perf_should_run, compute_pool_size,
+    SHORT_RETRY, MAX_SLEEP, FAILURE_GRACE, POOL_CAP)
 
 
 UTC = timezone.utc
@@ -326,3 +326,71 @@ def test_is_closed_whitelist():
         assert scheduling.is_closed(s) is True
     for s in ("REGULAR", None, "", "unknown"):
         assert scheduling.is_closed(s) is False
+
+
+# ---------------------------------------------------------------------------
+# compute_pool_size — auto executor-pool sizing (#619, design #611)
+# ---------------------------------------------------------------------------
+
+def _shares(*symbols):
+    """Minimal share dicts — compute_pool_size only reads ``symbol``."""
+    return [{"symbol": s} for s in symbols]
+
+
+def _same_exchange(symbols, exchange="NMS"):
+    return {s: exchange for s in symbols}
+
+
+@pytest.mark.parametrize("mode,count,expected", [
+    # Design #611 worked examples: reserved + ceil(cohort*5/30), reserved 3/1.
+    ("events", 30, 8),    # 3 + ceil(150/30)=5
+    ("manual", 30, 6),    # 1 + 5
+    ("events", 100, 20),  # 3 + ceil(500/30)=17
+    ("manual", 5, 2),     # 1 + ceil(25/30)=1
+    ("events", 1, 4),     # 3 + ceil(5/30)=1
+    ("manual", 1, 2),     # 1 + 1
+])
+def test_compute_pool_size_same_exchange_cohort(mode, count, expected):
+    symbols = [f"SYM{i}" for i in range(count)]
+    assert compute_pool_size(
+        mode, _shares(*symbols), _same_exchange(symbols)) == expected
+
+
+def test_compute_pool_size_clamps_to_cap():
+    # A cohort large enough to blow past POOL_CAP is clamped to it.
+    symbols = [f"SYM{i}" for i in range(1000)]
+    size = compute_pool_size("events", _shares(*symbols), _same_exchange(symbols))
+    assert size == POOL_CAP
+
+
+@pytest.mark.parametrize("mode,expected", [("manual", 1), ("events", 3)])
+def test_compute_pool_size_empty_portfolio_is_reserved_and_at_least_one(mode, expected):
+    assert compute_pool_size(mode, [], {}) == expected
+
+
+def test_compute_pool_size_sizes_on_largest_cohort_only():
+    # Two exchanges: NMS holds 30, PAR holds 3 -> the 30-cohort drives the size.
+    nms = [f"N{i}" for i in range(30)]
+    par = [f"P{i}" for i in range(3)]
+    exchange_of = {**_same_exchange(nms, "NMS"), **_same_exchange(par, "PAR")}
+    assert compute_pool_size(
+        "manual", _shares(*(nms + par)), exchange_of) == 6  # 1 + 5
+
+
+def test_compute_pool_size_unknown_exchange_is_a_solo_market():
+    # No exchange known for any symbol -> each is a solo cohort of 1, not grouped.
+    symbols = [f"SYM{i}" for i in range(30)]
+    exchange_of = {s: None for s in symbols}
+    # largest cohort = 1 -> ceil(5/30)=1 -> manual 1+1=2 (not 6).
+    assert compute_pool_size("manual", _shares(*symbols), exchange_of) == 2
+
+
+def test_compute_pool_size_missing_exchange_entry_is_solo():
+    # A symbol absent from exchange_of behaves like an unknown exchange (solo).
+    symbols = ["AAA", "BBB"]
+    assert compute_pool_size("manual", _shares(*symbols), {}) == 2  # 1 + 1
+
+
+def test_compute_pool_size_ignores_shares_without_symbol():
+    shares = [{"symbol": "AAA"}, {"name": "no symbol"}, {"symbol": None}]
+    assert compute_pool_size("manual", shares, {"AAA": "NMS"}) == 2  # 1 + 1

--- a/app/tests/test_scheduling_wiring.py
+++ b/app/tests/test_scheduling_wiring.py
@@ -747,3 +747,23 @@ def test_capture_exchange_of_maps_failed_and_undefined_to_none(
 
     # Failed fetch and the 'undefined' sentinel both become solo (None).
     assert result == {"AAA": None, "BBB": None}
+
+
+def test_capture_exchange_of_times_out_to_solo_market(
+        mock_influx, shares_validator, mocker):
+    """A fetch that outlives the deadline maps to a solo market, not a hang."""
+    m = _metrics([_share(symbol="SLOW")], mock_influx, shares_validator, mocker)
+    mocker.patch("main._EXCHANGE_CAPTURE_TIMEOUT_SECONDS", 0.2)
+    release = threading.Event()
+
+    def _slow(symbol):
+        release.wait(timeout=5)          # outlasts the 0.2s deadline
+        return (1.0, {"exchange": "NMS"})
+
+    mocker.patch.object(m, "_fetch_ticker_data", side_effect=_slow)
+    try:
+        result = m.capture_exchange_of()
+        # Startup didn't block on the slow fetch; the symbol fell back to solo.
+        assert result == {"SLOW": None}
+    finally:
+        release.set()                    # let the worker thread exit cleanly

--- a/app/tests/test_scheduling_wiring.py
+++ b/app/tests/test_scheduling_wiring.py
@@ -12,17 +12,31 @@ import threading
 from datetime import date, datetime, timedelta, timezone
 from types import SimpleNamespace
 
+import pytest
 from apscheduler.jobstores.base import JobLookupError
 from apscheduler.schedulers.background import BackgroundScheduler
 
 import main
+import scheduling
 from main import (
     SuiviBourseMetrics, _scrape_job_id, resolve_regular_interval,
-    register_interval_jobs, SCRAPE_JOB_PREFIX)
+    resolve_executor_pool_size, register_interval_jobs, SCRAPE_JOB_PREFIX)
 
 
 UTC = timezone.utc
 NOW = datetime(2024, 1, 15, 15, 0, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _no_jitter(mocker):
+    """Zero the anti-herd jitter (issue #619) for the cadence/reconcile tests.
+
+    Jitter is an orthogonal concern: these tests pin the exact base re-arm delay,
+    so the random ``uniform(0, JITTER_SECONDS)`` offset ``_arm_symbol`` adds would
+    make ``run_date`` non-deterministic. Zero it here; the dedicated jitter tests
+    below re-patch ``main.random.uniform`` to assert the spread.
+    """
+    mocker.patch("main.random.uniform", return_value=0.0)
 
 
 def _share(symbol="AAPL", name="Apple", account="default"):
@@ -594,3 +608,142 @@ def test_regular_interval_no_warning_when_old_var_absent(monkeypatch, mocker):
     warn = mocker.patch.object(main.app_logger, "warning")
     assert resolve_regular_interval() == 45
     warn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Anti-herd jitter + misfire/max_instances on the per-symbol jobs (issue #619)
+# ---------------------------------------------------------------------------
+
+def test_arm_symbol_offsets_run_date_by_jitter(
+        mock_influx, shares_validator, mocker):
+    """Jitter is applied as a uniform(0, JITTER_SECONDS) offset on run_date."""
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    # Re-patch over the autouse zero-jitter with a fixed non-zero offset.
+    uniform = mocker.patch("main.random.uniform", return_value=7.5)
+
+    m._arm_symbol("AAPL", 120, NOW)
+
+    uniform.assert_called_once_with(0, scheduling.JITTER_SECONDS)
+    assert m.scheduler.add_job.call_args.kwargs["run_date"] == \
+        NOW + timedelta(seconds=127.5)
+
+
+def test_arm_symbol_jitter_stays_within_window(
+        mock_influx, shares_validator, mocker):
+    """With real randomness the offset lands in [0, JITTER_SECONDS]."""
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    mocker.stopall()  # drop the autouse zero-jitter -> real random.uniform
+
+    lo = NOW + timedelta(seconds=120)
+    hi = lo + timedelta(seconds=scheduling.JITTER_SECONDS)
+    for _ in range(50):
+        m._arm_symbol("AAPL", 120, NOW)
+        run_date = m.scheduler.add_job.call_args.kwargs["run_date"]
+        assert lo <= run_date <= hi
+
+
+def test_arm_symbol_registers_misfire_none_and_single_instance(
+        mock_influx, shares_validator, mocker):
+    """Per-symbol jobs carry misfire_grace_time=None and max_instances=1."""
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+
+    m._arm_symbol("AAPL", 120, NOW)
+
+    kwargs = m.scheduler.add_job.call_args.kwargs
+    assert kwargs["misfire_grace_time"] is None
+    assert kwargs["max_instances"] == 1
+    assert kwargs["replace_existing"] is True
+
+
+def test_scrape_symbol_rearm_carries_misfire_and_max_instances(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch):
+    """The self-reschedule (not just the bootstrap) keeps the misfire policy."""
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    monkeypatch.setattr(main.yf, "Ticker", lambda s: fake_ticker(market_state="REGULAR"))
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    kwargs = m.scheduler.add_job.call_args.kwargs
+    assert kwargs["misfire_grace_time"] is None
+    assert kwargs["max_instances"] == 1
+
+
+# ---------------------------------------------------------------------------
+# resolve_executor_pool_size — the two dials (issue #619)
+# ---------------------------------------------------------------------------
+
+def _never_capture():  # a capture callable that must NOT be invoked
+    raise AssertionError("capture_exchanges called on the fixed-pool path")
+
+
+def test_executor_pool_defaults_to_ten(monkeypatch):
+    monkeypatch.delenv("SB_DYNAMIC_EXECUTOR_POOL", raising=False)
+    monkeypatch.delenv("SB_EXECUTOR_POOL", raising=False)
+    # Fixed path: capture must not run (no pre-scheduler fetch).
+    assert resolve_executor_pool_size("manual", [], _never_capture) == 10
+
+
+def test_executor_pool_honors_fixed_dial(monkeypatch):
+    monkeypatch.setenv("SB_DYNAMIC_EXECUTOR_POOL", "false")
+    monkeypatch.setenv("SB_EXECUTOR_POOL", "4")
+    assert resolve_executor_pool_size("manual", [], _never_capture) == 4
+
+
+def test_executor_pool_fixed_enforces_at_least_one(monkeypatch):
+    monkeypatch.setenv("SB_EXECUTOR_POOL", "0")
+    monkeypatch.delenv("SB_DYNAMIC_EXECUTOR_POOL", raising=False)
+    assert resolve_executor_pool_size("manual", [], _never_capture) == 1
+
+
+def test_executor_pool_auto_uses_compute_pool_size(monkeypatch):
+    monkeypatch.setenv("SB_DYNAMIC_EXECUTOR_POOL", "true")
+    monkeypatch.delenv("SB_EXECUTOR_POOL", raising=False)
+    shares = [{"symbol": f"S{i}"} for i in range(30)]
+    exchange_of = {s["symbol"]: "NMS" for s in shares}
+    # events/30-same-exchange -> 3 + ceil(150/30) = 8 (design #611 example).
+    assert resolve_executor_pool_size(
+        "events", shares, lambda: exchange_of) == 8
+
+
+def test_executor_pool_auto_warns_when_fixed_also_set(monkeypatch, mocker):
+    monkeypatch.setenv("SB_DYNAMIC_EXECUTOR_POOL", "true")
+    monkeypatch.setenv("SB_EXECUTOR_POOL", "10")
+    warn = mocker.patch.object(main.app_logger, "warning")
+    size = resolve_executor_pool_size("manual", [], lambda: {})
+    warn.assert_called_once()          # conflicting fixed dial flagged
+    assert size == 1                   # empty portfolio, manual -> reserved 1
+
+
+# ---------------------------------------------------------------------------
+# capture_exchange_of — pre-scheduler exchange snapshot (issue #619)
+# ---------------------------------------------------------------------------
+
+def test_capture_exchange_of_reads_info_cache_and_fetches_missing(
+        mock_influx, shares_validator, mocker):
+    m = _metrics([_share(symbol="AAPL"), _share(symbol="MSFT")],
+                 mock_influx, shares_validator, mocker)
+    # AAPL already cached; MSFT must be fetched.
+    m._share_info_cache["AAPL"] = {"exchange": "NMS"}
+    fetch = mocker.patch.object(
+        m, "_fetch_ticker_data", return_value=(1.0, {"exchange": "PAR"}))
+
+    result = m.capture_exchange_of()
+
+    assert result == {"AAPL": "NMS", "MSFT": "PAR"}
+    fetch.assert_called_once_with("MSFT")   # cached AAPL not re-fetched
+
+
+def test_capture_exchange_of_maps_failed_and_undefined_to_none(
+        mock_influx, shares_validator, mocker):
+    m = _metrics([_share(symbol="AAA"), _share(symbol="BBB")],
+                 mock_influx, shares_validator, mocker)
+
+    def _fetch(symbol):
+        return (None, None) if symbol == "AAA" else (1.0, {"exchange": "undefined"})
+
+    mocker.patch.object(m, "_fetch_ticker_data", side_effect=_fetch)
+
+    result = m.capture_exchange_of()
+
+    # Failed fetch and the 'undefined' sentinel both become solo (None).
+    assert result == {"AAA": None, "BBB": None}

--- a/website/docs/configuration/overview.mdx
+++ b/website/docs/configuration/overview.mdx
@@ -51,7 +51,15 @@ All settings can be overridden with environment variables.
 | `SB_CONFIG_MODE` | `manual` | Configuration mode (`manual` or `events`) |
 | `SB_SCRAPING_INTERVAL` | `120` | Price scraping interval (seconds) |
 | `SB_INGESTION_INTERVAL` | `300` | Event ingestion interval (seconds) |
+| `SB_DYNAMIC_EXECUTOR_POOL` | `false` | Auto-size the scheduler's thread pool from the largest same-exchange cohort. Off by default (fixed pool) — opt-in. |
+| `SB_EXECUTOR_POOL` | `10` | Fixed thread-pool size when `SB_DYNAMIC_EXECUTOR_POOL=false`. Ignored (with a warning) when auto sizing is on. |
 | `LOG_LEVEL` | `INFO` | Logging level |
+
+:::note Anti-herd jitter
+Each per-symbol job spreads its wake over a hardcoded **30 s** jitter window, so
+a whole exchange's holdings don't fetch in lockstep at market open. This is not
+an operator dial.
+:::
 
 ### Backfill (events mode)
 


### PR DESCRIPTION
Closes #619.

Under one self-rescheduling job per symbol (#616), every symbol on the same exchange gets the same next-open timestamp, so at market open N jobs fire in lockstep. This adds anti-herd spacing and a correctly-sized executor pool so simultaneous wakes don't stampede yfinance or starve the scheduler.

## What changed

**Anti-herd jitter** (`_arm_symbol`) — a `date` trigger can't carry APScheduler's own `jitter` (interval/cron only), so we offset every arming's `run_date` by a fresh `uniform(0, JITTER_SECONDS=30)`, reproducing APScheduler's exact `uniform(0, jitter)` semantics. Heir of the removed inter-share `time.sleep(1)`; spreads a same-exchange cohort over `[open, open+30s]` and re-randomizes the `REGULAR`-poll lockstep each cycle.

**Misfire policy** — per-symbol jobs carry `misfire_grace_time=None` (a skipped self-rescheduling run would permanently kill the symbol; the on-wake `marketState` re-read self-corrects) and `max_instances=1`.

**Executor pool, two dials** — `SB_DYNAMIC_EXECUTOR_POOL` (default `false` → fixed `SB_EXECUTOR_POOL`, default 10, zero change on upgrade) or, when `true`, the pure `scheduling.compute_pool_size(mode, shares, exchange_of)` = `min(reserved + ceil(largest_cohort × 5 / 30), POOL_CAP=50)`, `reserved` 3 (events) / 1 (manual), clamped `≥1`. `exchange_of` is captured pre-scheduler by `capture_exchange_of()` (auto path only, reuses `_share_info_cache`). Warns if `SB_EXECUTOR_POOL` is set while auto.

Design worked examples verified: events/30→8, manual/30→6, events/100→20, manual/5→2.

## Acceptance criteria

- [x] Per-symbol jobs registered with jitter=30, `misfire_grace_time=None`, `max_instances=1`; no residual `time.sleep` spacing remains.
- [x] `SB_DYNAMIC_EXECUTOR_POOL` defaults to `false` → fixed pool of `SB_EXECUTOR_POOL` (default 10).
- [x] Auto formula `min(reserved + ceil(largest_cohort × 5 / 30), 50)`, reserved 3/1, `≥1`.
- [x] Warning logged when `SB_EXECUTOR_POOL` is set while auto=true.
- [x] `exchange_of` captured pre-scheduler (adapted to the post-#616 boot: `capture_exchange_of()` runs before the executor is fixed at scheduler construction).
- [x] Unit + wiring tests pass; flake8 clean; no new dependency (`math.ceil`, `random` stdlib).

## Tests

`compute_pool_size` (both modes, cohort sizing, cap clamp, ≥1, solo markets); jitter offset (fixed + `[0,30]` window), misfire/max_instances wiring, the two pool dials + warn-on-conflict, `capture_exchange_of`. Full suite: 420 passing.

Reviewed with `/code-review` (Standards + Spec): no hard violations, both spec nuances judged faithful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq4dzKFBnKwmEfr4UouXhr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic scheduler worker-pool sizing based on held-symbol exchange distribution.
  - Added configurable fixed and dynamic executor pool settings.
  - Staggered per-symbol jobs with up to 30 seconds of scheduling jitter.
  - Prevented overlapping symbol jobs and ensured missed jobs are handled consistently.

- **Documentation**
  - Documented executor pool configuration and anti-herd scheduling behavior.
- **Tests**
  - Added coverage for pool sizing, scheduling safeguards, jitter, and exchange detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->