### PR TITLE
docs(website): document market-aware scraping & rollout framing (#620)

### DIFF
--- a/website/docs/advanced/market-aware-scraping.mdx
+++ b/website/docs/advanced/market-aware-scraping.mdx
@@ -1,0 +1,169 @@
+---
+title: Market-aware scraping (v4.1)
+description: Per-symbol, market-state-driven price scraping — the cadence model, the worker-pool dials, the resulting weekend/holiday chart gaps, and the optional purge
+sidebar_position: 5
+---
+
+From **v4.1**, price scraping is **per-symbol and market-aware**. Instead of one
+global loop that polled every symbol every `SB_SCRAPING_INTERVAL` seconds around
+the clock, SuiviBourse now schedules **one self-rescheduling job per held
+symbol**, and each job decides its own next wake-up from the symbol's live
+market state. This page explains the cadence model, the two worker-pool dials,
+the visible weekend/holiday gaps it introduces, and the (deprecated) env-var
+mapping.
+
+:::info No config change, no user action required
+This is a `feat` (minor) release. Your `config.yaml` / event files are
+**unchanged**, the in-memory job store is rebuilt at every boot, and
+`SB_SCRAPING_INTERVAL` is **still honored** (see the
+[deprecation](#deprecation) section below). The only visible changes are honest
+[chart gaps](#weekend-and-holiday-gaps) across closed markets and the storage fix
+that stops closed days from writing dense points.
+:::
+
+## The cadence model
+
+Each per-symbol job fetches its symbol from Yahoo! Finance, writes a point per
+account holding it, then **re-arms itself** based on the returned `marketState`:
+
+| Market state | What happens | Next wake-up |
+|---|---|---|
+| **`REGULAR`** (open) | Poll and write a point | `SB_REGULAR_INTERVAL` (default **120 s**) later |
+| **Closed** (pre/post, weekend, holiday) | Write nothing | Sleep until the **next open** (capped at 24 h) |
+
+There is **no global scrape job** anymore. A closed market produces **no point at
+all** — the non-trading-day gap is by design, not missing data.
+
+### Anti-herd jitter
+
+Every re-arm offsets its wake-up by a fresh random `uniform(0, 30 s)` jitter, so
+a whole exchange's holdings — which all share the same next-open time — spread
+their fetches over a 30-second window instead of stampeding Yahoo! Finance in
+lockstep at the opening bell. The `REGULAR`-poll cadence is re-randomized the
+same way each cycle. The 30 s window is hardcoded; it is **not** an operator dial.
+
+### Dead-ticker backoff
+
+If a non-closed cycle keeps producing no writable price (a delisted or bad
+ticker), the job backs off instead of hammering the API every
+`SB_REGULAR_INTERVAL`:
+
+- the first **3** failures still re-arm at the base interval;
+- after that the delay grows `base_interval × 2^(n−3)`, capped at **24 h**;
+- the delay **resets to zero on the first successful write**.
+
+Closed-market cycles never count as failures — sleeping over a weekend does not
+trip the backoff.
+
+## Worker-pool dials
+
+The per-symbol jobs share an APScheduler thread pool, sized at boot from two
+environment variables:
+
+| Variable | Default | Effect |
+|---|---|---|
+| `SB_DYNAMIC_EXECUTOR_POOL` | `false` | `false` → a **fixed** pool of `SB_EXECUTOR_POOL`. `true` → **auto-size** from the largest same-exchange cohort. |
+| `SB_EXECUTOR_POOL` | `10` | Fixed pool size (used only when auto sizing is **off**). Enforced ≥ 1; ignored with a warning when auto sizing is on. |
+
+When `SB_DYNAMIC_EXECUTOR_POOL=true`, the pool is sized as
+`min(reserved + ceil(largest_cohort × 5 / 30), 50)`, where `reserved` covers the
+non-scrape jobs (3 in events mode, 1 in manual mode). The default (`false`) keeps
+the fixed pool of 10 — **identical to previous behavior**, so leaving both unset
+changes nothing.
+
+## The performance job
+
+Recomputing the per-account and global return series
+(`account_metrics` / `portfolio_totals`) is **its own gated job**, decoupled from
+scraping, running every `SB_PERF_INTERVAL` seconds (default **120 s**, events
+mode / opt-in accounts only). Each cycle is **gated**: it recomputes only when
+something actually changed since the last run — the events cache reloaded, a
+backfill watermark is pending, or a live `REGULAR` write landed. A fully-closed
+market wave writes nothing and the perf job skips its run, so a closed day adds
+no Parquet churn.
+
+## Weekend and holiday gaps
+
+Because a closed market writes **no** point, charts now show **honest gaps**
+across weekends and holidays instead of the flat, fake frozen candles you saw
+before. How this reads on the dashboard:
+
+- **Stat tiles** (Total value, Cash balance, XIRR, Absolute gain) resolve the
+  **last point in the selected range**, so over a weekend they keep showing the
+  **frozen-but-correct last close** — the number you want.
+- **Candlestick, volume and time-series panels** render a blank
+  Saturday/Sunday — the market being shut, not a data loss. This is an
+  improvement over the old fake weekend candles.
+
+Keep the dashboard range at **a few days or more** (the shipped defaults already
+do) so every stat tile always resolves to a recent point.
+
+:::caution External Prometheus staleness alerts
+The legacy `sb_share_price` gauge legitimately **stops updating while a market is
+closed**. If you run an external Prometheus *"no fresh samples"* / staleness
+alert on it, widen the alert window past a weekend so a normal closed market
+doesn't page you. See the
+[legacy Prometheus endpoint](/docs/advanced/prometheus-legacy).
+:::
+
+See [Reading the dashboard](/docs/reading-the-dashboard#weekend-and-holiday-gaps-in-the-charts)
+for how these gaps interact with the return metrics.
+
+## Deprecation: `SB_SCRAPING_INTERVAL` → `SB_REGULAR_INTERVAL` {#deprecation}
+
+The old single scrape interval was renamed to **`SB_REGULAR_INTERVAL`** because
+it now describes only the *open-market* poll cadence — closed markets sleep to
+the next open instead.
+
+| Old | New | Behavior |
+|---|---|---|
+| `SB_SCRAPING_INTERVAL` | `SB_REGULAR_INTERVAL` | Same default (120 s), now the `REGULAR`-state poll interval. |
+
+`SB_SCRAPING_INTERVAL` is **deprecated but still honored**: if `SB_REGULAR_INTERVAL`
+is unset, its value is used as a fallback and a **warning** is logged. If **both**
+are set, `SB_REGULAR_INTERVAL` wins and `SB_SCRAPING_INTERVAL` is ignored (also
+warned). Migrate at your leisure by renaming the variable — no other change is
+required.
+
+## Optional: purge pre-upgrade closed-market points
+
+Before this release, the global loop wrote a **dense** point on every cycle, even
+while markets were closed — so your pre-upgrade history has fake weekend/holiday
+samples, while everything written after the upgrade has honest gaps. If that seam
+bothers you, you can **optionally** wipe the old table and let backfill + live
+scraping rebuild a uniformly-gapped history.
+
+:::warning InfluxDB 3 Core deletes at table granularity only
+InfluxDB 3 **Core** has **no row-level or predicate/time-range `DELETE`** (that
+`influx delete --predicate` flow exists only on Cloud/Serverless). So you cannot
+surgically remove *just* the closed-market rows — the only purge available is
+dropping the **whole** measurement and rebuilding it.
+:::
+
+Drop `portfolio_metrics` (and, if you want the perf series rebuilt too,
+`account_metrics` / `portfolio_totals`). Each table is recreated cleanly on the
+next write:
+
+```bash
+for table in portfolio_metrics account_metrics portfolio_totals; do
+  curl -X DELETE "$INFLUXDB_HOST/api/v3/configure/table" \
+    -H "Authorization: Bearer $INFLUXDB_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"db\": \"suivi_bourse\", \"table\": \"$table\"}"
+done
+```
+
+:::danger This destroys real history — never automate it
+A drop throws away every **live** scrape and can only be **rebuilt from
+backfill**, which is strictly worse:
+
+- backfill returns **daily closes only** — you lose the every-120 s granularity
+  of live scraping;
+- `dividend_yield`, `pe_ratio` and `market_cap` are **never** rebuilt — they exist
+  only on live scrapes and are gone for good.
+
+There is intentionally **no application flag** to purge data — combined with
+`restart: unless-stopped` a destructive flag would be a data shredder. This stays
+a deliberate, manual, one-off `curl` you run yourself. If in doubt, **do
+nothing**: the seam is cosmetic and the two regimes read together fine.
+:::

--- a/website/docs/configuration/overview.mdx
+++ b/website/docs/configuration/overview.mdx
@@ -49,11 +49,21 @@ All settings can be overridden with environment variables.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SB_CONFIG_MODE` | `manual` | Configuration mode (`manual` or `events`) |
-| `SB_SCRAPING_INTERVAL` | `120` | Price scraping interval (seconds) |
+| `SB_REGULAR_INTERVAL` | `120` | Poll interval (seconds) for a symbol whose market is **open** (`REGULAR`). Closed markets sleep to the next open instead — see [market-aware scraping](/docs/advanced/market-aware-scraping). |
+| `SB_SCRAPING_INTERVAL` | _(deprecated)_ | **Deprecated** heir of the old global scrape interval. Still honored as a fallback for `SB_REGULAR_INTERVAL` when the latter is unset (logs a warning). Prefer `SB_REGULAR_INTERVAL`. |
+| `SB_PERF_INTERVAL` | `120` | Recompute interval (seconds) for the `account_metrics` / `portfolio_totals` performance series (events mode, opt-in accounts). |
 | `SB_INGESTION_INTERVAL` | `300` | Event ingestion interval (seconds) |
 | `SB_DYNAMIC_EXECUTOR_POOL` | `false` | Auto-size the scheduler's thread pool from the largest same-exchange cohort. Off by default (fixed pool) — opt-in. |
 | `SB_EXECUTOR_POOL` | `10` | Fixed thread-pool size when `SB_DYNAMIC_EXECUTOR_POOL=false`. Ignored (with a warning) when auto sizing is on. |
 | `LOG_LEVEL` | `INFO` | Logging level |
+
+:::caution `SB_SCRAPING_INTERVAL` is deprecated
+The old single scrape interval was renamed to `SB_REGULAR_INTERVAL` when scraping
+became **per-symbol and market-aware**. `SB_SCRAPING_INTERVAL` is still read as a
+fallback (with a warning) so existing deployments keep working unchanged, but
+set `SB_REGULAR_INTERVAL` going forward. If both are set, `SB_REGULAR_INTERVAL`
+wins and `SB_SCRAPING_INTERVAL` is ignored.
+:::
 
 :::note Anti-herd jitter
 Each per-symbol job spreads its wake over a hardcoded **30 s** jitter window, so

--- a/website/docs/deployment/docker.mdx
+++ b/website/docs/deployment/docker.mdx
@@ -62,7 +62,8 @@ Use the `-e` / `--env` flags to override defaults. The most common ones:
 | `INFLUXDB_TOKEN` | _(required)_ | InfluxDB API token |
 | `INFLUXDB_DATABASE` | `suivi_bourse` | InfluxDB database name |
 | `SB_CONFIG_MODE` | `manual` | Configuration mode (`manual` or `events`) |
-| `SB_SCRAPING_INTERVAL` | `120` | Price scraping interval (seconds) |
+| `SB_REGULAR_INTERVAL` | `120` | Poll interval (seconds) while a symbol's market is open (closed markets sleep to the next open) |
+| `SB_SCRAPING_INTERVAL` | _(deprecated)_ | Deprecated fallback for `SB_REGULAR_INTERVAL` (honored with a warning) |
 | `LOG_LEVEL` | `INFO` | Logging level |
 
 See the [configuration overview](/docs/configuration/overview#environment-variables)

--- a/website/docs/deployment/standalone.mdx
+++ b/website/docs/deployment/standalone.mdx
@@ -165,7 +165,8 @@ At minimum you must set the InfluxDB connection variables:
 | `INFLUXDB_HOST` | `http://influxdb:8181` | InfluxDB 3 host URL |
 | `INFLUXDB_TOKEN` | _(required)_ | InfluxDB API token |
 | `INFLUXDB_DATABASE` | `suivi_bourse` | InfluxDB database name |
-| `SB_SCRAPING_INTERVAL` | `120` | Price scraping interval (seconds) |
+| `SB_REGULAR_INTERVAL` | `120` | Poll interval (seconds) while a symbol's market is open (closed markets sleep to the next open) |
+| `SB_SCRAPING_INTERVAL` | _(deprecated)_ | Deprecated fallback for `SB_REGULAR_INTERVAL` (honored with a warning) |
 | `SB_METRICS_PORT` | `8081` | Port for the legacy Prometheus `/metrics` endpoint |
 | `LOG_LEVEL` | `INFO` | Logging level |
 

--- a/website/docs/intro/design.mdx
+++ b/website/docs/intro/design.mdx
@@ -8,10 +8,15 @@ sidebar_position: 1
 
 1. SuiviBourse loads your portfolio from either a `config.yaml` file
    (**manual mode**) or from CSV/XLSX transaction files (**events mode**).
-2. Three independent scheduled jobs run in parallel:
-   - **Scraping** — fetches current prices from Yahoo! Finance.
+2. Independent scheduled jobs run in parallel:
+   - **Scraping** — fetches current prices from Yahoo! Finance. There is **one
+     self-rescheduling job per held symbol**, and each one is
+     [market-aware](/docs/advanced/market-aware-scraping): it polls only while
+     the symbol's market is open and sleeps until the next open otherwise.
    - **Ingestion** — reloads and re-aggregates your portfolio configuration.
    - **Backfill** — progressively fills in historical prices (events mode only).
+   - **Performance** — recomputes the per-account and global return series
+     (events mode, opt-in accounts only).
 3. Every data point is written to **InfluxDB 3 Core** in the
    `portfolio_metrics` measurement.
 4. **Grafana** reads InfluxDB (SQL datasource) to display your portfolio in a
@@ -22,21 +27,21 @@ sidebar_position: 1
 ## Architecture
 
 ```
-                             SuiviBourse (app)
-┌──────────────────────┬──────────────────────┬──────────────────────┐
-│      SCRAPING        │      INGESTION       │      BACKFILL        │
-│    (every 120s)      │    (every 300s)      │    (every 60s)       │
-│                      │                      │  events mode only    │
-│ • yfinance.Ticker()  │ • Load config or     │ • Find first BUY     │
-│ • Current price,     │   event files        │ • Check oldest point │
-│   volume, P/E, …     │ • Validate           │   in InfluxDB        │
-│ • Write InfluxDB     │ • Aggregate          │ • Fetch 1 chunk of   │
-│ • Update legacy      │ • Cache (by mtime)   │   history (≈1 year)  │
-│   Prometheus gauges  │ • Update shares[]    │ • Enrich + write     │
-└──────────┬───────────┴──────────┬───────────┴──────────┬───────────┘
-           │                      │                       │
-           └──────────────────────┼───────────────────────┘
-                                  ▼
+                                    SuiviBourse (app)
+┌────────────────────┬────────────────────┬────────────────────┬────────────────────┐
+│      SCRAPING      │     INGESTION      │      BACKFILL      │    PERFORMANCE     │
+│  (per symbol,      │    (every 300s)    │    (every 60s)     │  (SB_PERF_INTERVAL)│
+│   market-aware)    │                    │  events mode only  │  events mode only  │
+│ • yfinance.Ticker()│ • Load config or   │ • Find first BUY   │ • Only when data   │
+│ • marketState →    │   event files      │ • Check oldest pt  │   changed          │
+│   poll or sleep    │ • Validate         │   in InfluxDB      │ • Recompute XIRR / │
+│ • Open: write pt   │ • Aggregate        │ • Fetch 1 chunk of │   TWR / value      │
+│ • Closed: sleep to │ • Cache (by mtime) │   history (≈1 year)│ • Write account_/  │
+│   next open        │ • Update shares[]  │ • Enrich + write   │   portfolio series │
+└─────────┬──────────┴─────────┬──────────┴─────────┬──────────┴─────────┬──────────┘
+          │                    │                    │                    │
+          └────────────────────┴─────────┬──────────┴────────────────────┘
+                                         ▼
                         ┌───────────────────┐        ┌──────────────────┐
                         │  InfluxDB 3 Core  │◄──────►│     Grafana      │
                         │ portfolio_metrics │  SQL   │    dashboard     │
@@ -48,24 +53,34 @@ sidebar_position: 1
                         └───────────────────┘
 ```
 
-## Three independent schedules
+## Independent schedules
 
-The application runs three separate scheduled jobs that operate independently.
-Because they are decoupled, an error in one never blocks the others.
+The application runs several scheduled jobs that operate independently. Because
+they are decoupled, an error in one never blocks the others.
 
-| Job | Default interval | Env variable | Purpose | Error handling |
-|-----|------------------|--------------|---------|----------------|
-| **Scraping** | 120 s | `SB_SCRAPING_INTERVAL` | Fetch live prices from Yahoo! Finance | Retries with exponential backoff on rate limits |
-| **Ingestion** | 300 s | `SB_INGESTION_INTERVAL` | Reload & re-aggregate the portfolio | Keeps the previous valid configuration |
-| **Backfill** | 60 s | `SB_BACKFILL_INTERVAL` | Fill historical price data (events mode) | Retries the same chunk on the next cycle |
+| Job | Cadence | Env variable | Purpose | Error handling |
+|-----|---------|--------------|---------|----------------|
+| **Scraping** | Per symbol, market-aware | `SB_REGULAR_INTERVAL` | Fetch live prices from Yahoo! Finance | Sleeps closed markets to next open; backs a dead ticker off exponentially |
+| **Ingestion** | Every 300 s | `SB_INGESTION_INTERVAL` | Reload & re-aggregate the portfolio | Keeps the previous valid configuration |
+| **Backfill** | Every 60 s | `SB_BACKFILL_INTERVAL` | Fill historical price data (events mode) | Retries the same chunk on the next cycle |
+| **Performance** | Every `SB_PERF_INTERVAL` s (gated) | `SB_PERF_INTERVAL` | Recompute per-account & global returns (events mode, opt-in) | Skips the run when nothing changed |
 
-:::tip Why three separate schedules?
+Scraping is no longer a single global loop: SuiviBourse schedules **one
+self-rescheduling job per held symbol**, and each job re-arms on its own cadence
+from the symbol's live `marketState`. An open (`REGULAR`) market re-polls every
+`SB_REGULAR_INTERVAL`; a closed one sleeps until the next open. See
+[market-aware scraping](/docs/advanced/market-aware-scraping) for the full model,
+the worker-pool dials and the resulting weekend/holiday chart gaps.
+
+:::tip Why separate schedules?
 - **Isolation** — if your event files contain an error, price scraping keeps
   running with the last valid configuration.
-- **Different frequencies** — stock prices change constantly, your portfolio
-  rarely does, and backfill only needs to nibble away at history over time.
+- **Different frequencies** — stock prices change only while markets are open,
+  your portfolio rarely changes, and backfill only needs to nibble away at
+  history over time.
 - **Efficient caching** — ingestion only reprocesses when files actually change
-  (based on their modification time).
+  (based on their modification time), and the performance job only recomputes
+  when something new has landed.
 :::
 
 ## Storage & visualization

--- a/website/docs/reading-the-dashboard.mdx
+++ b/website/docs/reading-the-dashboard.mdx
@@ -198,6 +198,26 @@ the right creates an absolute range ending in the future, which Grafana caches
 in the URL. Pick a relative range (**Last 90 days**, **Last 1 year**) to re-anchor
 the axis on *now*.
 
+### Weekend and holiday gaps in the charts
+
+Since [market-aware scraping](/docs/advanced/market-aware-scraping), SuiviBourse
+**writes no point while a market is closed** — a fully-closed day (weekend,
+public holiday) produces nothing rather than repeating the last close. That
+changes how two kinds of panels read across a closed market:
+
+- **Stat tiles** (Total value, Cash balance, XIRR, Absolute gain) resolve the
+  **last point in the selected range**, so over a weekend they keep showing the
+  **frozen-but-correct last close** — exactly the number you want.
+- **Candlestick, volume and time-series panels show honest gaps** across closed
+  days instead of the old flat, fake weekend candles. A blank Saturday/Sunday is
+  the market being shut, not missing data.
+
+Keep the dashboard range at **a few days or more** (the shipped defaults already
+do) so a stat tile always has a recent point to resolve to. If you run external
+Prometheus staleness alerts, see the
+[market-aware scraping](/docs/advanced/market-aware-scraping#weekend-and-holiday-gaps)
+note on widening them past a weekend.
+
 ## Numbers that settle over time
 
 Right after startup, [backfill](/docs/backfill) is still walking price history


### PR DESCRIPTION
## What

Documentation-only implementation of #620 — documents the shipped per-symbol,
market-state-driven scraping behavior (#616–#619) and frames the release. **No
app code changes.**

## Changes

- **Env-var tables** (`overview.mdx`, `docker.mdx`, `standalone.mdx`): add
  `SB_REGULAR_INTERVAL` and `SB_PERF_INTERVAL`; mark `SB_SCRAPING_INTERVAL`
  **deprecated** (still honored as a fallback with a warning).
- **`intro/design.mdx`**: reframe from three static schedules to four jobs,
  market-aware per-symbol scraping and the gated perf job; update the
  architecture diagram.
- **`reading-the-dashboard.mdx`**: new "Weekend and holiday gaps" section —
  frozen-but-correct last-close stat tiles vs honest candlestick/timeseries gaps.
- **New `advanced/market-aware-scraping.mdx` (v4.1)**: cadence model,
  anti-herd `jitter=30s`, dead-ticker backoff, worker-pool dials, gated perf
  job, chart gaps, Prometheus staleness note, `SB_SCRAPING_INTERVAL`
  deprecation section, and an optional **manual** table-drop purge recipe
  (InfluxDB 3 Core has no row/predicate `DELETE`), clearly marked never-automatic.

## Acceptance criteria (#620)

- [x] CLAUDE.md env-var table (already landed by #621–#624)
- [x] v4 docs page: `marketState` cadence, weekend/holiday gaps (#606), honest
  candlestick/perf gaps vs last-close tiles + Prometheus staleness (#609),
  worker-pool dials + `jitter=30s` (#611)
- [x] Release framing as `feat`/minor + prominent deprecation section + chart-gap
  heads-up
- [x] Optional manual `DELETE` purge recipe, marked never-automatic
- [x] `website` build passes (no broken links)

## Review

Two-axis review (Standards + Spec) run via parallel sub-agents: all facts
verified against `CLAUDE.md` / `app/src`, all cross-references resolve, 5/5
acceptance criteria met. Post-review dedup applied so the Prometheus staleness
note has a single source of truth.

Closes #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq4dzKFBnKwmEfr4UouXhr