### PR TITLE
feat(app): forward gap-fill backfill pass for missed sessions (#627)

### DIFF
--- a/app/src/influxdb_writer.py
+++ b/app/src/influxdb_writer.py
@@ -326,6 +326,60 @@ class InfluxDBWriter:
 
         return None
 
+    def get_newest_timestamp(
+        self, share_symbol: str, account: Optional[str] = None
+    ) -> Optional[datetime]:
+        """
+        Get the newest timestamp for a given share symbol in InfluxDB.
+
+        Mirror of ``get_oldest_timestamp`` (``ORDER BY time DESC``), used by the
+        forward gap-fill pass (issue #627) to find where the stored series ends
+        so it can recover a session missed while the app was down.
+
+        Args:
+            share_symbol: Yahoo Finance symbol
+            account: When provided, scope the lookup to this account like
+                ``get_oldest_timestamp``. Uses COALESCE(account, 'default') so
+                points written before the account tag existed count as
+                'default' — never a bare ``WHERE account = ...`` that would drop
+                them.
+
+        Returns:
+            Newest timestamp as datetime, or None if no data exists
+        """
+        if self._client is None:
+            self.connect()
+
+        # Escape single quotes to keep share_symbol a safe SQL string literal
+        safe_symbol = share_symbol.replace("'", "''")
+        where = f"share_symbol = '{safe_symbol}'"
+        if account is not None:
+            safe_account = account.replace("'", "''")
+            where += f" AND COALESCE(account, 'default') = '{safe_account}'"
+        # Use SQL query for InfluxDB 3
+        query = f"""
+        SELECT time
+        FROM "{self.MEASUREMENT}"
+        WHERE {where}
+        ORDER BY time DESC
+        LIMIT 1
+        """
+
+        try:
+            table = self._client.query(query=query, language="sql")
+            if table and len(table) > 0:
+                # Convert Arrow table to Python
+                df = table.to_pandas()
+                if not df.empty:
+                    ts = df.iloc[0]['time']
+                    if hasattr(ts, 'to_pydatetime'):
+                        return ts.to_pydatetime()
+                    return ts
+        except Exception as e:
+            logger.error(f"Error querying newest timestamp for {share_symbol}: {e}")
+
+        return None
+
     def has_data_for_date(self, share_symbol: str, date: datetime) -> bool:
         """
         Check if data exists for a specific symbol on a given date.

--- a/app/src/influxdb_writer.py
+++ b/app/src/influxdb_writer.py
@@ -336,13 +336,22 @@ class InfluxDBWriter:
         forward gap-fill pass (issue #627) to find where the stored series ends
         so it can recover a session missed while the app was down.
 
+        Anchors on the newest **price-bearing** point (``share_price IS NOT
+        NULL``): ``write_metrics`` can persist a point without a price, and the
+        forward pass exists to fill *price* gaps that ``holdings_value`` reads
+        (``get_price_series`` filters the same way). Without the filter a newer
+        price-less point would make the forward pass believe coverage reaches
+        ``now`` and skip an older missing price range.
+
         Args:
             share_symbol: Yahoo Finance symbol
             account: When provided, scope the lookup to this account like
                 ``get_oldest_timestamp``. Uses COALESCE(account, 'default') so
                 points written before the account tag existed count as
                 'default' — never a bare ``WHERE account = ...`` that would drop
-                them.
+                them. Scoped per account (not symbol-only like
+                ``get_price_series``) because a backfill *coverage* anchor is
+                per-series: each account's gap is tracked independently.
 
         Returns:
             Newest timestamp as datetime, or None if no data exists
@@ -360,7 +369,7 @@ class InfluxDBWriter:
         query = f"""
         SELECT time
         FROM "{self.MEASUREMENT}"
-        WHERE {where}
+        WHERE {where} AND share_price IS NOT NULL
         ORDER BY time DESC
         LIMIT 1
         """

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -1104,152 +1104,270 @@ class SuiviBourseMetrics:
         timeline = EventAggregator().replay(events, accounts_declared) if events else None
 
         for share in self.shares:
-            symbol = share['symbol']
-            name = share['name']
-            account = share.get('account', DEFAULT_ACCOUNT)
-
-            # Get the target date (first BUY)
-            first_buy_date = self.config_manager.get_first_buy_date(symbol)
-            if not first_buy_date:
-                app_logger.debug(f"No BUY events found for {symbol}, skipping backfill")
-                continue
-
-            # Convert date to datetime if needed and make timezone-aware
-            if isinstance(first_buy_date, datetime):
-                if first_buy_date.tzinfo is None:
-                    first_buy_date = first_buy_date.replace(tzinfo=timezone.utc)
-            else:
-                # It's a date object, convert to datetime
-                first_buy_date = datetime.combine(first_buy_date, datetime.min.time(), tzinfo=timezone.utc)
-
-            # Skip symbols already backfilled up to their first BUY date to avoid
-            # refetching the same window every cycle (e.g. a first BUY on a
-            # non-trading day never lets oldest reach it exactly).
-            if self._backfill_complete.get((symbol, account)) == first_buy_date:
-                app_logger.debug(f"Backfill already complete for {symbol} ({account})")
-                continue
-
-            # Ensure share info (tags) is available so historical points share the
-            # same series identity as live scrape points. Fetch it if the scrape
-            # job has not populated the cache yet; defer backfill if unavailable.
-            info = self._share_info_cache.get(symbol)
-            if not info:
-                self._fetch_ticker_data(symbol)
-                info = self._share_info_cache.get(symbol)
-            if not info:
-                app_logger.warning(
-                    f"No share info available for {symbol}, deferring backfill")
-                continue
-
-            # Get the oldest data point in InfluxDB for this (symbol, account)
-            oldest_timestamp = self.influxdb.get_oldest_timestamp(symbol, account=account)
-
-            # Determine if we need to backfill (compare at day granularity)
-            if oldest_timestamp is not None:
-                # Already have some data, check if we need to go further back
-                # Compare dates only to avoid tiny time windows
-                if oldest_timestamp.date() <= first_buy_date.date():
-                    app_logger.debug(
-                        f"Backfill complete for {symbol} ({account}): "
-                        f"oldest={oldest_timestamp.date()}, target={first_buy_date.date()}")
-                    self._backfill_complete[(symbol, account)] = first_buy_date
-                    continue
-
-                # Need to fetch data before oldest_timestamp
-                # Use the actual timestamp to minimize gaps with hourly data
-                end_date = oldest_timestamp
-                if end_date.tzinfo is None:
-                    end_date = end_date.replace(tzinfo=timezone.utc)
-            else:
-                # No data at all, start from now
-                end_date = datetime.now(timezone.utc)
-
-            # Calculate the chunk to fetch (going backwards in time)
-            start_date = end_date - timedelta(days=self.backfill_chunk_days)
-
-            # Don't go before the first BUY date
-            if start_date < first_buy_date:
-                start_date = first_buy_date
-
-            # Skip if window is less than 1 day (avoids useless requests outside market hours)
-            if (end_date - start_date).days < 1:
-                app_logger.debug(
-                    f"Backfill window too small for {symbol}, skipping until next cycle")
-                continue
-
-            app_logger.info(
-                f"Backfilling {name} ({symbol}): {start_date.date()} to {end_date.date()}")
-
-            # Fetch historical data
-            prices = self._fetch_historical_data(symbol, start_date, end_date)
-
-            if prices is None:
-                app_logger.warning(f"Failed to fetch history for {symbol}, will retry next cycle")
-                continue
-
-            if not prices:
-                # Empty window: the fetch succeeded but returned no rows. If we
-                # have already reached the first BUY date there is no earlier
-                # trading data (e.g. the first BUY fell on a weekend/holiday), so
-                # mark the symbol complete to avoid refetching this window forever.
-                if start_date <= first_buy_date:
-                    app_logger.debug(
-                        f"Backfill complete for {symbol} ({account}): reached first BUY "
-                        f"date with no earlier trading data")
-                    self._backfill_complete[(symbol, account)] = first_buy_date
-                time.sleep(self.backfill_delay)
-                continue
-
-            # Enrich price data with portfolio state at each date, read from the
-            # single per-cycle timeline. Many price points (esp. hourly) share the
-            # same calendar day and thus the same state; look up once per date.
-            if timeline is not None:
-                state_by_date: Dict = {}
-                for price_point in prices:
-                    ts = price_point['timestamp']
-                    # Convert datetime to date for the timeline lookup
-                    point_date = ts.date() if isinstance(ts, datetime) else ts
-                    if point_date not in state_by_date:
-                        state_by_date[point_date] = timeline.position_at(
-                            account, symbol, point_date)
-                    state = state_by_date[point_date]
-                    if state:
-                        price_point['purchased_quantity'] = state['purchase']['quantity']
-                        price_point['purchased_price'] = state['purchase']['cost_price']
-                        price_point['purchased_fee'] = state['purchase']['fee']
-                        price_point['owned_quantity'] = state['estate']['quantity']
-                        price_point['received_dividend'] = state['estate']['received_dividend']
-
-            # Write to InfluxDB using the share info resolved earlier in the loop.
-            # Guard the write like expose_metrics does so a transient InfluxDB
-            # error on one share does not abort backfilling the remaining shares.
-            try:
-                written = self.influxdb.write_historical_prices(
-                    share_name=name,
-                    share_symbol=symbol,
-                    prices=prices,
-                    share_currency=info.get('currency'),
-                    share_exchange=info.get('exchange'),
-                    quote_type=info.get('quoteType'),
-                    account=account
-                )
-                backfilled_count += written
-                # Newly filled earlier prices change holdings_value for that
-                # window; re-arm the perf series so the next scrape rewrites the
-                # tail from here (issue #597).
-                if written > 0:
-                    self._mark_perf_dirty(start_date.date())
-            except Exception as e:
-                app_logger.error(
-                    f"Failed to write historical prices for {symbol}: {e}")
-
-            # Rate limit between symbols
-            time.sleep(self.backfill_delay)
+            backfilled_count += self._backfill_share(share, timeline)
 
         if backfilled_count > 0:
             app_logger.info(f"Backfill cycle complete: {backfilled_count} data points written")
         else:
             app_logger.debug("Backfill cycle complete: no new data to write")
+
+    def _backfill_share(self, share, timeline) -> int:
+        """Backfill one share in both directions (issue #626).
+
+        The **backward** pass extends the series toward the first BUY date and
+        stops once ``_backfill_complete`` is set; the **forward** pass recovers a
+        recent session missed while the app was down. The two directions are
+        **independent** — a completed backward watermark never suppresses the
+        forward pass (issue #627). Returns points written this cycle.
+        """
+        symbol = share['symbol']
+        account = share.get('account', DEFAULT_ACCOUNT)
+
+        # Get the target date (first BUY)
+        first_buy_date = self.config_manager.get_first_buy_date(symbol)
+        if not first_buy_date:
+            app_logger.debug(f"No BUY events found for {symbol}, skipping backfill")
+            return 0
+
+        # Convert date to datetime if needed and make timezone-aware
+        if isinstance(first_buy_date, datetime):
+            if first_buy_date.tzinfo is None:
+                first_buy_date = first_buy_date.replace(tzinfo=timezone.utc)
+        else:
+            # It's a date object, convert to datetime
+            first_buy_date = datetime.combine(
+                first_buy_date, datetime.min.time(), tzinfo=timezone.utc)
+
+        written = 0
+        # Backward pass — skip once complete to avoid refetching the same window
+        # every cycle (e.g. a first BUY on a non-trading day never lets oldest
+        # reach it exactly). This skip must NOT gate the forward pass below.
+        if self._backfill_complete.get((symbol, account)) == first_buy_date:
+            app_logger.debug(f"Backfill already complete for {symbol} ({account})")
+        else:
+            written += self._backfill_backward(share, first_buy_date, timeline)
+
+        # Forward pass — independent of the backward-completion watermark.
+        written += self._backfill_forward(share, timeline)
+        return written
+
+    def _ensure_share_info(self, symbol: str) -> Optional[Dict]:
+        """Resolve the share info (tags) so historical points share the same
+        series identity as live scrape points.
+
+        Fetches it if the scrape job has not populated the cache yet; returns
+        ``None`` (the caller defers this cycle) if still unavailable.
+        """
+        info = self._share_info_cache.get(symbol)
+        if not info:
+            self._fetch_ticker_data(symbol)
+            info = self._share_info_cache.get(symbol)
+        if not info:
+            app_logger.warning(
+                f"No share info available for {symbol}, deferring backfill")
+        return info
+
+    def _enrich_and_write(self, share, info, prices, perf_from_date,
+                          timeline) -> int:
+        """Enrich a fetched price chunk with portfolio state and write it.
+
+        Shared by the backward and forward passes so recovered points carry the
+        **same** enriched series identity/tags as live and backward-filled ones,
+        letting the perf ``holdings_value`` pick them up on the next recompute.
+        Guarded like ``expose_metrics`` so a transient InfluxDB error on one
+        share does not abort backfilling the remaining shares. Returns the number
+        of points written.
+        """
+        symbol = share['symbol']
+        name = share['name']
+        account = share.get('account', DEFAULT_ACCOUNT)
+
+        # Enrich price data with portfolio state at each date, read from the
+        # single per-cycle timeline. Many price points (esp. hourly) share the
+        # same calendar day and thus the same state; look up once per date.
+        if timeline is not None:
+            state_by_date: Dict = {}
+            for price_point in prices:
+                ts = price_point['timestamp']
+                # Convert datetime to date for the timeline lookup
+                point_date = ts.date() if isinstance(ts, datetime) else ts
+                if point_date not in state_by_date:
+                    state_by_date[point_date] = timeline.position_at(
+                        account, symbol, point_date)
+                state = state_by_date[point_date]
+                if state:
+                    price_point['purchased_quantity'] = state['purchase']['quantity']
+                    price_point['purchased_price'] = state['purchase']['cost_price']
+                    price_point['purchased_fee'] = state['purchase']['fee']
+                    price_point['owned_quantity'] = state['estate']['quantity']
+                    price_point['received_dividend'] = state['estate']['received_dividend']
+
+        try:
+            written = self.influxdb.write_historical_prices(
+                share_name=name,
+                share_symbol=symbol,
+                prices=prices,
+                share_currency=info.get('currency'),
+                share_exchange=info.get('exchange'),
+                quote_type=info.get('quoteType'),
+                account=account
+            )
+            # Newly filled prices change holdings_value for that window; re-arm
+            # the perf series so the next recompute rewrites the tail from here
+            # (issue #597).
+            if written > 0:
+                self._mark_perf_dirty(perf_from_date)
+            return written
+        except Exception as e:
+            app_logger.error(
+                f"Failed to write historical prices for {symbol}: {e}")
+            return 0
+
+    def _fetch_and_store(self, share, info, start_date, end_date, timeline):
+        """Fetch one ``[start, end]`` chunk and, if non-empty, enrich + write it.
+
+        The shared tail of both backfill passes (they differ only in window
+        sizing and how they treat an empty window). Returns ``(prices, written)``:
+
+          * ``prices is None`` — the fetch failed; the caller logs and retries.
+          * ``prices == []`` — an empty window (yfinance returned no rows); the
+            caller decides what an empty window means for its direction.
+          * otherwise ``prices`` is the fetched rows and ``written`` the count
+            persisted.
+
+        Rate-limits (``SB_BACKFILL_DELAY``) after any completed fetch — empty or
+        written — but not after a fetch failure.
+        """
+        prices = self._fetch_historical_data(
+            share['symbol'], start_date, end_date)
+        if prices is None:
+            return None, 0
+        if not prices:
+            time.sleep(self.backfill_delay)
+            return prices, 0
+        written = self._enrich_and_write(
+            share, info, prices, start_date.date(), timeline)
+        # Rate limit between symbols
+        time.sleep(self.backfill_delay)
+        return prices, written
+
+    def _backfill_backward(self, share, first_buy_date, timeline) -> int:
+        """Backward pass: extend the series toward the first BUY date, one chunk
+        (``SB_BACKFILL_CHUNK_DAYS``) per cycle. Returns points written this cycle.
+        """
+        symbol = share['symbol']
+        name = share['name']
+        account = share.get('account', DEFAULT_ACCOUNT)
+
+        info = self._ensure_share_info(symbol)
+        if info is None:
+            return 0
+
+        # Get the oldest data point in InfluxDB for this (symbol, account)
+        oldest_timestamp = self.influxdb.get_oldest_timestamp(symbol, account=account)
+
+        # Determine if we need to backfill (compare at day granularity)
+        if oldest_timestamp is not None:
+            # Already have some data, check if we need to go further back
+            # Compare dates only to avoid tiny time windows
+            if oldest_timestamp.date() <= first_buy_date.date():
+                app_logger.debug(
+                    f"Backfill complete for {symbol} ({account}): "
+                    f"oldest={oldest_timestamp.date()}, target={first_buy_date.date()}")
+                self._backfill_complete[(symbol, account)] = first_buy_date
+                return 0
+
+            # Need to fetch data before oldest_timestamp
+            # Use the actual timestamp to minimize gaps with hourly data
+            end_date = oldest_timestamp
+            if end_date.tzinfo is None:
+                end_date = end_date.replace(tzinfo=timezone.utc)
+        else:
+            # No data at all, start from now
+            end_date = datetime.now(timezone.utc)
+
+        # Calculate the chunk to fetch (going backwards in time)
+        start_date = end_date - timedelta(days=self.backfill_chunk_days)
+
+        # Don't go before the first BUY date
+        if start_date < first_buy_date:
+            start_date = first_buy_date
+
+        # Skip if window is less than 1 day (avoids useless requests outside market hours)
+        if (end_date - start_date).days < 1:
+            app_logger.debug(
+                f"Backfill window too small for {symbol}, skipping until next cycle")
+            return 0
+
+        app_logger.info(
+            f"Backfilling {name} ({symbol}): {start_date.date()} to {end_date.date()}")
+
+        prices, written = self._fetch_and_store(
+            share, info, start_date, end_date, timeline)
+
+        if prices is None:
+            app_logger.warning(f"Failed to fetch history for {symbol}, will retry next cycle")
+            return 0
+
+        if not prices:
+            # Empty window: the fetch succeeded but returned no rows. If we
+            # have already reached the first BUY date there is no earlier
+            # trading data (e.g. the first BUY fell on a weekend/holiday), so
+            # mark the symbol complete to avoid refetching this window forever.
+            if start_date <= first_buy_date:
+                app_logger.debug(
+                    f"Backfill complete for {symbol} ({account}): reached first BUY "
+                    f"date with no earlier trading data")
+                self._backfill_complete[(symbol, account)] = first_buy_date
+
+        return written
+
+    def _backfill_forward(self, share, timeline) -> int:
+        """Forward pass: recover a session missed while the app was down by
+        fetching ``[newest, now]`` (issue #627).
+
+        Window sizing is delegated to the pure
+        ``scheduling.forward_backfill_window`` and gap classification to yfinance
+        — an empty window (weekend/holiday, or already covered) writes nothing.
+        The pure ``< 1 day`` guard makes this **no-op during live trading**
+        (newest ≈ now → sub-day window → skip), so the live ``REGULAR`` writer
+        stays the sole writer of the present with no duplicate at the seam.
+        Returns points written this cycle.
+        """
+        symbol = share['symbol']
+        name = share['name']
+        account = share.get('account', DEFAULT_ACCOUNT)
+
+        newest = self.influxdb.get_newest_timestamp(symbol, account=account)
+        window = scheduling.forward_backfill_window(
+            newest, datetime.now(timezone.utc), self.backfill_chunk_days)
+        if window is None:
+            return 0
+        start_date, end_date = window
+
+        info = self._ensure_share_info(symbol)
+        if info is None:
+            return 0
+
+        app_logger.info(
+            f"Forward-filling {name} ({symbol}): {start_date.date()} to {end_date.date()}")
+
+        # Same granularity/chunking as the backward pass: 1h within 730d, 1d beyond.
+        prices, written = self._fetch_and_store(
+            share, info, start_date, end_date, timeline)
+
+        if prices is None:
+            app_logger.warning(
+                f"Failed to fetch forward history for {symbol}, will retry next cycle")
+            return 0
+
+        if not prices:
+            # Empty window: yfinance returned no rows — a weekend/holiday gap or
+            # an already-covered range. Self-classifying no-op, nothing written.
+            app_logger.debug(
+                f"Forward-fill window for {symbol} returned no rows, skipping")
+
+        return written
 
     def scrape(self):
         """

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -1072,14 +1072,19 @@ class SuiviBourseMetrics:
 
     def backfill(self):
         """
-        Backfill historical price data for all shares.
+        Backfill historical price data for all shares, in both directions.
         This runs as a third scheduled job, progressively filling gaps.
 
-        For each share:
-        1. Find the first BUY date from events
-        2. Check the oldest data point in InfluxDB
-        3. If there's a gap, fetch one chunk (default: 1 year) of history
-        4. Rate limit between requests
+        For each share, delegates to ``_backfill_share`` which runs two
+        independent passes (issue #626):
+          * Backward: extend the series toward the first BUY date, one
+            ``SB_BACKFILL_CHUNK_DAYS`` chunk per cycle, until ``_backfill_complete``
+            is set.
+          * Forward: recover a session missed while the app was down by fetching
+            ``[newest, now]`` (issue #627) — independent of the backward
+            watermark.
+        Fetches one chunk (default: 1 year) of history per direction and rate
+        limits between requests.
         """
         if not self.shares:
             app_logger.debug("No shares configured, skipping backfill")

--- a/app/src/scheduling.py
+++ b/app/src/scheduling.py
@@ -158,6 +158,42 @@ def perf_should_run(events_changed: bool, backfill_pending: bool,
     return events_changed or backfill_pending or live_write
 
 
+def forward_backfill_window(
+    newest: Optional[datetime], now: datetime, chunk_days: int
+) -> Optional[Tuple[datetime, datetime]]:
+    """Size one forward gap-fill window ``[newest, end]``, or ``None`` (#627/#626).
+
+    Pure mirror of the backward pass's window sizing, injected ``now``, no
+    InfluxDB/yfinance — so the "should we fetch, and how wide" decision is unit
+    testable in isolation. The forward pass recovers a trading session the app
+    missed while down by asking ``history(newest → now)``; classifying the window
+    (real session vs weekend/holiday) is delegated to yfinance, never decided
+    here.
+
+    Returns ``None`` (no fetch this cycle) when:
+
+      * ``newest is None`` — the series has no stored point yet; the *backward*
+        pass owns seeding an empty series, the forward pass has no anchor.
+      * ``(now - newest).days < 1`` — reuse of the backward pass's ``< 1 day``
+        guard. This is what makes the forward pass **no-op during live trading**:
+        the live ``REGULAR`` writer keeps ``newest`` ≈ ``now``, the sub-day window
+        is skipped, and the forward pass never races or duplicates the seam. A
+        clock skew (``now < newest``) yields a negative delta → also skipped.
+
+    Otherwise returns ``(newest, end)`` where ``end = min(newest + chunk_days,
+    now)`` — chunked identically to the backward pass so a long gap is filled one
+    ``chunk_days`` window per cycle, advancing forward as ``newest`` catches up.
+    """
+    if newest is None:
+        return None
+    if newest.tzinfo is None:
+        newest = newest.replace(tzinfo=timezone.utc)
+    if (now - newest).days < 1:
+        return None
+    end = min(newest + timedelta(days=chunk_days), now)
+    return newest, end
+
+
 def compute_pool_size(mode: str, shares: List[dict],
                       exchange_of: Dict[str, Optional[str]]) -> int:
     """Auto executor-pool size for ``SB_DYNAMIC_EXECUTOR_POOL`` (#619, #611).

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -107,6 +107,7 @@ def mock_influx(mocker):
     without real I/O:
       - connect() / close() / write_metrics(): no-op (return None)
       - get_oldest_timestamp(): None (no existing data)
+      - get_newest_timestamp(): None (no existing data → forward pass no-ops)
       - has_data_for_date(): False
       - write_historical_prices(): 0 (points written; keeps ``+=`` arithmetic sane)
 
@@ -118,6 +119,7 @@ def mock_influx(mocker):
     m.close.return_value = None
     m.write_metrics.return_value = None
     m.get_oldest_timestamp.return_value = None
+    m.get_newest_timestamp.return_value = None
     m.has_data_for_date.return_value = False
     m.write_historical_prices.return_value = 0
     return m

--- a/app/tests/test_influxdb_writer.py
+++ b/app/tests/test_influxdb_writer.py
@@ -633,6 +633,9 @@ def test_get_newest_timestamp_orders_descending(writer, mock_client_cls):
     assert 'FROM "portfolio_metrics"' in q
     assert "share_symbol = 'AAPL'" in q
     assert "ORDER BY time DESC" in q
+    # Anchor on the newest price-bearing point so a price-less newer point can't
+    # make the forward pass skip an older missing price range.
+    assert "share_price IS NOT NULL" in q
     assert client.query.call_args.kwargs["language"] == "sql"
 
 

--- a/app/tests/test_influxdb_writer.py
+++ b/app/tests/test_influxdb_writer.py
@@ -587,6 +587,79 @@ def test_get_oldest_timestamp_query_targets_symbol_and_measurement(
 
 
 # --------------------------------------------------------------------------- #
+# get_newest_timestamp                                                         #
+# --------------------------------------------------------------------------- #
+def test_get_newest_timestamp_returns_datetime(writer, mock_client_cls):
+    client = mock_client_cls.return_value
+    df = pd.DataFrame({"time": [pd.Timestamp("2020-01-02T03:04:05Z")]})
+    client.query.return_value = FakeTable(df)
+
+    result = writer.get_newest_timestamp("AAPL")
+
+    assert isinstance(result, datetime)
+    assert result == datetime(2020, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+
+def test_get_newest_timestamp_plain_datetime_passthrough(writer, mock_client_cls):
+    client = mock_client_cls.return_value
+    plain = datetime(2019, 9, 9, tzinfo=timezone.utc)
+    df = pd.DataFrame({"time": pd.Series([plain], dtype="object")})
+    client.query.return_value = FakeTable(df)
+
+    assert writer.get_newest_timestamp("AAPL") == plain
+
+
+def test_get_newest_timestamp_empty_returns_none(writer, mock_client_cls):
+    client = mock_client_cls.return_value
+    client.query.return_value = FakeTable(pd.DataFrame({"time": []}), length=0)
+
+    assert writer.get_newest_timestamp("AAPL") is None
+
+
+def test_get_newest_timestamp_exception_returns_none(writer, mock_client_cls):
+    client = mock_client_cls.return_value
+    client.query.side_effect = RuntimeError("db down")
+
+    assert writer.get_newest_timestamp("AAPL") is None
+
+
+def test_get_newest_timestamp_orders_descending(writer, mock_client_cls):
+    client = mock_client_cls.return_value
+    client.query.return_value = FakeTable(pd.DataFrame({"time": []}), length=0)
+
+    writer.get_newest_timestamp("AAPL")
+
+    q = _last_query(client)
+    assert 'FROM "portfolio_metrics"' in q
+    assert "share_symbol = 'AAPL'" in q
+    assert "ORDER BY time DESC" in q
+    assert client.query.call_args.kwargs["language"] == "sql"
+
+
+def test_get_newest_timestamp_scopes_by_account(writer, mock_client_cls):
+    client = mock_client_cls.return_value
+    client.query.return_value = FakeTable(pd.DataFrame({"time": []}), length=0)
+
+    writer.get_newest_timestamp("AAPL", account="pea")
+
+    q = _last_query(client)
+    # Scoped like get_oldest_timestamp: COALESCE keeps pre-tag NULL points as
+    # 'default' rather than dropping them with a bare WHERE account = ...
+    assert "COALESCE(account, 'default') = 'pea'" in q
+
+
+def test_get_newest_timestamp_escapes_single_quote(writer, mock_client_cls):
+    client = mock_client_cls.return_value
+    client.query.return_value = FakeTable(pd.DataFrame({"time": []}), length=0)
+
+    writer.get_newest_timestamp("O'Reilly")
+
+    q = _last_query(client)
+    assert "share_symbol = 'O''Reilly'" in q
+    assert "'O'Reilly'" not in q
+
+
+# --------------------------------------------------------------------------- #
 # has_data_for_date                                                            #
 # --------------------------------------------------------------------------- #
 def test_has_data_for_date_true_when_count_positive(writer, mock_client_cls):

--- a/app/tests/test_metrics.py
+++ b/app/tests/test_metrics.py
@@ -433,6 +433,120 @@ def test_backfill_write_failure_does_not_abort_remaining_shares(
     assert symbols_written == ["AAPL", "MSFT"]
 
 
+# ---------------------------------------------------------------------------
+# backfill — forward gap-fill pass (issue #627)
+# ---------------------------------------------------------------------------
+
+def test_backfill_forward_fills_recent_gap(mock_influx, shares_validator, mocker):
+    """A session missed while down (old newest) is recovered by the forward pass,
+    carrying the same tags/account as live points, even when the backward pass is
+    already complete (the two directions are independent)."""
+    first_buy = date(2024, 1, 15)
+    metrics, _ = _build_metrics(
+        [_valid_shares("AAPL", "Apple")], mock_influx, shares_validator,
+        mode="events", first_buy_dates={"AAPL": first_buy}, events=None)
+    metrics._share_info_cache["AAPL"] = {
+        "currency": "USD", "exchange": "NMS", "quoteType": "EQUITY"}
+    metrics.backfill_chunk_days = 365
+    # Backward already complete -> only the forward pass should act.
+    metrics._backfill_complete[("AAPL", "default")] = datetime(
+        2024, 1, 15, tzinfo=timezone.utc)
+    # Newest stored point is old enough to leave a gap to fill up to now.
+    mock_influx.get_newest_timestamp.return_value = datetime(
+        2024, 6, 1, tzinfo=timezone.utc)
+    canned = [{"timestamp": datetime(2024, 6, 3, tzinfo=timezone.utc), "price": 175.0}]
+    mocker.patch.object(metrics, "_fetch_historical_data", return_value=canned)
+    mock_influx.write_historical_prices.return_value = 1
+
+    metrics.backfill()
+
+    # Backward complete -> its oldest lookup is never issued; forward drives it.
+    mock_influx.get_oldest_timestamp.assert_not_called()
+    mock_influx.get_newest_timestamp.assert_called_once_with("AAPL", account="default")
+    mock_influx.write_historical_prices.assert_called_once()
+    kwargs = mock_influx.write_historical_prices.call_args.kwargs
+    assert kwargs["share_symbol"] == "AAPL"
+    assert kwargs["account"] == "default"
+    assert kwargs["share_currency"] == "USD"
+    assert kwargs["share_exchange"] == "NMS"
+    assert kwargs["prices"] == canned
+
+
+def test_backfill_forward_empty_window_writes_nothing(
+        mock_influx, shares_validator, mocker):
+    """A weekend/holiday gap: yfinance returns no rows for the forward window, so
+    nothing is written (self-classifying, no calendar logic)."""
+    first_buy = date(2024, 1, 15)
+    metrics, _ = _build_metrics(
+        [_valid_shares("AAPL", "Apple")], mock_influx, shares_validator,
+        mode="events", first_buy_dates={"AAPL": first_buy}, events=None)
+    metrics._share_info_cache["AAPL"] = {
+        "currency": "USD", "exchange": "NMS", "quoteType": "EQUITY"}
+    metrics.backfill_chunk_days = 365
+    metrics._backfill_complete[("AAPL", "default")] = datetime(
+        2024, 1, 15, tzinfo=timezone.utc)
+    mock_influx.get_newest_timestamp.return_value = datetime(
+        2024, 6, 1, tzinfo=timezone.utc)
+    # yfinance returns no rows for the window -> empty, a no-op.
+    mocker.patch.object(metrics, "_fetch_historical_data", return_value=[])
+    mocker.patch("main.time.sleep")
+
+    metrics.backfill()
+
+    mock_influx.write_historical_prices.assert_not_called()
+
+
+def test_backfill_forward_noop_when_series_empty(
+        mock_influx, shares_validator, mocker):
+    """No stored point yet (newest None): the forward pass has no anchor and the
+    backward pass owns seeding the series, so no forward fetch happens."""
+    first_buy = date(2024, 1, 15)
+    metrics, _ = _build_metrics(
+        [_valid_shares("AAPL", "Apple")], mock_influx, shares_validator,
+        mode="events", first_buy_dates={"AAPL": first_buy}, events=None)
+    metrics._share_info_cache["AAPL"] = {
+        "currency": "USD", "exchange": "NMS", "quoteType": "EQUITY"}
+    metrics.backfill_chunk_days = 365
+    metrics._backfill_complete[("AAPL", "default")] = datetime(
+        2024, 1, 15, tzinfo=timezone.utc)
+    mock_influx.get_newest_timestamp.return_value = None
+    fetch = mocker.patch.object(metrics, "_fetch_historical_data", return_value=[])
+
+    metrics.backfill()
+
+    fetch.assert_not_called()
+    mock_influx.write_historical_prices.assert_not_called()
+
+
+def test_backfill_runs_both_directions_in_one_cycle(
+        mock_influx, shares_validator, mocker):
+    """When both an older gap (backward) and a recent gap (forward) exist, a
+    single cycle fills both for the same symbol."""
+    first_buy = date(2024, 1, 15)
+    metrics, _ = _build_metrics(
+        [_valid_shares("AAPL", "Apple")], mock_influx, shares_validator,
+        mode="events", first_buy_dates={"AAPL": first_buy}, events=None)
+    metrics._share_info_cache["AAPL"] = {
+        "currency": "USD", "exchange": "NMS", "quoteType": "EQUITY"}
+    metrics.backfill_chunk_days = 365
+    # Oldest after first BUY -> a backward gap; newest old -> a forward gap.
+    mock_influx.get_oldest_timestamp.return_value = datetime(
+        2024, 6, 1, tzinfo=timezone.utc)
+    mock_influx.get_newest_timestamp.return_value = datetime(
+        2024, 6, 10, tzinfo=timezone.utc)
+    canned = [{"timestamp": datetime(2024, 6, 3, tzinfo=timezone.utc), "price": 170.0}]
+    mocker.patch.object(metrics, "_fetch_historical_data", return_value=canned)
+    mocker.patch("main.time.sleep")
+    mock_influx.write_historical_prices.return_value = 1
+
+    metrics.backfill()
+
+    # One write for the backward chunk, one for the forward chunk.
+    assert mock_influx.write_historical_prices.call_count == 2
+    # Backward pass never marked complete (the older gap remains open).
+    assert ("AAPL", "default") not in metrics._backfill_complete
+
+
 def test_backfill_empty_window_marks_complete(mock_influx, shares_validator, mocker):
     first_buy = date(2024, 1, 15)
     metrics, _ = _build_metrics(

--- a/app/tests/test_scheduling.py
+++ b/app/tests/test_scheduling.py
@@ -14,6 +14,7 @@ import pytest
 import scheduling
 from scheduling import (
     decide, extract_market_context, perf_should_run, compute_pool_size,
+    forward_backfill_window,
     SHORT_RETRY, MAX_SLEEP, FAILURE_GRACE, POOL_CAP)
 
 
@@ -394,3 +395,58 @@ def test_compute_pool_size_missing_exchange_entry_is_solo():
 def test_compute_pool_size_ignores_shares_without_symbol():
     shares = [{"symbol": "AAA"}, {"name": "no symbol"}, {"symbol": None}]
     assert compute_pool_size("manual", shares, {"AAA": "NMS"}) == 2  # 1 + 1
+
+
+# ---------------------------------------------------------------------------
+# forward_backfill_window — forward gap-fill window sizing (#627/#626)
+# ---------------------------------------------------------------------------
+
+def test_forward_window_fresh_gap_fills_to_now():
+    # A missed session: newest is 2 days back, a large chunk covers it in one
+    # window, so end lands exactly on now.
+    newest = NOW - timedelta(days=2)
+    assert forward_backfill_window(newest, NOW, chunk_days=365) == (newest, NOW)
+
+
+def test_forward_window_no_gap_returns_none():
+    # newest == now (freshly written): nothing to recover.
+    assert forward_backfill_window(NOW, NOW, chunk_days=365) is None
+
+
+def test_forward_window_sub_day_gap_is_noop_during_live_trading():
+    # The live REGULAR writer keeps newest ≈ now; a sub-day window (e.g. a
+    # weekend that has only just begun) is skipped by the < 1 day guard so the
+    # forward pass never races the seam.
+    newest = NOW - timedelta(hours=6)
+    assert forward_backfill_window(newest, NOW, chunk_days=365) is None
+
+
+def test_forward_window_multi_chunk_long_gap_advances_one_chunk():
+    # An 800-day gap with a 365-day chunk: only the first chunk this cycle, end
+    # capped at newest + chunk_days (< now), advancing forward next cycles.
+    newest = NOW - timedelta(days=800)
+    start, end = forward_backfill_window(newest, NOW, chunk_days=365)
+    assert start == newest
+    assert end == newest + timedelta(days=365)
+    assert end < NOW
+
+
+def test_forward_window_none_newest_returns_none():
+    # Empty series: the backward pass owns seeding it, the forward pass has no
+    # anchor.
+    assert forward_backfill_window(None, NOW, chunk_days=365) is None
+
+
+def test_forward_window_naive_newest_is_coerced_utc():
+    # A naive newest (defensive) must not raise on the now - newest subtraction.
+    newest_naive = (NOW - timedelta(days=3)).replace(tzinfo=None)
+    start, end = forward_backfill_window(newest_naive, NOW, chunk_days=365)
+    assert start == NOW - timedelta(days=3)
+    assert end == NOW
+
+
+def test_forward_window_clock_skew_returns_none():
+    # now before newest (clock skew) yields a negative delta → skipped, not a
+    # backwards window.
+    newest = NOW + timedelta(days=1)
+    assert forward_backfill_window(newest, NOW, chunk_days=365) is None


### PR DESCRIPTION
## Résumé

Implémente le **forward gap-fill** du backfill bidirectionnel (issue #627, slice 1 de #626). Le backfill ne parcourait que le passé (oldest → premier BUY) puis marquait la série `complete` ; toute indisponibilité pendant une session `REGULAR` laissait donc un trou permanent. Cette PR ajoute une **passe forward indépendante** sur `[newest, now]` qui **délègue le calendrier à yfinance** (aucune logique de jours fériés/week-ends).

Contexte détaillé : issue #626 (décisions verrouillées).

## Changements

- **`influxdb_writer.py`** — `get_newest_timestamp(symbol, account)`, miroir de `get_oldest_timestamp` (`ORDER BY time DESC`), même scoping `COALESCE(account, 'default')`.
- **`scheduling.py`** — `forward_backfill_window(newest, now, chunk_days)`, fonction **pure** (`now` injecté, sans InfluxDB/yfinance). Réutilise le garde-fou `< 1 jour` → **no-op pendant le trading live** (newest ≈ now, aucun doublon au raccord) ; chunké comme la passe backward.
- **`main.py`** — `backfill()` refactorisé en `_backfill_share` → `_backfill_backward` / `_backfill_forward`, avec les helpers partagés `_ensure_share_info`, `_enrich_and_write`, `_fetch_and_store`. Le watermark `_backfill_complete` ne gate **que** la passe backward ; les deux directions sont indépendantes. Les points récupérés portent les mêmes tags/identité de série que les points live, donc `holdings_value` (perf) les reprend au prochain recompute.

## Tests

- `forward_backfill_window` : fresh gap, no gap, sous-jour/live, multi-chunk, newest None, tz naïf, clock-skew.
- `get_newest_timestamp` : retour, empty, exception, `ORDER BY DESC`, scoping account, échappement quotes.
- Intégration backfill : comblement d'un gap récent, fenêtre vide = no-op, série vide = no-op, deux directions dans un même cycle.
- **439 tests passent**, **flake8 propre**. Comportement backward-pass et `_backfill_complete` inchangés.

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq4dzKFBnKwmEfr4UouXhr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added forward gap-filling to recover recent missing market data using a “newest stored timestamp” anchor.
  * Enhanced backfill to run independent backward (older gaps) and forward (recent gaps) passes per share.
* **Bug Fixes**
  * Prevent forward recovery during live trading or sub-day/no-gap windows, and handle clock-skew/timezone-naive anchors safely.
  * Improved enrichment/write flow so failures for one share don’t interrupt the full backfill.
* **Tests**
  * Expanded coverage for newest-timestamp lookup, forward window sizing, forward/backward backfill interactions, and error/edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->