### PR TITLE
feat(app): price-freshness liveness sonde (#628)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,20 @@ The application runs independent scheduled jobs on a single APScheduler:
   symbol off when non-closed cycles keep producing no writable price: the first
   3 failures still re-arm at `base_interval`, then the delay grows
   `base_interval × 2^(n−3)` capped at 24h, resetting to 0 on the first
-  successful write. Closed cycles never count as failures. There is no global
+  successful write. Closed cycles never count as failures. A **price-freshness
+  liveness sonde** (issue #628) rides the `REGULAR` write path: before each write
+  it reads the newest stored price for the (symbol, account) and advances the
+  pure `scheduling.price_freshness_step` against per-series memory
+  (`_sonde_state`). When the stored value stays frozen across *consecutive*
+  `REGULAR` cycles for at least `SB_STALENESS_HORIZON` (default 900s) while the
+  live quote moves, it emits a WARNING and raises the `sb_price_staleness` gauge.
+  Staleness is measured over consecutive polling, **not** the stored point's
+  wall-clock age — the writer advancing the value each cycle re-baselines, and a
+  polling gap wider than the horizon (overnight/weekend close) re-baselines too,
+  so the first tick after a close never fires a false positive (#628 acceptance).
+  Purely diagnostic — it never changes cadence, write gating, or the #617 backoff;
+  it catches a writer that fetches fine but persists *stale* values, which the
+  forward gap-fill (#627) can't see. There is no global
   scrape job. **Anti-herd (issue #619):** every arming offsets its `run_date` by
   a fresh `uniform(0, 30s)` jitter (the heir of the removed inter-share
   `time.sleep(1)`; a `date` trigger can't carry APScheduler's own `jitter`), so a
@@ -269,6 +282,7 @@ If ingestion fails (invalid event, file error), the **previous valid configurati
 | `SB_BACKFILL_INTERVAL` | `60` | Backfill check interval (seconds) |
 | `SB_BACKFILL_DELAY` | `10` | Delay between yfinance requests (seconds) |
 | `SB_BACKFILL_CHUNK_DAYS` | `365` | Days of history per backfill request |
+| `SB_STALENESS_HORIZON` | `900` | Price-freshness liveness sonde horizon (seconds): during `REGULAR`, flag a symbol whose stored price stays frozen this long across consecutive polling cycles while the live quote moves (issue #628). Diagnostic only — never changes cadence/write gating/#617 backoff. `0` disables the sonde. |
 | `SB_CONFIG_MODE` | `manual` | Configuration mode (`manual` or `events`) |
 | `SB_PROMETHEUS_ENABLED` | `true` | Expose the legacy Prometheus `/metrics` endpoint |
 | `SB_METRICS_PORT` | `8081` | Port for the Prometheus `/metrics` endpoint |
@@ -304,7 +318,11 @@ Gauges (prefix `sb_`, labels `share_name`/`share_symbol`/`account`): `sb_share_p
 `sb_purchased_quantity`, `sb_purchased_price`, `sb_purchased_fee`,
 `sb_owned_quantity`, `sb_received_dividend`, `sb_dividend_yield`, `sb_pe_ratio`,
 `sb_market_cap`, `sb_volume`, plus `sb_share_info` (value `1`, with extra labels
-`share_currency`/`share_exchange`/`quote_type`).
+`share_currency`/`share_exchange`/`quote_type`). `sb_price_staleness` is the
+price-freshness liveness sonde (issue #628): `1` when a symbol's stored price is
+silently stale (frozen past `SB_STALENESS_HORIZON` during `REGULAR` while the
+live quote moves), `0` otherwise — a gauge so it auto-clears when the writer
+recovers.
 
 ## InfluxDB Data Model
 

--- a/app/src/influxdb_writer.py
+++ b/app/src/influxdb_writer.py
@@ -276,6 +276,24 @@ class InfluxDBWriter:
 
         return len(points)
 
+    @staticmethod
+    def _symbol_account_where(share_symbol: str, account: Optional[str]) -> str:
+        """Build the shared ``share_symbol [+ account]`` SQL WHERE clause.
+
+        Escapes single quotes so ``share_symbol``/``account`` stay safe string
+        literals, and scopes by ``COALESCE(account, 'default')`` when an account
+        is given — so points written before the account tag existed count as
+        'default' rather than being dropped by a bare ``WHERE account = ...``.
+        Shared by the oldest/newest lookups so the escaping + COALESCE rule lives
+        in one place.
+        """
+        safe_symbol = share_symbol.replace("'", "''")
+        where = f"share_symbol = '{safe_symbol}'"
+        if account is not None:
+            safe_account = account.replace("'", "''")
+            where += f" AND COALESCE(account, 'default') = '{safe_account}'"
+        return where
+
     def get_oldest_timestamp(
         self, share_symbol: str, account: Optional[str] = None
     ) -> Optional[datetime]:
@@ -296,12 +314,7 @@ class InfluxDBWriter:
         if self._client is None:
             self.connect()
 
-        # Escape single quotes to keep share_symbol a safe SQL string literal
-        safe_symbol = share_symbol.replace("'", "''")
-        where = f"share_symbol = '{safe_symbol}'"
-        if account is not None:
-            safe_account = account.replace("'", "''")
-            where += f" AND COALESCE(account, 'default') = '{safe_account}'"
+        where = self._symbol_account_where(share_symbol, account)
         # Use SQL query for InfluxDB 3
         query = f"""
         SELECT time
@@ -359,12 +372,7 @@ class InfluxDBWriter:
         if self._client is None:
             self.connect()
 
-        # Escape single quotes to keep share_symbol a safe SQL string literal
-        safe_symbol = share_symbol.replace("'", "''")
-        where = f"share_symbol = '{safe_symbol}'"
-        if account is not None:
-            safe_account = account.replace("'", "''")
-            where += f" AND COALESCE(account, 'default') = '{safe_account}'"
+        where = self._symbol_account_where(share_symbol, account)
         # Use SQL query for InfluxDB 3
         query = f"""
         SELECT time
@@ -386,6 +394,45 @@ class InfluxDBWriter:
                     return ts
         except Exception as e:
             logger.error(f"Error querying newest timestamp for {share_symbol}: {e}")
+
+        return None
+
+    def get_newest_price(
+        self, share_symbol: str, account: Optional[str] = None
+    ) -> Optional[float]:
+        """Return the newest stored ``share_price`` for a series, or ``None``.
+
+        Used by the price-freshness liveness sonde (issue #628): the sonde
+        compares the newest stored price *value* against the live quote across
+        consecutive ``REGULAR`` cycles to catch a writer that fetches fine but
+        persists stale values. Anchors on the newest **price-bearing** point
+        (``share_price IS NOT NULL``) and scopes by ``share_symbol`` + ``account``
+        exactly like ``get_newest_timestamp``.
+
+        Returns ``None`` when the series has no price-bearing point (or the query
+        fails — the sonde is diagnostic, a read error must never surface).
+        """
+        if self._client is None:
+            self.connect()
+
+        where = self._symbol_account_where(share_symbol, account)
+        # Use SQL query for InfluxDB 3
+        query = f"""
+        SELECT share_price
+        FROM "{self.MEASUREMENT}"
+        WHERE {where} AND share_price IS NOT NULL
+        ORDER BY time DESC
+        LIMIT 1
+        """
+
+        try:
+            table = self._client.query(query=query, language="sql")
+            if table and len(table) > 0:
+                df = table.to_pandas()
+                if not df.empty:
+                    return float(df.iloc[0]['share_price'])
+        except Exception as e:
+            logger.error(f"Error querying newest price for {share_symbol}: {e}")
 
         return None
 

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -495,6 +495,15 @@ class SuiviBourseMetrics:
         self.backfill_delay = int(os.getenv('SB_BACKFILL_DELAY', '10'))
         self.backfill_chunk_days = int(os.getenv('SB_BACKFILL_CHUNK_DAYS', '365'))
 
+        # Price-freshness liveness sonde horizon (issue #628, design #626). The
+        # staleness signal fires only once the newest stored price has gone
+        # unrefreshed for at least this many seconds while the live quote moves;
+        # a few REGULAR cycles wide by default so an ordinary tick never trips it.
+        # ``0`` (or negative) disables the sonde — the pure decision returns
+        # False and the check no-ops.
+        self.staleness_horizon = int(
+            os.getenv('SB_STALENESS_HORIZON', str(scheduling.STALENESS_HORIZON)))
+
         # Market-aware per-symbol scheduling (issue #616). Each held symbol runs
         # as its own self-rescheduling APScheduler job; the scheduler is injected
         # from __main__ (None until then, so unit tests that never wire it skip
@@ -542,6 +551,16 @@ class SuiviBourseMetrics:
         self._perf_dirty_from: Optional[date] = None
         self._perf_last_events: Optional[List] = None
         self._perf_dirty_live: bool = True
+
+        # Price-freshness liveness sonde state (issue #628). Per-(symbol, account)
+        # memory so staleness is measured over *consecutive* REGULAR polling, not
+        # the raw wall-clock age of the stored point (which can't tell a stuck
+        # writer from a normal overnight/weekend close). Each (symbol, account) is
+        # touched only by its own single scrape job (one job per symbol,
+        # max_instances=1), but the dict is guarded for parity with the other
+        # cross-thread scrape state.
+        self._sonde_lock = threading.Lock()
+        self._sonde_state: Dict[Tuple[str, str], scheduling.SondeState] = {}
 
     def validate(self) -> bool:
         """
@@ -920,6 +939,57 @@ class SuiviBourseMetrics:
                 with self._failure_counts_lock:
                     self._failure_counts.pop(symbol, None)
 
+    def _check_price_freshness(self, holdings: List[dict], live_price,
+                               now: datetime) -> None:
+        """Price-freshness liveness sonde (issue #628, design #626).
+
+        Runs only on the ``REGULAR`` write path (the caller's ``should_write``
+        gate): for each (symbol, account) holding, read the newest stored price
+        and advance the pure ``scheduling.price_freshness_step`` against this
+        series' remembered state. When the stored price has stayed frozen across
+        consecutive ``REGULAR`` cycles for at least ``staleness_horizon`` while
+        the live quote has moved, the writer is silently stale — emit a WARNING
+        and raise the ``sb_price_staleness`` gauge (cleared to 0 otherwise so it
+        auto-recovers). Measuring over consecutive polling (not the stored
+        point's raw age) is what keeps the first tick after an overnight/weekend
+        close — legitimately hours old — from firing a false positive.
+
+        **Diagnostic only** — never changes scrape cadence, write gating, or the
+        #617 dead-ticker backoff. Fully guarded: a read or metric error here must
+        never disturb the surrounding scrape cycle (the sonde complements #617
+        from the monitoring side, it is not part of the writer's control flow).
+        Called *before* this cycle's write so it reads the coverage as it stood,
+        not the point the write is about to refresh.
+        """
+        if self.staleness_horizon <= 0:
+            return
+        for share in holdings:
+            symbol = share['symbol']
+            account = share.get('account', DEFAULT_ACCOUNT)
+            key = (symbol, account)
+            try:
+                stored_price = self.influxdb.get_newest_price(symbol, account=account)
+                with self._sonde_lock:
+                    new_state, stale = scheduling.price_freshness_step(
+                        self._sonde_state.get(key), live_price, stored_price,
+                        now, self.staleness_horizon)
+                    if new_state is None:
+                        self._sonde_state.pop(key, None)
+                    else:
+                        self._sonde_state[key] = new_state
+
+                if stale:
+                    app_logger.warning(
+                        f"Price-freshness sonde: stored price for {share['name']} "
+                        f"({symbol}, account={account}) frozen at {stored_price} "
+                        f"across REGULAR polling while the live quote is "
+                        f"{live_price} — the writer may be silently stale")
+                if self.prometheus is not None:
+                    self.prometheus.update_price_staleness(share, stale)
+            except Exception as e:
+                app_logger.debug(
+                    f"Price-freshness sonde failed for {symbol}: {e}")
+
     def _scrape_symbol(self, symbol: str, now: Optional[datetime] = None) -> None:
         """Scrape one symbol, gate the write, and re-arm the job (design #602).
 
@@ -966,6 +1036,11 @@ class SuiviBourseMetrics:
                 self._failure_counts.pop(symbol, None)
 
         if should_write:
+            # Price-freshness liveness sonde (issue #628): read the stored price
+            # *before* this cycle's write refreshes it, so a silently stale writer
+            # is caught. Purely diagnostic — never gates the write below.
+            self._check_price_freshness(holdings, last_quote, now)
+
             wrote_live_data = False
             for share in holdings:
                 wrote = self._write_share_metrics(share, last_quote, info)

--- a/app/src/prometheus_exporter.py
+++ b/app/src/prometheus_exporter.py
@@ -68,6 +68,13 @@ class PrometheusExporter:
         self.volume = Gauge(
             "sb_volume", "Trading volume of the share", COMMON_LABELS,
             registry=self.registry)
+        # Price-freshness liveness sonde (issue #628). 1 when the stored price is
+        # silently stale (frozen past the horizon while the live quote moves), 0
+        # when fresh — a gauge so it auto-clears when the writer recovers.
+        self.price_staleness = Gauge(
+            "sb_price_staleness",
+            "1 when the stored price is silently stale while the live quote moves",
+            COMMON_LABELS, registry=self.registry)
 
         # Per-account cash & value gauges (opt-in accounts feature). Labelled by
         # account so each account is its own series.
@@ -162,6 +169,17 @@ class PrometheusExporter:
             self.market_cap.labels(*labels).set(info['marketCap'])
         if info.get('volume') is not None:
             self.volume.labels(*labels).set(info['volume'])
+
+    def update_price_staleness(self, share: dict, stale: bool) -> None:
+        """Set the price-freshness sonde gauge for one share (issue #628).
+
+        Diagnostic only: ``1`` flags a silently stale writer for
+        (share_name, share_symbol, account), ``0`` clears it once the stored
+        price tracks the live quote again.
+        """
+        account = share.get('account', DEFAULT_ACCOUNT)
+        labels = (share['name'], share['symbol'], account)
+        self.price_staleness.labels(*labels).set(1 if stale else 0)
 
     def update_account(self, point) -> None:
         """Update the per-account gauges from a computed account_metrics point.

--- a/app/src/scheduling.py
+++ b/app/src/scheduling.py
@@ -12,8 +12,8 @@ testable against dicts and an injected clock (issue #616, design #602-#609).
 """
 
 from datetime import datetime, timedelta, timezone
-from math import ceil
-from typing import Dict, List, Optional, Tuple
+from math import ceil, isclose
+from typing import Dict, List, NamedTuple, Optional, Tuple
 
 try:  # zoneinfo is stdlib on 3.9+; no new dependency (design #602/#603).
     from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -192,6 +192,96 @@ def forward_backfill_window(
         return None
     end = min(newest + timedelta(days=chunk_days), now)
     return newest, end
+
+
+# Price-freshness sonde default horizon (issue #628, design #626). The operator
+# dial ``SB_STALENESS_HORIZON`` (main.py) overrides it; the default is a few
+# ``REGULAR`` poll cycles wide so an ordinary tick never trips the sonde.
+STALENESS_HORIZON = 900  # s
+
+# Relative tolerance for "the stored price is unchanged". A live quote differing
+# by more than this fraction has *moved*; anything within it is treated as the
+# same price (a genuinely flat quote is not a stuck writer).
+_STALENESS_REL_TOL = 1e-9
+
+
+class SondeState(NamedTuple):
+    """The price-freshness sonde's per-(symbol, account) memory (issue #628).
+
+    Carried across ``REGULAR`` cycles by the caller so staleness is measured over
+    *consecutive polling*, not the raw wall-clock age of the stored point:
+
+      * ``stored_price`` — the newest stored price observed last cycle, to detect
+        whether the writer advanced it since.
+      * ``frozen_since`` — when the stored price was first seen frozen (the anchor
+        the horizon is measured from).
+      * ``last_seen`` — when the sonde last ran for this series, to detect a break
+        in consecutive polling (a market-closed gap) and re-baseline across it.
+    """
+    stored_price: float
+    frozen_since: datetime
+    last_seen: datetime
+
+
+def price_freshness_step(
+    prev: Optional[SondeState], live_price: Optional[float],
+    stored_price: Optional[float], now: datetime, horizon: float,
+) -> Tuple[Optional[SondeState], bool]:
+    """Advance the price-freshness liveness sonde one ``REGULAR`` cycle (#628/#626).
+
+    Pure and stateful-by-value — no InfluxDB / yfinance, ``now`` injected,
+    ``prev`` fed back in from last cycle — so the "is the writer silently stale"
+    call is unit-testable in isolation. This is the repurposed price-diff,
+    shipped as **observability**, not as a backfill trigger: the time-window
+    forward pass (#627) can't see a writer that fetches fine but persists a frozen
+    value because it believes coverage reaches ``now``.
+
+    **Why memory instead of the stored point's raw age.** A healthy writer
+    advances the newest stored price *every* ``REGULAR`` cycle, so "the newest
+    stored value stopped advancing across *consecutive* cycles" is the true
+    stuck-writer signal. Measuring the horizon over consecutive observations —
+    not the wall-clock age of the stored point — is what stops the **first tick
+    after an overnight/weekend close** from firing a false positive: the market
+    being shut writes nothing (#606), so that morning point is legitimately hours
+    old, yet the writer is fine. Age alone can't tell the two apart; consecutive
+    observation can. Two guards make it robust:
+
+      * **value advanced** (or first observation) → the writer is persisting:
+        re-baseline ``frozen_since = now``, no signal. In the healthy case the
+        last-of-session write advanced the value beyond the sonde's last
+        observation, so the morning cycle sees a change and re-baselines.
+      * **polling gap wider than the horizon** (``now − last_seen > horizon``) →
+        the market was closed in between, so accrued frozen time can't be trusted:
+        re-baseline, no signal. A genuinely stuck writer polls every
+        ``base_interval`` (≪ horizon) and never trips this.
+
+    Otherwise, with the stored value unchanged across consecutive polling, the
+    signal fires (``stale=True``) iff the live quote has **moved** away from it
+    (``not isclose``) *and* it has stayed frozen for at least ``horizon`` seconds.
+    A flat live quote is a genuinely flat market, not a stuck writer — no signal
+    (the accepted false-negative called out in #626).
+
+    Returns ``(new_state, stale)``; a ``None`` new-state means "forget this
+    series" (sonde disabled or empty series). Diagnostic only: the caller must
+    never let this change scrape cadence, write gating, or the #617 backoff.
+    """
+    if horizon <= 0 or stored_price is None:
+        return None, False
+
+    value_advanced = prev is None or not isclose(
+        prev.stored_price, stored_price, rel_tol=_STALENESS_REL_TOL, abs_tol=0.0)
+    polling_broke = prev is not None and (
+        now - prev.last_seen).total_seconds() > horizon
+    if value_advanced or polling_broke:
+        # Writer advanced the value, or consecutive polling broke (market closed)
+        # — re-baseline the frozen anchor to now, emit nothing.
+        return SondeState(stored_price, now, now), False
+
+    frozen_since = prev.frozen_since
+    moved = live_price is not None and not isclose(
+        live_price, stored_price, rel_tol=_STALENESS_REL_TOL, abs_tol=0.0)
+    stale = moved and (now - frozen_since).total_seconds() >= horizon
+    return SondeState(stored_price, frozen_since, now), stale
 
 
 def compute_pool_size(mode: str, shares: List[dict],

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -120,6 +120,9 @@ def mock_influx(mocker):
     m.write_metrics.return_value = None
     m.get_oldest_timestamp.return_value = None
     m.get_newest_timestamp.return_value = None
+    # None → the price-freshness sonde (#628) has no stored price to anchor on,
+    # so it forgets state and never flags.
+    m.get_newest_price.return_value = None
     m.has_data_for_date.return_value = False
     m.write_historical_prices.return_value = 0
     return m

--- a/app/tests/test_influxdb_writer.py
+++ b/app/tests/test_influxdb_writer.py
@@ -663,6 +663,63 @@ def test_get_newest_timestamp_escapes_single_quote(writer, mock_client_cls):
 
 
 # --------------------------------------------------------------------------- #
+# get_newest_price (price-freshness liveness sonde, #628)                     #
+# --------------------------------------------------------------------------- #
+def test_get_newest_price_returns_float(writer, mock_client_cls):
+    client = mock_client_cls.return_value
+    client.query.return_value = FakeTable(pd.DataFrame({"share_price": [185.5]}))
+
+    price = writer.get_newest_price("AAPL")
+
+    assert price == 185.5
+    assert isinstance(price, float)
+
+
+def test_get_newest_price_empty_returns_none(writer, mock_client_cls):
+    client = mock_client_cls.return_value
+    client.query.return_value = FakeTable(
+        pd.DataFrame({"share_price": []}), length=0)
+
+    assert writer.get_newest_price("AAPL") is None
+
+
+def test_get_newest_price_exception_returns_none(writer, mock_client_cls):
+    client = mock_client_cls.return_value
+    client.query.side_effect = RuntimeError("db down")
+
+    # Diagnostic-only sonde: a read error must never surface.
+    assert writer.get_newest_price("AAPL") is None
+
+
+def test_get_newest_price_query_shape(writer, mock_client_cls):
+    client = mock_client_cls.return_value
+    client.query.return_value = FakeTable(
+        pd.DataFrame({"share_price": []}), length=0)
+
+    writer.get_newest_price("AAPL", account="pea")
+
+    q = _last_query(client)
+    assert 'FROM "portfolio_metrics"' in q
+    assert "share_symbol = 'AAPL'" in q
+    assert "ORDER BY time DESC" in q
+    # Anchor on a price-bearing point and scope by account like get_newest_timestamp.
+    assert "share_price IS NOT NULL" in q
+    assert "COALESCE(account, 'default') = 'pea'" in q
+    assert client.query.call_args.kwargs["language"] == "sql"
+
+
+def test_get_newest_price_escapes_single_quote(writer, mock_client_cls):
+    client = mock_client_cls.return_value
+    client.query.return_value = FakeTable(
+        pd.DataFrame({"share_price": []}), length=0)
+
+    writer.get_newest_price("O'Reilly")
+
+    q = _last_query(client)
+    assert "share_symbol = 'O''Reilly'" in q
+
+
+# --------------------------------------------------------------------------- #
 # has_data_for_date                                                            #
 # --------------------------------------------------------------------------- #
 def test_has_data_for_date_true_when_count_positive(writer, mock_client_cls):

--- a/app/tests/test_prometheus_exporter.py
+++ b/app/tests/test_prometheus_exporter.py
@@ -52,7 +52,7 @@ def test_all_expected_gauges_are_registered(exporter):
         'sb_share_price', 'sb_purchased_quantity', 'sb_purchased_price',
         'sb_purchased_fee', 'sb_owned_quantity', 'sb_received_dividend',
         'sb_share_info', 'sb_dividend_yield', 'sb_pe_ratio', 'sb_market_cap',
-        'sb_volume',
+        'sb_volume', 'sb_price_staleness',
     ):
         assert f'# HELP {name} ' in text
 
@@ -109,6 +109,27 @@ def test_same_symbol_in_two_accounts_produces_distinct_series(exporter):
         'share_name': 'Apple', 'share_symbol': 'AAPL', 'account': 'PEA'}) == 10.0
     assert exporter.registry.get_sample_value('sb_owned_quantity', {
         'share_name': 'Apple', 'share_symbol': 'AAPL', 'account': 'CTO'}) == 5.0
+
+
+# --- price-freshness sonde (#628) -------------------------------------------
+
+def test_update_price_staleness_sets_one_when_stale(exporter):
+    exporter.update_price_staleness(_share(), True)
+    assert _val(exporter, 'sb_price_staleness') == 1
+
+
+def test_update_price_staleness_clears_to_zero_when_fresh(exporter):
+    # A gauge: it clears when the writer recovers.
+    exporter.update_price_staleness(_share(), True)
+    exporter.update_price_staleness(_share(), False)
+    assert _val(exporter, 'sb_price_staleness') == 0
+
+
+def test_price_staleness_labelled_per_account(exporter):
+    pea = dict(_share(), account='PEA')
+    exporter.update_price_staleness(pea, True)
+    assert exporter.registry.get_sample_value('sb_price_staleness', {
+        'share_name': 'Apple', 'share_symbol': 'AAPL', 'account': 'PEA'}) == 1
 
 
 # --- None handling ----------------------------------------------------------

--- a/app/tests/test_scheduling.py
+++ b/app/tests/test_scheduling.py
@@ -14,8 +14,8 @@ import pytest
 import scheduling
 from scheduling import (
     decide, extract_market_context, perf_should_run, compute_pool_size,
-    forward_backfill_window,
-    SHORT_RETRY, MAX_SLEEP, FAILURE_GRACE, POOL_CAP)
+    forward_backfill_window, price_freshness_step, SondeState,
+    SHORT_RETRY, MAX_SLEEP, FAILURE_GRACE, POOL_CAP, STALENESS_HORIZON)
 
 
 UTC = timezone.utc
@@ -450,3 +450,118 @@ def test_forward_window_clock_skew_returns_none():
     # backwards window.
     newest = NOW + timedelta(days=1)
     assert forward_backfill_window(newest, NOW, chunk_days=365) is None
+
+
+# ---------------------------------------------------------------------------
+# price_freshness_step — price-freshness liveness sonde (#628/#626)
+# ---------------------------------------------------------------------------
+
+HORIZON = 900
+
+
+def _step(prev, live, stored, now):
+    return price_freshness_step(prev, live, stored, now, HORIZON)
+
+
+def test_first_observation_baselines_and_never_flags():
+    # No prior state: baseline the frozen anchor, never flag on the first look.
+    state, stale = _step(None, live=191.0, stored=185.0, now=NOW)
+    assert stale is False
+    assert state == SondeState(185.0, NOW, NOW)
+
+
+def test_frozen_value_moved_quote_past_horizon_is_stale():
+    # Stored value unchanged across consecutive polling for >= horizon while the
+    # live quote has moved away from it: the writer is silently stale.
+    prev = SondeState(stored_price=185.0, frozen_since=NOW,
+                      last_seen=NOW + timedelta(seconds=450))
+    now = NOW + timedelta(seconds=HORIZON)
+    state, stale = _step(prev, live=191.0, stored=185.0, now=now)
+    assert stale is True
+    assert state == SondeState(185.0, NOW, now)  # anchor carried forward
+
+
+def test_frozen_but_within_horizon_is_not_stale():
+    # Unchanged and moved, but not frozen long enough yet: no false positive on
+    # an ordinary tick.
+    prev = SondeState(185.0, NOW, NOW)
+    now = NOW + timedelta(seconds=HORIZON - 1)
+    _state, stale = _step(prev, live=191.0, stored=185.0, now=now)
+    assert stale is False
+
+
+def test_value_advanced_rebaselines_and_is_not_stale():
+    # A healthy writer advances the stored value each cycle → re-baseline, never
+    # flag, however old the previous anchor.
+    prev = SondeState(185.0, NOW, NOW)
+    now = NOW + timedelta(seconds=HORIZON + 5000)
+    state, stale = _step(prev, live=191.0, stored=190.0, now=now)
+    assert stale is False
+    assert state == SondeState(190.0, now, now)
+
+
+def test_polling_gap_wider_than_horizon_rebaselines():
+    # The market-open-after-close fix: a break in consecutive polling wider than
+    # the horizon (overnight/weekend) re-baselines even with the value unchanged,
+    # so the first morning tick never fires a false positive (#628 acceptance).
+    prev = SondeState(185.0, NOW, NOW)
+    now = NOW + timedelta(hours=16)  # overnight gap, value still 185
+    state, stale = _step(prev, live=191.0, stored=185.0, now=now)
+    assert stale is False
+    assert state == SondeState(185.0, now, now)
+
+
+def test_flat_market_past_horizon_is_not_stale():
+    # Stored value frozen and old, but the live quote still matches it: a
+    # genuinely flat market, not a stuck writer (accepted #626 false-negative).
+    prev = SondeState(185.0, NOW, NOW + timedelta(seconds=450))
+    now = NOW + timedelta(seconds=HORIZON)
+    _state, stale = _step(prev, live=185.0, stored=185.0, now=now)
+    assert stale is False
+
+
+def test_flat_quote_within_tolerance_is_not_stale():
+    # A sub-epsilon float wobble on an otherwise flat price is "unchanged".
+    prev = SondeState(185.0, NOW, NOW + timedelta(seconds=450))
+    now = NOW + timedelta(seconds=HORIZON)
+    _state, stale = _step(prev, live=185.0 + 1e-9, stored=185.0, now=now)
+    assert stale is False
+
+
+def test_missing_live_quote_never_flags():
+    # No live quote to compare against → no signal (state still advances).
+    prev = SondeState(185.0, NOW, NOW + timedelta(seconds=450))
+    now = NOW + timedelta(seconds=HORIZON)
+    _state, stale = _step(prev, live=None, stored=185.0, now=now)
+    assert stale is False
+
+
+def test_empty_series_forgets_state_and_never_flags():
+    # No stored price yet (empty series): nothing to anchor on.
+    state, stale = _step(SondeState(185.0, NOW, NOW), live=191.0,
+                         stored=None, now=NOW + timedelta(seconds=HORIZON))
+    assert (state, stale) == (None, False)
+
+
+@pytest.mark.parametrize("horizon", [0, -1, -900])
+def test_non_positive_horizon_disables_sonde(horizon):
+    # A non-positive horizon turns the sonde off, even with a clearly stuck writer.
+    prev = SondeState(185.0, NOW, NOW)
+    state, stale = price_freshness_step(
+        prev, 191.0, 185.0, NOW + timedelta(seconds=10_000), horizon)
+    assert (state, stale) == (None, False)
+
+
+def test_at_exactly_horizon_counts_as_stale():
+    # frozen elapsed == horizon meets the ">= horizon" gate (inclusive boundary),
+    # with the polling gap itself not exceeding the horizon (so no re-baseline).
+    prev = SondeState(185.0, NOW, NOW)
+    now = NOW + timedelta(seconds=HORIZON)
+    _state, stale = _step(prev, live=191.0, stored=185.0, now=now)
+    assert stale is True
+
+
+def test_default_horizon_is_several_cycles_wide():
+    # The shipped default is comfortably wider than a REGULAR poll interval so an
+    # ordinary tick can't trip the sonde.
+    assert STALENESS_HORIZON >= 5 * BASE

--- a/app/tests/test_scheduling_wiring.py
+++ b/app/tests/test_scheduling_wiring.py
@@ -463,6 +463,140 @@ def test_prometheus_not_updated_when_fetch_fails(
 
 
 # ---------------------------------------------------------------------------
+# Price-freshness liveness sonde (#628) — diagnostic only
+# ---------------------------------------------------------------------------
+
+def test_sonde_flags_writer_frozen_across_consecutive_regular_cycles(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch, caplog):
+    """A writer whose stored price stays frozen across consecutive REGULAR cycles
+    for >= the horizon while the live quote moves → WARNING + gauge 1. The signal
+    needs a first cycle to baseline, then a later cycle past the horizon."""
+    prom = mocker.MagicMock()
+    m = _metrics([_share()], mock_influx, shares_validator, mocker, prometheus=prom)
+    m.staleness_horizon = 900
+    # Live close is 185.0 (fake_ticker default); stored value never advances.
+    mock_influx.get_newest_price.return_value = 180.0
+    monkeypatch.setattr(main.yf, "Ticker", lambda s: fake_ticker(market_state="REGULAR"))
+
+    # Cycle 1: baseline — no signal yet.
+    m._scrape_symbol("AAPL", now=NOW)
+    assert prom.update_price_staleness.call_args == mocker.call(m.shares[0], False)
+
+    # Cycle 2, one horizon later (gap not wider than the horizon): still frozen,
+    # quote moved → stale.
+    with caplog.at_level("WARNING"):
+        m._scrape_symbol("AAPL", now=NOW + timedelta(seconds=900))
+
+    assert any("Price-freshness sonde" in r.message and "AAPL" in r.message
+               for r in caplog.records)
+    assert prom.update_price_staleness.call_args == mocker.call(m.shares[0], True)
+    # Diagnostic only: writes and re-arms happened normally each cycle.
+    assert mock_influx.write_metrics.call_count == 2
+
+
+def test_sonde_no_false_positive_first_tick_after_close(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch):
+    """The market-open-after-close fix: a polling gap wider than the horizon
+    (overnight) re-baselines, so the first morning tick raises no signal even
+    though the stored point is legitimately hours old and the quote gapped."""
+    prom = mocker.MagicMock()
+    m = _metrics([_share()], mock_influx, shares_validator, mocker, prometheus=prom)
+    m.staleness_horizon = 900
+    mock_influx.get_newest_price.return_value = 180.0  # frozen value across the gap
+    monkeypatch.setattr(main.yf, "Ticker", lambda s: fake_ticker(market_state="REGULAR"))
+
+    # Yesterday's last REGULAR cycle baselines the series.
+    m._scrape_symbol("AAPL", now=NOW)
+    # This morning, 16h later (a break in consecutive polling): re-baseline, not stale.
+    m._scrape_symbol("AAPL", now=NOW + timedelta(hours=16))
+
+    assert prom.update_price_staleness.call_args == mocker.call(m.shares[0], False)
+
+
+def test_sonde_no_false_positive_when_writer_advances_value(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch):
+    """A normally-updating symbol advances the stored value each cycle → the
+    sonde re-baselines and never flags, however long it runs."""
+    prom = mocker.MagicMock()
+    m = _metrics([_share()], mock_influx, shares_validator, mocker, prometheus=prom)
+    m.staleness_horizon = 900
+    monkeypatch.setattr(main.yf, "Ticker", lambda s: fake_ticker(market_state="REGULAR"))
+
+    mock_influx.get_newest_price.return_value = 180.0
+    m._scrape_symbol("AAPL", now=NOW)
+    # Next cycle the writer has persisted a new value (healthy).
+    mock_influx.get_newest_price.return_value = 184.0
+    m._scrape_symbol("AAPL", now=NOW + timedelta(seconds=900))
+
+    assert prom.update_price_staleness.call_args == mocker.call(m.shares[0], False)
+
+
+def test_sonde_does_not_run_on_closed_market(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch):
+    """The sonde is a REGULAR-only check: a closed probe writes nothing and never
+    reads the stored price or touches the staleness gauge."""
+    prom = mocker.MagicMock()
+    m = _metrics([_share()], mock_influx, shares_validator, mocker, prometheus=prom)
+    m.staleness_horizon = 900
+    monkeypatch.setattr(main.yf, "Ticker", lambda s: fake_ticker(market_state="CLOSED"))
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    mock_influx.get_newest_price.assert_not_called()
+    prom.update_price_staleness.assert_not_called()
+
+
+def test_sonde_disabled_when_horizon_non_positive(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch):
+    """A non-positive horizon turns the sonde off: no read, no gauge, write intact."""
+    prom = mocker.MagicMock()
+    m = _metrics([_share()], mock_influx, shares_validator, mocker, prometheus=prom)
+    m.staleness_horizon = 0
+    monkeypatch.setattr(main.yf, "Ticker", lambda s: fake_ticker(market_state="REGULAR"))
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    mock_influx.get_newest_price.assert_not_called()
+    prom.update_price_staleness.assert_not_called()
+    mock_influx.write_metrics.assert_called_once()
+
+
+def test_sonde_read_error_never_disturbs_scrape(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch):
+    """A read error in the sonde is swallowed: the write, re-arm, and backoff
+    reset all proceed exactly as if the sonde were absent (diagnostic only)."""
+    m = _metrics([_share()], mock_influx, shares_validator, mocker)
+    m.staleness_horizon = 900
+    mock_influx.get_newest_price.side_effect = RuntimeError("db down")
+    monkeypatch.setattr(main.yf, "Ticker", lambda s: fake_ticker(market_state="REGULAR"))
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    mock_influx.write_metrics.assert_called_once()
+    assert m.scheduler.add_job.call_args.kwargs["run_date"] == NOW + timedelta(seconds=120)
+
+
+def test_sonde_checks_each_account_holding(
+        mock_influx, shares_validator, fake_ticker, mocker, monkeypatch):
+    """One live fetch, but the sonde reads and reports per (symbol, account)."""
+    prom = mocker.MagicMock()
+    shares = [_share(account="pea"), _share(account="cto")]
+    m = _metrics(shares, mock_influx, shares_validator, mocker, prometheus=prom)
+    m.staleness_horizon = 900
+    mock_influx.get_newest_price.return_value = None  # no stored price yet
+    monkeypatch.setattr(main.yf, "Ticker", lambda s: fake_ticker(market_state="REGULAR"))
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    # Scoped per account on the read side...
+    read_accounts = {c.kwargs["account"]
+                     for c in mock_influx.get_newest_price.call_args_list}
+    assert read_accounts == {"pea", "cto"}
+    # ...and both cleared to fresh (None stored price → not stale).
+    assert prom.update_price_staleness.call_count == 2
+
+
+# ---------------------------------------------------------------------------
 # _reconcile_jobs — add / remove / revive / untouched + race guard
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What & why

Implements the observability slice of #626 (issue #628): a **diagnostic price-freshness sonde** that flags when the live scrape is silently stale — the last stored price frozen while the market is `REGULAR` and actually moving. This is the "price-diff" idea repurposed as **observability**, not a backfill trigger: the forward gap-fill (#627) can't see a stuck writer because it believes coverage reaches `now`. It complements the #617 dead-ticker guard from the monitoring side (#617 backs off tickers with no *writable* price; this catches a writer that fetches fine but persists *stale* values).

## How

- **`scheduling.price_freshness_step`** — pure, stateful-by-value decider (`SondeState` NamedTuple carried across cycles; `now` injected, no I/O). Staleness is measured over **consecutive `REGULAR` polling**, not the stored point's wall-clock age, so the first tick after an overnight/weekend close (legitimately hours old) never false-positives: the writer advancing the value re-baselines, and a polling gap wider than the horizon re-baselines too.
- **`influxdb_writer.get_newest_price`** — newest stored price value per (symbol, account); a shared `_symbol_account_where` helper DRYs the escaping/`COALESCE` clause with the oldest/newest-timestamp lookups.
- **`main._check_price_freshness`** — runs on the `REGULAR` write path *before* the write, per (symbol, account), fully guarded. **Diagnostic only** — never touches scrape cadence, write gating, or the #617 backoff.
- **Prometheus** `sb_price_staleness` gauge (`1` stale / `0` fresh, auto-clears) + WARNING log naming the symbol.
- **`SB_STALENESS_HORIZON`** dial (default `900`s, `0` disables).

## Acceptance criteria

- [x] During `REGULAR`, a symbol whose stored price stays frozen while the live quote changes → staleness WARNING + `sb_price_staleness` metric naming the symbol.
- [x] No effect on scheduling, write gating, or #617 backoff — purely additive observability.
- [x] A normally-updating symbol produces no staleness signal (incl. the first tick after a market close — the gap-aware fix).
- [x] `flake8` clean; unit tests for the staleness decision (+ reader, exporter, wiring).

## Tests

468 passing, flake8 clean. Pure decider covers baseline, value-advanced re-baseline, post-close gap re-baseline, flat market (accepted #626 false-negative), horizon boundary, and disabled horizon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq4dzKFBnKwmEfr4UouXhr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added monitoring to detect when stored share prices remain unchanged while live prices move.
  - Added the `sb_price_staleness` Prometheus gauge, reported per share and account.
  - Added the `SB_STALENESS_HORIZON` setting, configurable by default to 900 seconds and disableable with `0`.

- **Documentation**
  - Documented price-staleness detection, gauge behavior, configuration, and recovery handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->