### PR TITLE
fix(compose): separate port publishing into an optional overlay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,19 @@ variables, and the InfluxDB admin token has one source (`INFLUXDB_TOKEN` in
 `.env`) that `influxdb3-init.sh` materialises into a token file and Grafana's
 datasource reads via `$__env{}`.
 
+**Port publishing is an overlay.** `docker-compose.yaml` declares no `ports:`
+— the services reach each other over the compose network — and
+`docker-compose.expose.yaml` holds the three blocks. `.env.example` chains them
+with `COMPOSE_FILE=docker-compose.yaml:docker-compose.expose.yaml`, so local use
+is unchanged; `GRAFANA_PORT`/`INFLUXDB_PORT`/`SB_METRICS_PORT` are read by the
+overlay. PaaS platforms that regenerate from `docker-compose.yaml` alone and
+write their own env (Coolify, Dokploy) never load the overlay and get the
+unpublished stack, which is what a reverse proxy in front of Grafana wants.
+`docker-compose.dev.yaml` is standalone and keeps its own `ports:` (an explicit
+`-f` overrides `COMPOSE_FILE`). Existing `.env` files predate the line — `make
+init` warns when it is missing, since the stack would otherwise come up with
+nothing published.
+
 ## Architecture
 
 **Main entry point**: `app/src/main.py`

--- a/docker-compose/.env.example
+++ b/docker-compose/.env.example
@@ -31,6 +31,13 @@ SB_CONFIG_DIR=./data
 # ---------------------------------------------------------------------------
 # Ports
 # ---------------------------------------------------------------------------
+# docker-compose.yaml publishes nothing on its own; docker-compose.expose.yaml
+# is the overlay that maps the services onto host ports. Chaining both here is
+# what makes a plain `docker compose up -d` behave as it always did. Comment
+# this line out to stop publishing anything on the host — do that when a reverse
+# proxy fronts the stack and reaches the services over the compose network.
+# (Windows: separate the two files with `;` instead of `:`.)
+COMPOSE_FILE=docker-compose.yaml:docker-compose.expose.yaml
 GRAFANA_PORT=3000
 INFLUXDB_PORT=8181
 # Grafana's admin password. `admin` is the documented first-login default;

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -25,7 +25,8 @@ init:  ## Create .env (with a unique token) and data/ from the templates
 	@grep -q '^COMPOSE_FILE=' .env || { \
 		echo "note: your .env predates the port overlay — no port is published."; \
 		echo "      add this line to keep reaching Grafana on the host:"; \
-		echo "      COMPOSE_FILE=docker-compose.yaml:docker-compose.expose.yaml"; \
+		echo "        Linux/macOS: COMPOSE_FILE=docker-compose.yaml:docker-compose.expose.yaml"; \
+		echo "        Windows:     COMPOSE_FILE=docker-compose.yaml;docker-compose.expose.yaml"; \
 	}
 	@echo "Ready. Edit data/config.yaml, or drop broker exports into data/events/."
 

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -22,6 +22,11 @@ init:  ## Create .env (with a unique token) and data/ from the templates
 		fi; \
 	}
 	@test -d data || { cp -r data.example data; echo "created data/"; }
+	@grep -q '^COMPOSE_FILE=' .env || { \
+		echo "note: your .env predates the port overlay — no port is published."; \
+		echo "      add this line to keep reaching Grafana on the host:"; \
+		echo "      COMPOSE_FILE=docker-compose.yaml:docker-compose.expose.yaml"; \
+	}
 	@echo "Ready. Edit data/config.yaml, or drop broker exports into data/events/."
 
 up: init  ## Start the stack

--- a/docker-compose/docker-compose.expose.yaml
+++ b/docker-compose/docker-compose.expose.yaml
@@ -1,0 +1,29 @@
+# SuiviBourse — host port publishing.
+#
+# Overlay on top of docker-compose.yaml, which publishes nothing by itself.
+# `.env.example` chains the two with
+#
+#   COMPOSE_FILE=docker-compose.yaml:docker-compose.expose.yaml
+#
+# so `docker compose up -d` in this folder keeps publishing Grafana, InfluxDB and
+# the /metrics endpoint on the host, as it always did. The ports themselves stay
+# tunable through GRAFANA_PORT / INFLUXDB_PORT / SB_METRICS_PORT in .env.
+#
+# Drop this file from COMPOSE_FILE (or never opt in, which is what a platform
+# regenerating its own environment from docker-compose.yaml does) when a reverse
+# proxy fronts the stack and nothing should be reachable on the host directly.
+#
+# Only publish what you actually reach from outside: Grafana alone is enough for
+# dashboards — the app and InfluxDB are reached over the compose network.
+services:
+  app:
+    ports:
+    - ${SB_METRICS_PORT:-8081}:${SB_METRICS_PORT:-8081}  # Prometheus /metrics (legacy)
+
+  grafana:
+    ports:
+    - ${GRAFANA_PORT:-3000}:3000
+
+  influxdb:
+    ports:
+    - ${INFLUXDB_PORT:-8181}:8181

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -3,6 +3,14 @@
 # Everything is tunable from .env; this file should not need editing. Copy
 # .env.example to .env and data.example/ to data/ (or run `make init`), then
 # `docker compose up -d`.
+#
+# This file publishes NO port: the services talk to each other over the compose
+# network, and how they are reached from outside is a deployment decision.
+# `docker-compose.expose.yaml` is the overlay that maps them onto host ports,
+# and `.env.example` enables it through COMPOSE_FILE, so a local stack behaves
+# exactly as before. Platforms that regenerate their own environment from this
+# file alone (Coolify, Dokploy, …) get the unpublished variant and route to the
+# services through their reverse proxy.
 name: ${COMPOSE_PROJECT_NAME:-suivi-bourse}
 
 x-logging: &logging
@@ -44,8 +52,6 @@ services:
       INFLUXDB_TOKEN: ${INFLUXDB_TOKEN:?set INFLUXDB_TOKEN in .env}
       INFLUXDB_DATABASE: ${INFLUXDB_DATABASE:-suivi_bourse}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
-    ports:
-    - ${SB_METRICS_PORT:-8081}:${SB_METRICS_PORT:-8081}  # Prometheus /metrics (legacy)
     volumes:
     # One mount for the whole config directory: settings.yaml, config.yaml and
     # events/ all live in there, so switching modes is a file drop rather than a
@@ -77,8 +83,6 @@ services:
       # token and database stay defined in .env only.
       INFLUXDB_TOKEN: ${INFLUXDB_TOKEN:?set INFLUXDB_TOKEN in .env}
       INFLUXDB_DATABASE: ${INFLUXDB_DATABASE:-suivi_bourse}
-    ports:
-    - ${GRAFANA_PORT:-3000}:3000
     volumes:
     - ./grafana_provisioning:/etc/grafana/provisioning:ro
     - sb_grafana_data:/var/lib/grafana
@@ -96,8 +100,6 @@ services:
       # init.sh materialises the admin-token file from this value, so .env is
       # the single source of truth for the token.
       SB_INFLUXDB_ADMIN_TOKEN: ${INFLUXDB_TOKEN:?set INFLUXDB_TOKEN in .env}
-    ports:
-    - ${INFLUXDB_PORT:-8181}:8181
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8181/health"]
       interval: 10s

--- a/website/docs/changelog.mdx
+++ b/website/docs/changelog.mdx
@@ -68,11 +68,23 @@ config directory — Coolify recreates the repository clone on every deployment,
 `data/` is git-ignored so it is never in that clone, and `make init` never runs.
 Point `SB_CONFIG_DIR` at an absolute host path, which also keeps your portfolio
 outside the deployment's working directory so redeploys cannot touch it. The
-guide also flags two traps: publishing ports instead of serving Grafana through
-Coolify's proxy, and Coolify's non-standard `is_directory: true` bind-mount flag,
+guide also flags Coolify's non-standard `is_directory: true` bind-mount flag,
 which plain Docker Compose rejects outright.
 
 → [Deploying with Coolify](/docs/deployment/docker-compose#coolify)
+
+### Publishing ports is an overlay
+
+`docker-compose.yaml` no longer binds anything on the host: the three services
+talk over the compose network, and `docker-compose.expose.yaml` carries the
+`ports:` blocks. `.env.example` chains both through `COMPOSE_FILE`, so a local
+`docker compose up -d` is unchanged. Drop that line and the same stack comes up
+with nothing published — which is what you want behind a reverse proxy, and what
+Coolify gets for free since it regenerates its deployment from
+`docker-compose.yaml` alone. It is also the file to trim when only Grafana
+should be reachable and InfluxDB should not.
+
+→ [Not publishing ports at all](/docs/deployment/docker-compose#port-overlay)
 
 ### New deployment variables
 
@@ -84,6 +96,7 @@ Set in `.env`, all optional except `INFLUXDB_TOKEN`.
 | `SB_CONFIG_DIR` | `./data` | Config directory mounted into the app — point it at a NAS share or an absolute path. |
 | `COMPOSE_PROJECT_NAME` | `suivi-bourse` | Prefix for container and volume names, to run two stacks side by side. |
 | `GRAFANA_PORT` / `INFLUXDB_PORT` | `3000` / `8181` | Published ports, previously hard-coded in the compose file. |
+| `COMPOSE_FILE` | `docker-compose.yaml:docker-compose.expose.yaml` | Chains the port overlay onto the stack. Comment it out to publish nothing. |
 | `GF_ADMIN_PASSWORD` | `admin` | Grafana admin password. |
 
 → [Environment variables](/docs/deployment/docker-compose#environment-variables)
@@ -106,6 +119,13 @@ clobbers your configuration.
 **`influxdb3-token.json` is gone.** The token comes from `INFLUXDB_TOKEN` in
 `.env` alone. Avoid `$` in its value: Grafana expands `$VAR` inside provisioning
 files.
+
+**An `.env` written before the port overlay publishes nothing.** The `ports:`
+blocks moved out of `docker-compose.yaml`, and it is the `COMPOSE_FILE` line in
+`.env` that pulls them back in — without it Grafana is unreachable on
+`localhost:3000`. Add
+`COMPOSE_FILE=docker-compose.yaml:docker-compose.expose.yaml` to your existing
+`.env`; `make init` prints the same reminder when the line is missing.
 
 **`SB_CONFIG_MODE` now defaults to unset, not `manual`.** If you keep event files
 around while deliberately running in manual mode, the new auto-detection would

--- a/website/docs/deployment/docker-compose.mdx
+++ b/website/docs/deployment/docker-compose.mdx
@@ -104,6 +104,32 @@ Every port is configurable in `.env`.
 | InfluxDB 3 | `INFLUXDB_PORT` | `8181` | Database HTTP API |
 | App | `SB_METRICS_PORT` | `8081` | Legacy Prometheus `/metrics` endpoint |
 
+### Not publishing them at all {#port-overlay}
+
+Publishing is **an overlay**, not part of the stack itself.
+`docker-compose.yaml` maps no port — the three services talk to each other over
+the compose network — and `docker-compose.expose.yaml` is what puts them on the
+host. `.env.example` chains the two, so nothing changes for a local stack:
+
+```bash title=".env"
+COMPOSE_FILE=docker-compose.yaml:docker-compose.expose.yaml
+```
+
+Comment that line out and `docker compose up -d` starts the same stack with
+nothing bound on the host. That is what you want behind a reverse proxy, which
+reaches Grafana over the compose network instead — see
+[Deploying with Coolify](#coolify). The port variables above keep working either
+way; they are read by the overlay.
+
+Nothing else has to change: the compose commands stay `docker compose up -d`,
+`docker compose logs -f app`, and so on. Compose reads `COMPOSE_FILE` from
+`.env` and chains the files itself. On Windows, separate them with `;` instead
+of `:`.
+
+The overlay is also the place to publish **less**: keep only the `grafana`
+block if the dashboards are all you reach from outside, and leave InfluxDB and
+`/metrics` on the internal network.
+
 ## Configuration directory
 
 The stack mounts **one** directory read-only at
@@ -195,7 +221,8 @@ docker-compose/
 ├── examples/
 │   └── events-example.csv     # Sample transaction file
 ├── Makefile                   # init / up / logs / upgrade helpers
-├── docker-compose.yaml
+├── docker-compose.yaml        # The stack — publishes no port
+├── docker-compose.expose.yaml # Overlay: publishes them on the host
 ├── influxdb3-init.sh          # InfluxDB 3 bootstrap (creates the database)
 └── grafana_provisioning/
     ├── datasources/           # InfluxDB SQL datasource
@@ -215,6 +242,19 @@ docker compose pull && docker compose up -d     # or: make upgrade
 Bump `SB_VERSION` in `.env` to move across majors, or set it back to the
 previous version to roll back. Your `.env` and config directory are untouched by
 an upgrade, so re-extracting a newer release over the folder is safe.
+
+:::caution Ports moved to an overlay
+`docker-compose.yaml` no longer publishes anything by itself — an `.env` written
+before that change has no `COMPOSE_FILE` line, and the stack then comes up with
+Grafana unreachable on `localhost:3000`. Add the line to your existing `.env`:
+
+```bash title=".env"
+COMPOSE_FILE=docker-compose.yaml:docker-compose.expose.yaml
+```
+
+`make init` prints the same reminder when it finds an `.env` without it. See
+[Not publishing them at all](#port-overlay) for why the split exists.
+:::
 
 ## Migrating from a pre-4.2 layout {#migration}
 
@@ -253,6 +293,14 @@ most of it fits without changes: every setting is a `${VAR}` in
 variables, and the InfluxDB / Grafana named volumes are handled natively. There
 is no `.env` to provide — Coolify injects the variables itself.
 
+**Ports take care of themselves.** Coolify regenerates its deployment from
+`docker-compose.yaml` alone and writes its own environment, so it never sees the
+`COMPOSE_FILE` line from `.env.example` and never loads
+`docker-compose.expose.yaml`. What it deploys is the unpublished stack: attach a
+domain to the `grafana` service and its proxy reaches the container over the
+compose network, with nothing bound on the host. Same reasoning for any other
+reverse-proxied deployment — Dokploy, a hand-written Traefik or Caddy setup.
+
 **One thing needs care: the configuration directory.** Coolify recreates the
 repository clone on every deployment, `data/` is git-ignored so it is never in
 that clone, and `make init` does not run. Left at its `./data` default, the app
@@ -285,10 +333,11 @@ deployment's working directory, so redeployments never touch it. Everything else
 — upgrades via `SB_VERSION`, mode auto-detection, adding event files — works the
 same as anywhere else.
 
-:::tip Serve Grafana through Coolify's proxy
-The stack publishes its ports on the host by default. On Coolify you will
-usually prefer to attach a domain to the `grafana` service and let its proxy
-terminate TLS, rather than exposing port `3000` directly.
+:::tip Publishing a port anyway
+If you do want a port bound on the Coolify host — reaching the InfluxDB API from
+outside, say — add the mapping in Coolify's compose editor for that service.
+Pointing the resource at `docker-compose.expose.yaml` instead is not an option:
+the overlay only carries `ports:` blocks and is not a stack on its own.
 :::
 
 :::caution `is_directory` belongs in a Coolify-only file


### PR DESCRIPTION
## Summary

Refactors the Docker Compose setup to decouple port publishing from the core stack definition. `docker-compose.yaml` now declares no ports, allowing services to communicate over the compose network. Port publishing is moved to an optional `docker-compose.expose.yaml` overlay that can be chained via `COMPOSE_FILE` in `.env`.

## Key Changes

- **`docker-compose.yaml`**: Removed all `ports:` blocks from `app`, `grafana`, and `influxdb` services. Added documentation explaining that the file publishes nothing and that port publishing is a deployment decision.

- **`docker-compose.expose.yaml`** (new file): Created overlay file containing the three `ports:` blocks for all services, parameterized by `GRAFANA_PORT`, `INFLUXDB_PORT`, and `SB_METRICS_PORT` environment variables.

- **`.env.example`**: Added `COMPOSE_FILE=docker-compose.yaml:docker-compose.expose.yaml` to chain both files by default, preserving existing behavior for local deployments. Added explanatory comments about the overlay pattern.

- **`Makefile`**: Enhanced `init` target to detect when `.env` lacks the `COMPOSE_FILE` line and print a reminder, since the stack would otherwise come up with no published ports.

- **Documentation** (`docker-compose.mdx`):
  - Added new section "Not publishing them at all" explaining the overlay pattern and use cases (reverse proxy deployments)
  - Updated file structure documentation to note the new overlay file
  - Added caution box for users upgrading from pre-4.2 layouts
  - Updated Coolify deployment section to explain that it automatically gets the unpublished variant
  - Updated the "Serve Grafana through Coolify's proxy" tip to reflect the new architecture

- **Changelog** (`changelog.mdx`): Documented the port overlay as a new feature with migration guidance for existing `.env` files.

- **`CLAUDE.md`**: Added explanation of the port overlay pattern for future maintainers.

## Implementation Details

The overlay pattern allows three deployment scenarios without code duplication:

1. **Local development**: Chain both files via `COMPOSE_FILE` in `.env` (default) → ports published on host
2. **Reverse proxy**: Comment out `COMPOSE_FILE` line → stack runs with no published ports, reverse proxy reaches services over compose network
3. **PaaS platforms** (Coolify, Dokploy): Regenerate from `docker-compose.yaml` alone → automatically get unpublished variant

The port variables (`GRAFANA_PORT`, `INFLUXDB_PORT`, `SB_METRICS_PORT`) remain functional in all scenarios; they are read by the overlay when present.

Windows users must separate files with `;` instead of `:` in `COMPOSE_FILE`.

https://claude.ai/code/session_01D2E8KiEPmKoj7iZcvHWFcq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Docker Compose port-publication overlay for Grafana, InfluxDB, and the metrics endpoint.
  * Added configurable host ports through the `COMPOSE_FILE` environment setting.
  * Supports deployments behind reverse proxies without publishing ports directly.

* **Documentation**
  * Updated setup, deployment, and upgrade guidance, including migration steps for existing environment files.
  * Added warnings when port publishing is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->