### PR TITLE
fix(docker-compose): authenticate the InfluxDB healthcheck

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -101,7 +101,15 @@ services:
       # the single source of truth for the token.
       SB_INFLUXDB_ADMIN_TOKEN: ${INFLUXDB_TOKEN:?set INFLUXDB_TOKEN in .env}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8181/health"]
+      # /health is authenticated when the server runs with an admin token, so a
+      # bare curl answers 401 forever and the container never turns healthy.
+      # CMD-SHELL (not CMD) so the container's shell expands the token; the
+      # doubled $$ keeps compose from interpolating it at parse time.
+      test:
+      - CMD-SHELL
+      - >-
+        curl -fsS -H "Authorization: Bearer $${SB_INFLUXDB_ADMIN_TOKEN}"
+        http://localhost:8181/health
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
The InfluxDB healthcheck was failing when the server runs with an admin token, because the `/health` endpoint requires authentication but the healthcheck curl command was not providing credentials. This caused the container to never reach a healthy state.

## Changes
- Updated the InfluxDB healthcheck in `docker-compose.yaml` to authenticate using the `SB_INFLUXDB_ADMIN_TOKEN`
- Changed from `CMD` to `CMD-SHELL` to allow shell variable expansion of the token
- Added `Authorization: Bearer` header with the token to the curl request
- Used `$$` escaping to prevent Docker Compose from interpolating the variable at parse time, allowing the container's shell to expand it at runtime
- Added explanatory comments documenting why this approach is necessary

## Implementation Details
The healthcheck now uses:
```bash
curl -fsS -H "Authorization: Bearer ${SB_INFLUXDB_ADMIN_TOKEN}" http://localhost:8181/health
```

The `-fsS` flags ensure the curl fails on HTTP errors while suppressing progress output, and the token is passed via the standard Bearer token authorization header that InfluxDB expects.

https://claude.ai/code/session_01TNrYwmXFmNiw1AM9F3aG7m

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved InfluxDB health checks by authenticating requests with the admin token.
  * Updated health-check execution to provide more reliable service status detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->