### PR TITLE
fix(compose): declare the config mount with the long volume syntax

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -56,7 +56,22 @@ services:
     # One mount for the whole config directory: settings.yaml, config.yaml and
     # events/ all live in there, so switching modes is a file drop rather than a
     # compose edit. Read-only — the app never writes to its config.
-    - ${SB_CONFIG_DIR:-./data}:/home/appuser/.config/SuiviBourse:ro
+    #
+    # Long syntax on purpose. Coolify's compose parser rewrites bind-mount
+    # sources at parse time, and for the *short* syntax it substitutes the
+    # literal default written here (`./data`) without ever consulting the
+    # application environment, then expands the leading `.` into its own clone
+    # directory — mounting an empty folder however SB_CONFIG_DIR is set
+    # (issue #646). The long-syntax source is copied through verbatim and
+    # resolved at runtime by docker compose, like the image tag above.
+    # `create_host_path` keeps the short syntax's habit of creating a missing
+    # source directory, so a local `docker compose up` behaves as before.
+    - type: bind
+      source: ${SB_CONFIG_DIR:-./data}
+      target: /home/appuser/.config/SuiviBourse
+      read_only: true
+      bind:
+        create_host_path: true
     healthcheck:
       # Probes the /metrics endpoint, unless it has been turned off.
       test:

--- a/website/docs/deployment/docker-compose.mdx
+++ b/website/docs/deployment/docker-compose.mdx
@@ -333,6 +333,19 @@ deployment's working directory, so redeployments never touch it. Everything else
 — upgrades via `SB_VERSION`, mode auto-detection, adding event files — works the
 same as anywhere else.
 
+:::note Why that mount uses the long syntax
+Coolify rewrites bind-mount sources when it parses the compose file, and for the
+short `source:target:ro` form it substitutes the default written in the file
+(`./data`) without ever reading your environment, then expands the leading `.`
+into its own clone directory. `SB_CONFIG_DIR` was silently ignored and the app
+started against an empty directory. The config mount is therefore declared with
+the long syntax (`type: bind` / `source:` / `target:`), which Coolify copies
+through untouched so `docker compose` resolves the variable at runtime — exactly
+like the `SB_VERSION` image tag. One side effect: Coolify recomposes the mount
+without its access mode, so the read-only flag is dropped there. The app never
+writes to its config directory, so nothing changes in practice.
+:::
+
 :::tip Publishing a port anyway
 If you do want a port bound on the Coolify host — reaching the InfluxDB API from
 outside, say — add the mapping in Coolify's compose editor for that service.


### PR DESCRIPTION
## Summary

Fixes a critical issue where the `SB_CONFIG_DIR` environment variable was silently ignored when deploying to Coolify, causing the app to start against an empty config directory instead of the user-specified path.

## Changes

- **docker-compose.yaml**: Converted the config mount from short syntax (`source:target:ro`) to long syntax (`type: bind` / `source:` / `target:` / `read_only:`) with `create_host_path: true`
  - The short syntax caused Coolify's compose parser to substitute the literal default (`./data`) at parse time without consulting the environment, then expand the leading `.` into Coolify's own clone directory
  - The long syntax is copied through verbatim by Coolify and resolved at runtime by `docker compose`, matching how the `SB_VERSION` image tag is handled
  - Added `create_host_path: true` to preserve the short syntax's behavior of auto-creating missing source directories for local `docker compose up`

- **website/docs/deployment/docker-compose.mdx**: Added a note explaining why the mount uses long syntax
  - Documents the Coolify parser limitation and the workaround
  - Notes that Coolify drops the read-only flag when recomposing, but this is safe since the app never writes to its config directory

## Implementation Details

This is a deployment-specific fix that does not affect the application code itself. The change ensures that environment variable substitution happens at the correct stage (runtime via `docker compose` rather than parse time via Coolify's parser), allowing users to override `SB_CONFIG_DIR` as intended.

https://claude.ai/code/session_01VBrbJuMmp9vX2Wvfno7sXx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker Compose configuration mounting for more reliable deployments.
  * Configuration directories are now mounted read-only and created automatically when needed.

* **Documentation**
  * Added guidance for deploying with Coolify, including bind-mount syntax considerations and configuration directory behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->