### PR TITLE
feat(mcp): a read-only MCP server exposing the portfolio

### DIFF
--- a/.github/scripts/container-contract.sh
+++ b/.github/scripts/container-contract.sh
@@ -374,4 +374,31 @@ for name in SOURCE_COMMIT RELEASE_VERSION; do
 done
 ok 'the build stamps itself, and the notice keeps quiet about it'
 
+assertion '11 — every native extension in the image resolves its libraries'
+# The image installs `binutils` to strip debug symbols out of the compiled
+# wheels and purges it in the same layer (#749 review). `apt-get autoremove`
+# runs in that purge, and APT cannot see an ELF dependency: it knows which
+# *packages* need `libstdc++6`, never that `_duckdb.so` does. Today those
+# libraries ship with `python:*-slim` and are held by packages that stay, so
+# nothing is taken — but that is a property of a base image this project does
+# not own, and the failure it would produce is the bad kind: not a red build, a
+# green one whose container dies on `import duckdb`.
+#
+# So the property is asserted where it is true or false — on the artefact — and
+# for **every** extension rather than for the two libraries somebody thought of:
+# the next dependency that needs a third is covered on the day it lands. `ldd`
+# prints `not found` per unresolved object and says nothing about a file that is
+# not an ELF at all.
+unresolved="$(docker run --rm --entrypoint bash "$IMAGE" -c \
+    'find /opt/venv -name "*.so*" -exec ldd {} + 2>/dev/null | grep "not found" | sort -u' || true)"
+[ -z "$unresolved" ] \
+    || fail "assertion 11: a compiled extension is missing a shared library: $unresolved"
+# And the imports themselves, because a library that resolves is not yet one
+# that loads: this is the list of wheels the app cannot boot without.
+docker run --rm --entrypoint python "$IMAGE" \
+    -c 'import duckdb, pandas, numpy, numpy.testing, pyarrow, yfinance, cryptography, mcp' \
+    >/dev/null 2>&1 \
+    || fail 'assertion 11: the image cannot import the wheels the app boots on'
+ok 'the compiled wheels find what they link against, and load'
+
 printf '\nThe image honours its contract.\n'

--- a/.github/scripts/container-contract.sh
+++ b/.github/scripts/container-contract.sh
@@ -389,8 +389,26 @@ assertion '11 — every native extension in the image resolves its libraries'
 # the next dependency that needs a third is covered on the day it lands. `ldd`
 # prints `not found` per unresolved object and says nothing about a file that is
 # not an ELF at all.
-unresolved="$(docker run --rm --entrypoint bash "$IMAGE" -c \
-    'find /opt/venv -name "*.so*" -exec ldd {} + 2>/dev/null | grep "not found" | sort -u' || true)"
+# **The scan reports its own health**, because an assertion written against a
+# silent failure must not have one. A blanket `|| true` around the whole
+# `docker run` was the first shape of this and it was the defect it exists to
+# catch: `bash`, `find` or `ldd` falling over left `unresolved` empty and the
+# assertion green. `set -euo pipefail` inside makes any of those a non-zero exit
+# the capture below sees; the only tolerated status is `grep`'s 1, which is the
+# **normal** case — nothing unresolved — and it is tolerated where it happens
+# rather than over the whole command.
+scan="$(docker run --rm --entrypoint bash "$IMAGE" -c '
+set -euo pipefail
+find /opt/venv -name "*.so*" -exec ldd {} + 2>/dev/null > /tmp/ldd.txt
+printf "scanned=%s\n" "$(wc -l < /tmp/ldd.txt)"
+grep "not found" /tmp/ldd.txt | sort -u || true
+')" || fail 'assertion 11: the native-extension scan could not run in the image'
+# And it says how much it looked at, which is the guard no exit code gives: a
+# scan that resolved *nothing* did not succeed, it failed to find the wheels.
+scanned="$(printf '%s\n' "$scan" | sed -n 's/^scanned=//p')"
+[ "${scanned:-0}" -gt 0 ] \
+    || fail 'assertion 11: the scan resolved no library at all — it did not run over /opt/venv'
+unresolved="$(printf '%s\n' "$scan" | grep 'not found' || true)"
 [ -z "$unresolved" ] \
     || fail "assertion 11: a compiled extension is missing a shared library: $unresolved"
 # And the imports themselves, because a library that resolves is not yet one

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -238,6 +238,34 @@ typed. It ends when they have been traversed, and the memory of that is the brow
 alone, so the state stays derived on the server and a wiped store asks again.
 _Avoid_: onboarding (as a phase), setup, installation wizard, first boot
 
+### The app talking to an agent
+
+**Agent**:
+Something that reads the portfolio without a person watching each read. It reaches the app
+over its own interface, not the front's, and it only ever reads: the ledger has one writer
+and it is reached by a gesture, never by a tool. Two of them are in view and they are the
+same shape — the chat inside the app, and whatever the owner has already built and wants
+their own figures in.
+_Avoid_: AI, bot, assistant, LLM
+
+**Tool**:
+A question the app has agreed to answer, named and described so that a model chooses it
+without being told to. Its **description is payload, not documentation**: what a page would
+explain with a convention note beside the figure, a tool has to carry in the text the model
+reads before calling — which of three absences a `null` is, that a quantity of zero is a
+sold position and not a mistake, that the currency is stated once for the whole answer.
+A tool whose description omits them returns figures a model will narrate wrongly and
+confidently.
+_Avoid_: endpoint, route, API method, function
+
+**Tool surface**:
+The set of them, and **the only promise this app makes to a machine** besides health. Names,
+arguments and payload shapes are held across a minor version, which the front's interface
+explicitly is not: an owner points their own client at this one, and a tool that renames
+itself breaks their setup in silence, with no screen anywhere to say so. It is documented
+for the same reason — a contract nobody can read is not one.
+_Avoid_: API, contract (on its own), integration
+
 ### On screen
 
 **Convention note**:

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,16 @@ COPY pyproject.toml uv.lock ./
 # `binutils` is installed and purged inside the same RUN for the same reason the
 # deletions are here: kept, it would be a second thing to carry.
 #
+# **The purge runs `autoremove`, and APT cannot see an ELF dependency**: it knows
+# which *packages* need `libstdc++6`, never that `_duckdb.so` does. Today that
+# library ships with `python:*-slim` and is held by packages that stay, so
+# nothing is taken — but that is a property of a base image this project does not
+# own, and what it would produce is the bad kind of failure: not a red build, a
+# green one whose container dies on `import duckdb`. So the property is asserted
+# on the artefact rather than reasoned about here — `container-contract.sh`
+# assertion 11, which resolves **every** compiled extension and imports the
+# wheels the app boots on.
+#
 # Measured, on this Dockerfile: **645 MB -> 529 MB**.
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-install-project \

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,46 @@ COPY pyproject.toml uv.lock ./
 # not downloaded again on the next local rebuild. `/root/.cache/uv` is uv's own
 # default location and this layer runs as root — naming it here rather than
 # moving it with UV_CACHE_DIR keeps one convention instead of two.
+# Two cuts, **in this RUN and not a later one**, which is the whole reason they
+# are written here in the middle of an install rather than in a tidy step of
+# their own: a layer only ever adds. Deleting these files further down was
+# measured at **+237 MB** — the removal lands in a new layer while every byte it
+# removed is still carried by the one below it. They have to happen before the
+# layer is written, so they happen here.
+#
+# * **The bundled test suites, 61 MB** — `pandas/tests` alone is 37 of them,
+#   then `numpy/_core/tests` and `pyarrow/tests`. They are a library's own
+#   fixtures, they are never imported by anything this app runs, and nothing in
+#   the image can invoke them.
+#
+#   `tests` and `test`, and **never `testing`**. `numpy.testing` is a *public
+#   API* that pandas imports at load; a pattern that matched it would produce an
+#   image that fails on its first `import pandas`, which is the difference
+#   between this line and a broken one.
+#
+# * **The debug symbols in the compiled extensions, 57 MB** — `_duckdb.so` is
+#   52 MB on its own before this, `curl_cffi` 29, OpenBLAS 25.
+#   `--strip-unneeded` keeps every dynamic symbol a linker or a runtime import
+#   resolves against, and removes what only a debugger reads. What is lost is a
+#   readable native backtrace out of a segfault inside DuckDB — which this
+#   project has met exactly once, on macOS, outside a container (ADR-0039), and
+#   which is investigated on a checkout rather than by attaching gdb to a
+#   production image.
+#
+# `binutils` is installed and purged inside the same RUN for the same reason the
+# deletions are here: kept, it would be a second thing to carry.
+#
+# Measured, on this Dockerfile: **645 MB -> 529 MB**.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-install-project
+    uv sync --locked --no-install-project \
+ && apt-get update -qq \
+ && apt-get install -y -qq --no-install-recommends binutils \
+ && find /opt/venv -type d -name tests -prune -print0 | xargs -0 rm -rf \
+ && find /opt/venv -type d -name test -prune -print0 | xargs -0 rm -rf \
+ && find /opt/venv -name "*.so*" -exec strip --strip-unneeded {} + \
+ && apt-get purge -y -qq binutils \
+ && apt-get autoremove -y -qq \
+ && rm -rf /var/lib/apt/lists/*
 
 # And the server's console script goes straight back out (ADR-0039). uvicorn is
 # called from `boot.py` as a library — `uvicorn.run(...)`, in process — and the

--- a/docs/adr/0040-the-app-gets-a-second-reader-and-it-is-an-agent.md
+++ b/docs/adr/0040-the-app-gets-a-second-reader-and-it-is-an-agent.md
@@ -96,6 +96,18 @@ operations"* and is wrong.
 - **A store that cannot answer is a tool error, never an empty payload.** `/api` already
   separates a failed request from an empty portfolio, and the stakes are higher here: an agent
   handed `[]` will report that the owner holds nothing.
+- **The interface answers under any host name, and that is passed explicitly.**
+  Handing the SDK no transport-security settings is the one thing that does not
+  mean *no policy*: it reads its `host` argument, defaults it to `127.0.0.1`,
+  and substitutes an allowlist of localhost names — which answers `421 Invalid
+  Host header` to a LAN address, a container name and a reverse proxy's domain
+  alike, every way this app is actually reached except the one a developer tests
+  from. The alternative, a real allowlist, is not available: the app cannot know
+  the name it is reached under, and learning one would be a fourth boot
+  variable. What the check defends is defended structurally instead — the SDK
+  enforces `Content-Type: application/json` on every POST whatever that setting
+  says, and a browser cannot send it cross-origin without a preflight this app
+  answers no CORS header to.
 - **The site gets its first machine-facing page**, in English only — `i18n/` holds `en/` alone
   and French arrives through Crowdin, never by hand.
 

--- a/docs/adr/0040-the-app-gets-a-second-reader-and-it-is-an-agent.md
+++ b/docs/adr/0040-the-app-gets-a-second-reader-and-it-is-an-agent.md
@@ -1,0 +1,109 @@
+# The app gets a second reader, and it is an agent
+
+[ADR-0033](./0033-prometheus-leaves-and-the-api-stops-being-a-contract.md) removed the last
+non-browser consumer and drew the conclusion out loud: `/api` is **the front's interface**,
+it sheds a promise of stability it never actually made, and a product with one owner, one
+browser and one container *"pays for a second interface twice — once to build it, once in
+the shape it forces on the model"*. **This record reopens exactly one half of that**, and it
+does it the way ADR-0033 asked to be answered: *"the API's status is decided here rather
+than left to erode."* The app gets a second reader. It is an agent, it only reads, and the
+decision is taken rather than drifted into.
+
+**The reason this is not `/metrics` coming back** is the one thing that endpoint never had:
+an internal consumer. The gauges were justified by *"whoever wants something very simple"* —
+a person with no existence — and that is why removing them cost nothing. The tool surface
+below has a consumer, and it is the headline feature of the same milestone: the built-in
+chat (#750) is defined on **the same tool functions**, called in process, with no HTTP hop
+in a loopback. A surface the app's own feature runs on cannot quietly rot, and that is the
+whole of what makes a second non-browser reader defensible here where the gauges were not.
+What the external client buys, on top, is the case the owner named: somebody who already has
+their own agent and wants their portfolio in it, without going through ours.
+
+**One socket, one process, and no fork.** The MCP server is not a second service. Its
+Streamable HTTP application is ASGI, mounted beside the WSGI-wrapped Flask app inside
+`boot.Serving`, on the same bind, under `/mcp`. The SDK requires the *host* application's
+lifespan to enter `session_manager.run()` — a mounted sub-application's own lifespan never
+runs — and `Serving` already intercepts the lifespan protocol, for another reason entirely:
+it is where the teardown lives, the heir of gunicorn's `worker_exit`. The hook the SDK asks
+for is therefore already there. `SB_WEB_PORT` stays the only port, the three boot variables
+stay three, and [ADR-0039](./0039-the-app-stops-forking.md) is untouched.
+
+**Three machine readers now, and three different statuses — stated, so none of them erodes.**
+`/health` is the orchestrator's contract, settled in
+[ADR-0036](./0036-the-dot-says-health-and-the-notices-lose-their-exception.md). `/api` stays
+the front's interface and stays disposable: a route and its caller may still be reshaped in
+one commit. The **tool surface is a contract** — names, arguments, payload shapes — and that
+is a narrow promise granted on purpose, because a person points their own client at it and a
+tool that renames itself breaks their setup in silence, with no page to show a diagnostic on.
+It is the reason the surface is documented on the site: ADR-0033 counted *"nothing on the
+site describes an API"* as an economy, and this is the first thing there that describes a
+machine interface. A contract nobody can read is not one.
+
+**It reads, and it does not write.** `entries.py` remains the ledger's one writer
+([ADR-0032](./0032-the-import-is-a-gesture-not-a-mount.md)), reached by a person's gesture.
+This is not caution for its own sake — it is what makes the access model honest. The
+`before_request` guard refuses a *foreign origin*, which is a statement about browsers; a
+client with no `Origin` at all is not refused, and never will be, because that is the rule's
+deliberate shape. So an MCP write would be an exposure that no existing guard covers, and
+the answer is not to invent a guard for it. **The socket is the authorization**, exactly as
+it already is for `/api` — *"whoever reaches the socket reaches the whole app"* — and
+read-only is what turns that from an oversight into a decision. Whoever publishes the socket
+puts it behind their own proxy, which is what publishing this app has always meant.
+
+**A tool's description is payload, not documentation.** This app has three structurally
+distinct states of absence ([ADR-0026](./0026-a-read-in-flight-is-not-an-absence.md)), a
+carrying convention with two terms — `terminal` separates *not priced yet* from *never
+priced* ([ADR-0004](./0004-carrying-price.md)) — one reporting currency carried in the head
+of a payload and never on a row ([ADR-0002](./0002-one-base-currency.md)), and a sold
+position that stays in the table at quantity zero
+([ADR-0017](./0017-a-closed-position-leaves-the-table-never-the-total.md)). A model that
+does not hold those will say *"you own 0 € of AAPL"* in perfect confidence when the truth is
+that nothing has ever priced it. The description string is the only channel that reaches the
+model **without anybody choosing to attach it** — which is why the conventions travel there,
+and not in a resource or a prompt that an optional client gesture may never load.
+
+**And there is exactly one place this surface departs from `/api`, which is the ledger.**
+[ADR-0031](./0031-the-ledger-loads-in-pages.md) answers `GET /api/events` *entire* and says
+so as a decision: the forty rows are a rendering budget, not a fetch, and *"paging the
+resource was never considered."* That is right for a browser, whose constraint is the pixel.
+A model's constraint is the context window, and the ledger is the only resource where the two
+differ enough to change the shape — every other tool is bounded by what the portfolio *is*.
+So the ledger tool is bounded, and it carries the total, because a bounded answer without one
+is worse than an unbounded answer: it produces an agent that states *"you have made a hundred
+operations"* and is wrong.
+
+## Consequences
+
+- **The MCP SDK becomes a direct dependency**, and its tail is not nothing: `pydantic`,
+  `starlette`, `sse-starlette`, `httpx2`, `jsonschema`, `pyjwt[crypto]` and — the line worth
+  writing down — `opentelemetry-api`. That is a transitive dependency of a protocol library
+  and **not the exporter returning**; the next reader of `pyproject.toml` is told so there,
+  in the comment, because every other line in that file explains itself and this one invites
+  the wrong conclusion.
+- **The code is a module of `application`, not a third package.** `src/mcp/` would shadow the
+  SDK's own import name under `PYTHONPATH=src` — a failure that appears in the image and not
+  in a checkout. It is not in `api` either: that package is Flask and WSGI, and this is ASGI.
+- **`Serving` grows a path branch, and it is the only new code on every request's path.** An
+  error there breaks the whole app, not the MCP surface, so it is tested as routing in its own
+  right: `/mcp` reaches the MCP application, everything else reaches the WSGI one, and the
+  lifespan enters and exits the session manager.
+- **`create_app()` stops being the whole application's test seam**, and that is the real price
+  of the mount. The tools are tested as functions over a real store in `tmp_path`, like
+  everything else; the surface is tested through the SDK's in-memory client, which is what
+  proves the descriptions exist at all. No test binds a socket to speak Streamable HTTP.
+- **The one faked external edge is still yfinance.** The store is real, the tools read the
+  store, and nothing here is doubled.
+- **A store that cannot answer is a tool error, never an empty payload.** `/api` already
+  separates a failed request from an empty portfolio, and the stakes are higher here: an agent
+  handed `[]` will report that the owner holds nothing.
+- **The site gets its first machine-facing page**, in English only — `i18n/` holds `en/` alone
+  and French arrives through Crowdin, never by hand.
+
+[The half it reopens: ADR-0033](./0033-prometheus-leaves-and-the-api-stops-being-a-contract.md) ·
+[the process it does not fork: ADR-0039](./0039-the-app-stops-forking.md) ·
+[the ledger shape it declines: ADR-0031](./0031-the-ledger-loads-in-pages.md) ·
+[the writer it does not become: ADR-0032](./0032-the-import-is-a-gesture-not-a-mount.md) ·
+[the conventions its descriptions carry: ADR-0004](./0004-carrying-price.md),
+[ADR-0026](./0026-a-read-in-flight-is-not-an-absence.md) ·
+[the ticket: #749](https://github.com/pbrissaud/suivi-bourse/issues/749) ·
+[its first consumer: #750](https://github.com/pbrissaud/suivi-bourse/issues/750)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -50,6 +50,7 @@ lives in [`CONTEXT.md`](../../CONTEXT.md) at the repo root.
 | [0037](./0037-notifications-have-a-space-and-the-banner-has-none.md) | Notifications have a space, and the banner has none |
 | [0038](./0038-settings-leaves-the-data-page.md) | Settings leaves the data page, and the tabs leave with it |
 | [0039](./0039-the-app-stops-forking.md) | The app stops forking, and two guards go with it |
+| [0040](./0040-the-app-gets-a-second-reader-and-it-is-an-agent.md) | The app gets a second reader, and it is an agent |
 
 > These records describe **v5**, and which side wins an argument depends on the branch.
 >

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,15 @@ dependencies = [
     # that is how its multiprocess mode stays out of reach without a guard.
     "uvicorn==0.52.4",
     "a2wsgi==1.10.10",
+    # The agent's interface (ADR-0040, issue #749). It is mounted **inside** this
+    # process, on the one socket, beside the Flask app — so it adds a reader and
+    # not a service. It is the heaviest line here and the tail is worth naming:
+    # pydantic, starlette, sse-starlette, httpx2, jsonschema, pyjwt[crypto] and
+    # `opentelemetry-api`. That last one is a protocol library's transitive
+    # dependency and **not the Prometheus exporter coming back** (ADR-0033):
+    # nothing in this app emits a span or a metric, and the read that used to be
+    # a gauge is still the health body and the runtime tab.
+    "mcp>=2.1.0",
 ]
 
 # Development / test tooling — installed by `uv sync`, excluded in Docker via UV_NO_DEV.

--- a/src/application/boot.py
+++ b/src/application/boot.py
@@ -21,22 +21,30 @@ Run it by hand, from the repository root::
 ``pythonpath = ["src"]`` in ``pyproject.toml`` is pytest's alone, and the project
 is not installable (``package = false``), so the import root is named here.
 """
+import contextlib
 import os
 import sys
 from functools import partial
-from typing import Callable, Mapping
+from typing import Callable, Mapping, Optional
 
 import uvicorn
 from a2wsgi import WSGIMiddleware
 
 from application import boot_env
 from application import main
+from application import mcp_server
 import api
 
 #: The size of the pool the WSGI application is called in. It is the
 #: ``threads = 4`` gunicorn's ``gthread`` worker carried — the number moved, it
 #: was not re-chosen.
 WSGI_THREADS = 4
+
+#: Where the agent's interface answers, on the one socket (ADR-0040, #749).
+#:
+#: It is the SDK's own default, which is why the mounted application needs no
+#: prefix stripped: it routes on the full path it is handed.
+MCP_PATH = '/mcp'
 
 #: The levels uvicorn's own logger understands. ``LOG_LEVEL`` is an app-wide
 #: dial that predates any server (ADR-0014), so a value it does not recognise
@@ -46,11 +54,19 @@ _UVICORN_LEVELS = ('critical', 'error', 'warning', 'info', 'debug', 'trace')
 
 
 class Serving:
-    """The ASGI application uvicorn is handed: the Flask app, and the teardown.
+    """The ASGI application uvicorn is handed: the Flask app, the agent's, and the teardown.
 
     The Flask application is served **unchanged**, behind a WSGI-to-ASGI adapter:
     no route is rewritten, and ``create_app()`` stays the seam the whole Python
     suite is written against (ADR-0039).
+
+    **Two applications on one socket since ADR-0040**, and the branch below is
+    the whole of the mount. The agent's interface is ASGI where Flask is WSGI, so
+    it cannot be a blueprint; it is not a second service either, because there is
+    no second bind, no second process and no fork. ``MCP_PATH`` reaches it and
+    every other path reaches the front's — which makes this branch **the only new
+    code on every request's path**, MCP's and the page's alike, and the reason it
+    is tested as routing in its own right rather than only through the tools.
 
     The teardown hangs off the **lifespan shutdown**, and that is not a matter of
     taste. uvicorn catches ``SIGTERM``, shuts down gracefully, restores the
@@ -60,40 +76,122 @@ class Serving:
     lifespan shutdown is the last thing uvicorn drives while the process is still
     alive, which makes it the exact heir of gunicorn's ``worker_exit``.
 
+    **And the lifespan is now load-bearing twice.** The MCP SDK requires the
+    *host* application to enter ``session_manager.run()`` itself: a mounted
+    sub-application's own lifespan never executes, so the one
+    ``streamable_http_app()`` wires into the app it returns is dead code the
+    moment it is mounted, and the first request fails without this. The hook it
+    asks for already existed here, for the teardown — which is why ADR-0040 could
+    say the mount costs a branch and a context.
+
+    **The order on the way out is not interchangeable.** The session manager is
+    closed *before* the runtime, because the teardown closes the store and a tool
+    still in flight would meet a store that is no longer there — the shape of
+    defect #858 records, met from the other side.
+
     a2wsgi answers the lifespan protocol itself, and correctly; it is intercepted
     here rather than delegated to because there is something to do in it.
     """
 
-    def __init__(self, app, on_shutdown: Callable[[], None]):
+    def __init__(self, app, on_shutdown: Callable[[], None], mcp=None):
         self.wsgi = WSGIMiddleware(app, workers=WSGI_THREADS)
         self._on_shutdown = on_shutdown
+        self._mcp = mcp
+        # Built once, at construction, so a failure to build is a failure to
+        # boot rather than a 500 on the first agent that calls.
+        #
+        # ``transport_security`` is left unset **on purpose**, which disables the
+        # SDK's DNS-rebinding check. Enabled, it validates ``Host`` against an
+        # allowlist that would have to be configured — and this app is reached
+        # under a LAN address, a container name or a reverse proxy's domain, none
+        # of which it can know, with no fourth boot variable to be told
+        # (ADR-0033, ADR-0040). What it would defend against is defended anyway,
+        # and structurally: the SDK enforces ``Content-Type: application/json``
+        # on every POST *whatever* this setting says, and a browser cannot send
+        # that cross-origin without a preflight this app answers no CORS headers
+        # to. It is the same reasoning ``api``'s own origin guard records for why
+        # the JSON routes were never reachable that way.
+        self._mcp_app = (
+            mcp.streamable_http_app(streamable_http_path=MCP_PATH)
+            if mcp is not None else None)
+        self._sessions: Optional[contextlib.AsyncExitStack] = None
 
     async def __call__(self, scope, receive, send) -> None:
-        if scope['type'] != 'lifespan':
-            await self.wsgi(scope, receive, send)
+        if scope['type'] == 'lifespan':
+            await self._lifespan(receive, send)
             return
 
+        if self._mcp_app is not None and _is_mcp(scope.get('path', '')):
+            await self._mcp_app(scope, receive, send)
+            return
+
+        await self.wsgi(scope, receive, send)
+
+    async def _lifespan(self, receive, send) -> None:
+        """Startup arms the session manager; shutdown disarms it, then the runtime.
+
+        A startup that raises is answered with ``lifespan.startup.failed`` rather
+        than left to hang: uvicorn exits on it, which is the one non-zero exit
+        :func:`run` owns, and a boot that cannot arm the agent's interface is a
+        boot that failed like any other.
+        """
         while True:
             message = await receive()
             if message['type'] == 'lifespan.startup':
+                try:
+                    await self._start()
+                except Exception as exc:  # noqa: BLE001 - reported, then re-raised by uvicorn
+                    await send({'type': 'lifespan.startup.failed',
+                                'message': str(exc)})
+                    return
                 await send({'type': 'lifespan.startup.complete'})
             elif message['type'] == 'lifespan.shutdown':
+                await self._stop()
                 self._on_shutdown()
                 await send({'type': 'lifespan.shutdown.complete'})
                 return
 
+    async def _start(self) -> None:
+        """Enter the MCP session manager and hold it for the life of the socket."""
+        if self._mcp is None:
+            return
+        sessions = contextlib.AsyncExitStack()
+        await sessions.enter_async_context(self._mcp.session_manager.run())
+        self._sessions = sessions
+
+    async def _stop(self) -> None:
+        """Close it, once, and before the runtime's own teardown."""
+        if self._sessions is None:
+            return
+        sessions, self._sessions = self._sessions, None
+        await sessions.aclose()
+
+
+def _is_mcp(path: str) -> bool:
+    """Is this path the agent's interface?
+
+    ``MCP_PATH`` itself and anything under it, and **not** a path that merely
+    starts with the same letters: ``/mcpsomething`` is an ordinary unknown path
+    and belongs to the SPA's catch-all, which is what answers it today.
+    """
+    return path == MCP_PATH or path.startswith(MCP_PATH + '/')
+
 
 def serve(app, environment: boot_env.BootEnvironment,
-          on_shutdown: Callable[[], None]) -> None:
+          on_shutdown: Callable[[], None], mcp=None) -> None:
     """Bind the one socket and serve until a signal says otherwise.
 
     ``uvicorn.run`` and not a command line, which is the whole of how the
     multiprocess door stays shut: there is no flag to pass because there is no
     CLI in the image to pass it to.
+
+    **One socket still** (ADR-0033, ADR-0040): the agent's interface arrives as
+    an argument to the application uvicorn is handed, not as a second bind, so
+    ``SB_WEB_PORT`` remains the only port and the boot variables remain three.
     """
     level = environment.log_level.lower()
     uvicorn.run(
-        Serving(app, on_shutdown),
+        Serving(app, on_shutdown, mcp),
         host='0.0.0.0',
         port=environment.web_port,
         log_level=level if level in _UVICORN_LEVELS else 'info',
@@ -112,7 +210,8 @@ def sequence(env: Mapping[str, str]) -> None:
     2. the store, opened, brought to its schema, seeded, and the ledger replayed
        — the connection stays open for the life of the process, because nothing
        has to survive a fork any more (ADR-0039);
-    3. the Flask application, built on that runtime;
+    3. the Flask application **and the agent's interface**, both built on that
+       runtime and both served from the one socket (ADR-0040);
     4. the scheduler and its jobs;
     5. the socket.
 
@@ -128,8 +227,9 @@ def sequence(env: Mapping[str, str]) -> None:
     teardown = partial(main.shutdown_runtime, runtime)
     try:
         app = api.create_app(runtime)
+        mcp = mcp_server.build_server(runtime)
         main.start_runtime(runtime)
-        serve(app, environment, teardown)
+        serve(app, environment, teardown, mcp)
     finally:
         teardown()
 

--- a/src/application/boot.py
+++ b/src/application/boot.py
@@ -125,6 +125,13 @@ class Serving:
     """
 
     def __init__(self, app, on_shutdown: Callable[[], None], mcp=None):
+        """Wrap the two applications, and build the agent's one **now**.
+
+        Building it here rather than on the first request is what makes a
+        server that cannot be built a failure to *boot* — one non-zero exit,
+        which is the whole of this file's failure handling — instead of a 500
+        met by the first agent to call.
+        """
         self.wsgi = WSGIMiddleware(app, workers=WSGI_THREADS)
         self._on_shutdown = on_shutdown
         self._mcp = mcp
@@ -138,6 +145,11 @@ class Serving:
         self._sessions: Optional[contextlib.AsyncExitStack] = None
 
     async def __call__(self, scope, receive, send) -> None:
+        """Three ways out: the lifespan, the agent's interface, the front.
+
+        The order matters only in that the lifespan is not a path and has to be
+        recognised before anything looks at one.
+        """
         if scope['type'] == 'lifespan':
             await self._lifespan(receive, send)
             return

--- a/src/application/boot.py
+++ b/src/application/boot.py
@@ -29,6 +29,7 @@ from typing import Callable, Mapping, Optional
 
 import uvicorn
 from a2wsgi import WSGIMiddleware
+from mcp.server.transport_security import TransportSecuritySettings
 
 from application import boot_env
 from application import main
@@ -45,6 +46,36 @@ WSGI_THREADS = 4
 #: It is the SDK's own default, which is why the mounted application needs no
 #: prefix stripped: it routes on the full path it is handed.
 MCP_PATH = '/mcp'
+
+#: The agent's interface answers under **any** host name, and that is explicit.
+#:
+#: It has to be passed, and passing nothing is the one thing that does not mean
+#: *no policy*. The SDK reads its ``host`` argument — ``127.0.0.1`` by default —
+#: and, finding no settings, **substitutes its own**::
+#:
+#:     if transport_security is None and host in ("127.0.0.1", "localhost", "::1"):
+#:         transport_security = TransportSecuritySettings(
+#:             allowed_hosts=["127.0.0.1:*", "localhost:*", "[::1]:*"], ...)
+#:
+#: which answers ``421 Invalid Host header`` to a LAN address, a container name
+#: and a reverse proxy's domain alike — every way this app is actually reached
+#: except the one a developer tests from. Handing it settings of our own is what
+#: keeps that branch from firing.
+#:
+#: **What it defends is defended anyway, and structurally.** The check exists
+#: against DNS rebinding: a page in the owner's browser resolving a name to this
+#: socket and posting to it. The SDK enforces ``Content-Type: application/json``
+#: on every POST *whatever this setting says* — the one validation that runs
+#: before the disable — and a browser cannot send that cross-origin without a
+#: preflight this app answers no CORS header to. It is the same reasoning
+#: ``api``'s own origin guard records for why the JSON routes were never
+#: reachable that way.
+#:
+#: The alternative was an allowlist, and it is not available: this app cannot
+#: know the name it is reached under, and learning one would be a fourth boot
+#: variable (ADR-0033, ADR-0040 — the boot variables stay three).
+NO_HOST_ALLOWLIST = TransportSecuritySettings(
+    enable_dns_rebinding_protection=False)
 
 #: The levels uvicorn's own logger understands. ``LOG_LEVEL`` is an app-wide
 #: dial that predates any server (ADR-0014), so a value it does not recognise
@@ -100,19 +131,9 @@ class Serving:
         # Built once, at construction, so a failure to build is a failure to
         # boot rather than a 500 on the first agent that calls.
         #
-        # ``transport_security`` is left unset **on purpose**, which disables the
-        # SDK's DNS-rebinding check. Enabled, it validates ``Host`` against an
-        # allowlist that would have to be configured — and this app is reached
-        # under a LAN address, a container name or a reverse proxy's domain, none
-        # of which it can know, with no fourth boot variable to be told
-        # (ADR-0033, ADR-0040). What it would defend against is defended anyway,
-        # and structurally: the SDK enforces ``Content-Type: application/json``
-        # on every POST *whatever* this setting says, and a browser cannot send
-        # that cross-origin without a preflight this app answers no CORS headers
-        # to. It is the same reasoning ``api``'s own origin guard records for why
-        # the JSON routes were never reachable that way.
         self._mcp_app = (
-            mcp.streamable_http_app(streamable_http_path=MCP_PATH)
+            mcp.streamable_http_app(streamable_http_path=MCP_PATH,
+                                    transport_security=NO_HOST_ALLOWLIST)
             if mcp is not None else None)
         self._sessions: Optional[contextlib.AsyncExitStack] = None
 

--- a/src/application/mcp_server.py
+++ b/src/application/mcp_server.py
@@ -515,8 +515,13 @@ def _window(from_day: Optional[str], to_day: Optional[str],
     start_day = _day(from_day, 'from_day')
     start = (datetime.combine(start_day, datetime.min.time(), timezone.utc)
              if start_day is not None else stop - default)
-    if start >= stop:
-        raise ToolError("from_day must be earlier than to_day")
+    # ``>`` and not ``>=``: two equal days are a **one-day window**, not an empty
+    # one. The store bounds a series inclusively at both ends
+    # (:func:`store_reads._window`), so ``from_day == to_day`` asks for exactly
+    # that day's point — and a tool that promises one point per calendar day
+    # cannot refuse to be asked for one of them (issue #877 review).
+    if start > stop:
+        raise ToolError("from_day must not be later than to_day")
     return start, stop
 
 

--- a/src/application/mcp_server.py
+++ b/src/application/mcp_server.py
@@ -287,6 +287,7 @@ def build_server(runtime, name: str = "suivibourse") -> MCPServer:
         diagnostic counter.
         """
         def _body():
+            """The read itself, so :func:`reading` can wrap a fault around it."""
             currency = _base_currency()
             return {
                 'base_currency': currency,
@@ -304,6 +305,7 @@ def build_server(runtime, name: str = "suivibourse") -> MCPServer:
         nothing, and asking is how a resource acquires queries it does not need.
         """
         def _body():
+            """The read itself, so :func:`reading` can wrap a fault around it."""
             reader = _reader()
             latest = reader.latest_totals()
 
@@ -330,6 +332,8 @@ def build_server(runtime, name: str = "suivibourse") -> MCPServer:
         start, stop = _window(from_day, to_day, DEFAULT_HISTORY_WINDOW)
 
         def _body():
+            """The read itself; the window was parsed before it, so a bad day is
+            refused as a bad day and not as a storage fault."""
             return {
                 'base_currency': _base_currency(),
                 'from': start.isoformat(),
@@ -358,6 +362,7 @@ def build_server(runtime, name: str = "suivibourse") -> MCPServer:
         measured at the same instant.
         """
         def _body():
+            """The read itself, so :func:`reading` can wrap a fault around it."""
             accounts = _snapshot().accounts
             declaration = (
                 accounts.accounts if accounts is not None

--- a/src/application/mcp_server.py
+++ b/src/application/mcp_server.py
@@ -1,0 +1,466 @@
+"""The agent's interface — five read-only tools on the one socket (ADR-0040, #749).
+
+This module is the second reader ADR-0040 grants, and it is deliberately the
+same shape as :mod:`api.api`: a thin adapter over the durable Python boundary,
+:class:`store_reads.PortfolioReader` and :mod:`portfolio_view`. **It computes
+nothing.** Every figure a tool returns is the figure a route already returns,
+reached through the same primitive, so the two interfaces cannot drift into
+disagreeing about what the portfolio is worth.
+
+**A tool has two audiences and therefore two texts.** The ``description=`` on the
+decorator is what a *model* reads before choosing to call, and ADR-0040 makes it
+payload rather than documentation: it states which of the three absences a
+``null`` is, that ``terminal`` separates *not priced yet* from *never priced*,
+that a quantity of zero is a sold position. A docstring is what the *next
+maintainer* reads, and it carries the decisions and their issue numbers, which
+mean nothing to a model. Neither text is the other's summary.
+
+**It imports no Flask and no** :mod:`api`. The blueprint reaches its runtime
+through a module global written by ``create_app``; this one is handed the runtime
+by :func:`build_server`, because :mod:`api` already imports :mod:`application`
+and the reverse would close a cycle.
+
+**It writes nothing.** ``entries.py`` remains the ledger's one writer (ADR-0032),
+reached by a person's gesture, and read-only is what makes ADR-0040's access
+model — *the socket is the authorization* — a decision rather than an oversight.
+
+**A refusal is raised as** :class:`ToolError` **and never as a bare exception**,
+and that is not decoration: the SDK reports anything else to the caller as
+*"Error executing tool <name>"* with the message dropped on the floor. An agent
+told that much cannot tell an unreadable store from a malformed date, and it is
+precisely the distinction ADR-0040 insists on — a failure to read must not reach
+a model as an empty portfolio, which means the message has to survive.
+"""
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from mcp.server import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
+
+from application import accounts as accounts_module
+from application import instants
+from application import portfolio_view
+from application import quotes
+from application import store as store_module
+
+#: The window a history tool defaults to when the caller names none. The global
+#: series is written **one point per calendar day** (#660), so a year of it is
+#: 365 points — the same default ``/api/portfolio-totals/history`` takes, and
+#: for the same reason: the short presets that suit a per-share chart are
+#: degenerate on this series.
+DEFAULT_HISTORY_WINDOW = timedelta(days=365)
+
+#: How many ledger rows a tool returns when the caller names no bound.
+#:
+#: **This is the one place the tool surface departs from** ``/api`` (ADR-0040).
+#: ADR-0031 answers ``GET /api/events`` with the ledger entire and argues it: the
+#: forty rows the page reveals are a rendering budget, not a fetch. A browser's
+#: constraint is the pixel; a model's is the context window, and the ledger is
+#: the only resource here whose size is unbounded by what the portfolio *is* —
+#: every other tool is bounded by the holdings, the accounts, or a day.
+DEFAULT_EVENT_LIMIT = 100
+
+#: The absence rule, stated in every description that can return one.
+#:
+#: It is repeated rather than referenced because a model reads one description at
+#: a time and cannot follow a pointer to another (ADR-0026, ADR-0040).
+_ABSENCE = (
+    "A null is never zero and never an error: it means this app has no figure "
+    "to give for that field. Say so plainly rather than substituting a number."
+)
+
+#: The currency rule (ADR-0002).
+_CURRENCY = (
+    "Every amount in this answer is in base_currency, which is stated once for "
+    "the whole payload and never on a row. base_currency is null when nobody "
+    "has answered the app's one required question yet; when it is null, report "
+    "amounts without naming a currency rather than guessing one."
+)
+
+LIST_POSITIONS_DESCRIPTION = f"""\
+What the owner currently holds, one row per (account, symbol).
+
+Each row carries quantity, unit_cost (a weighted average over everything bought,
+never a purchase price), market_value, and the unrealised gain.
+
+{_CURRENCY}
+
+Two things about a row will mislead you if you do not know them:
+
+- quantity 0 is a SOLD position, not a mistake and not an empty row. It stays in
+  the table on purpose, because what it realised still belongs to the totals.
+- terminal tells you which kind of pricelessness a null price is. terminal=false
+  means the app has simply not fetched a price yet and one is expected;
+  terminal=true means no price will ever come for this symbol over the period it
+  was held. Never report a position with a null price as being worth zero — in
+  both cases the honest answer is that it is not priced, and terminal is what
+  lets you say which of the two it is.
+
+{_ABSENCE}
+"""
+
+GET_PORTFOLIO_TOTALS_DESCRIPTION = f"""\
+The portfolio as a whole, on the most recent day the app has computed.
+
+Carries the market value, the net amount contributed, the money-weighted return
+(xirr, annualised), the time-weighted return (twr, an index based at 100), the
+year-to-date figures, and the gain broken into its four terms — the unrealised
+gain, the realised gain, the dividends received, and the transfer fees paid.
+Those four terms sum to the total gain by definition: do not recombine them some
+other way, and do not treat their sum as an independent check.
+
+{_CURRENCY}
+
+totals is null when the app has computed nothing yet, which has two causes and
+one shape: the ledger is empty, or the reporting currency has never been
+answered — the app computes no performance at all until it is. Neither is an
+error and neither means the portfolio is worth zero.
+
+{_ABSENCE}
+"""
+
+GET_PORTFOLIO_HISTORY_DESCRIPTION = f"""\
+The portfolio's value and return, one point per calendar day, over a window.
+
+Each point carries cash_balance, holdings_value, total_value, net_contributed
+and twr_index. Defaults to the last 365 days when no window is given; pass
+from_day and to_day as ISO calendar days (YYYY-MM-DD) to narrow it.
+
+twr_index is an index, not a percentage: it is based at 100 at the start of the
+series the app stored, so a difference between two of its points is a return and
+a single point is not. If you want the return over the window the caller asked
+about, rebase it yourself on the first point of what you received.
+
+{_CURRENCY}
+
+An empty points list means the app has computed nothing over that window — a
+young install, or a window before the ledger starts. It does not mean the
+portfolio was worth zero then.
+
+{_ABSENCE}
+"""
+
+LIST_ACCOUNTS_DESCRIPTION = f"""\
+The declared accounts, each with its newest figures — the allocation primitive.
+
+Use this to answer how the portfolio is split, and to compare accounts. Each
+account carries its own value, net contribution, returns and the four terms of
+its gain.
+
+declared=false means the owner has never declared an account, so what you are
+looking at is the single account every install is given. It is a designed state
+and not an empty one: the list always holds at least one row.
+
+Comparing accounts by value tells you about size, not about performance. twr is
+the figure that compares two accounts of different sizes, because an index
+carries neither size nor currency.
+
+{_CURRENCY}
+
+{_ABSENCE}
+"""
+
+LIST_EVENTS_DESCRIPTION = f"""\
+The event ledger — everything the owner declared they did, newest first.
+
+The ledger is the only thing this app stores as a fact; positions, prices and
+performance are all derived from it. Use this to answer what the owner actually
+did, and when.
+
+THIS ANSWER IS A SLICE. It returns at most `limit` events (default
+{DEFAULT_EVENT_LIMIT}) out of `total`, which counts every event matching the
+filters. Read `total` before you characterise the owner's history: if returned
+is less than total, you are looking at the most recent part of it and you must
+say so rather than describing it as the whole. Narrow with from_day / to_day
+(ISO calendar days), with symbol, or raise limit deliberately.
+
+Filtering by symbol excludes cash events (DEPOSIT and WITHDRAWAL), which carry no
+symbol. An account of "default" is the account every install is given.
+
+{_CURRENCY}
+
+{_ABSENCE}
+"""
+
+
+def build_server(runtime, name: str = "suivibourse") -> MCPServer:
+    """The MCP server for a runtime — the tools closed over it, and nothing else.
+
+    Takes the runtime rather than reaching for one, which is the seam
+    ``api.create_app(runtime)`` already established (ADR-0039) and the reason
+    this module does not import :mod:`api`.
+
+    The tool functions are defined here rather than at module level so that they
+    close over ``runtime``: that is what makes them **callable in process** by
+    the built-in chat (#750) with no HTTP hop in a loopback, which is ADR-0040's
+    one-surface-consumed-twice.
+    """
+    mcp = MCPServer(
+        name=name,
+        instructions=(
+            "SuiviBourse tracks one person's stock portfolio. A portfolio here "
+            "is a dated ledger of what its owner did; everything else — the "
+            "positions, the prices, the returns — is derived from it. These "
+            "tools read that data and cannot change it.\n\n"
+            "Advise on strategy and allocation. Do not recommend individual "
+            "securities to buy or sell.\n\n"
+            "Read each tool's description before using its figures: this app "
+            "distinguishes several kinds of absence that a null would otherwise "
+            "flatten, and reporting one of them as a zero is the mistake that "
+            "matters here."
+        ),
+    )
+
+    def _store():
+        """The runtime's open store, raising when there is none.
+
+        The raise is the contract, exactly as it is on the blueprint: an absent
+        store is a **failed call**, and it must never reach a model as an empty
+        portfolio. An agent handed ``[]`` reports that the owner holds nothing.
+        """
+        if runtime.store is None:
+            raise ToolError(
+                "the portfolio store is not available in this process; this is "
+                "a failure to read, not an empty portfolio")
+        return runtime.store
+
+    def _snapshot():
+        """The published configuration snapshot — the lock-free read (#658)."""
+        return runtime.config_manager.current()
+
+    def _reader():
+        """A reader over the open store — built per call, holding no state."""
+        from application.store_reads import PortfolioReader
+        return PortfolioReader(_store())
+
+    def _base_currency() -> Optional[str]:
+        """The reporting currency, or ``None`` while the question is unanswered."""
+        return _store().setting('base_currency')
+
+    def _carried():
+        """The symbols a position may be carried at cost on (ADR-0004, #845).
+
+        Two batched queries for the whole portfolio, never one per row — the
+        same call ``/api/positions`` makes, and the reason ``terminal`` can ride
+        on every row of :func:`list_positions` without a read per holding.
+        """
+        return quotes.terminal_symbols(
+            _store(), _snapshot().backfill_windows(),
+            datetime.now(timezone.utc))
+
+    @mcp.tool(description=LIST_POSITIONS_DESCRIPTION)
+    def list_positions() -> Dict[str, Any]:
+        """``/api/positions``' payload, field for field.
+
+        Reached through the same primitive and the same builder, so the page and
+        the agent cannot disagree about a holding. ``terminal`` rides on the row
+        for the reason #845 put it there: without it a reader cannot tell *no
+        price yet* from *no price ever*, and the substitute it reached for was a
+        diagnostic counter.
+        """
+        currency = _base_currency()
+        return {
+            'base_currency': currency,
+            'positions': portfolio_view.build_positions(
+                _reader().positions(), currency, _carried()),
+        }
+
+    @mcp.tool(description=GET_PORTFOLIO_TOTALS_DESCRIPTION)
+    def get_portfolio_totals() -> Dict[str, Any]:
+        """The newest day of the global perf series, plus its three derivations.
+
+        The three extra reads are asked only once there is a row to hang them
+        on: on an install whose perf cache is empty they would each answer
+        nothing, and asking is how a resource acquires queries it does not need.
+        """
+        reader = _reader()
+        latest = reader.latest_totals()
+
+        totals = None
+        if latest is not None:
+            day = latest['day']
+            totals = portfolio_view.build_portfolio_totals(
+                latest,
+                reader.totals_on_or_before(portfolio_view.ytd_base_day(day)),
+                reader.twr_origin(),
+                reader.transfer_fees(day))
+
+        return {'base_currency': _base_currency(), 'totals': totals}
+
+    @mcp.tool(description=GET_PORTFOLIO_HISTORY_DESCRIPTION)
+    def get_portfolio_history(from_day: Optional[str] = None,
+                              to_day: Optional[str] = None) -> Dict[str, Any]:
+        """The global perf series over a window — five members, as #721 defines them.
+
+        The five are the account resource's field for field, so one shape reads
+        both and a rebasing is written once (ADR-0019).
+        """
+        start, stop = _window(from_day, to_day, DEFAULT_HISTORY_WINDOW)
+        return {
+            'base_currency': _base_currency(),
+            'from': start.isoformat(),
+            'to': stop.isoformat(),
+            'points': [
+                {
+                    'day': instants.iso(row.get('day')),
+                    'cash_balance': row.get('cash_balance'),
+                    'holdings_value': row.get('holdings_value'),
+                    'total_value': row.get('total_value'),
+                    'net_contributed': row.get('net_contributed'),
+                    'twr_index': row.get('twr_index'),
+                }
+                for row in _reader().totals_series(start, stop)
+            ],
+        }
+
+    @mcp.tool(description=LIST_ACCOUNTS_DESCRIPTION)
+    def list_accounts() -> Dict[str, Any]:
+        """The declared accounts with their newest figures — ``/api/accounts``.
+
+        ``transfer_fees`` is bounded per account by the day its own row
+        describes (#765): the days differ the moment one account's series is
+        capped in the past, and ADR-0018's identity only holds between terms
+        measured at the same instant.
+        """
+        accounts = _snapshot().accounts
+        declaration = (accounts.accounts if accounts is not None
+                       else [row for row in accounts_module.read_accounts(_store())
+                             if row.id == accounts_module.DEFAULT_ACCOUNT])
+        declaration = [accounts_module.as_declared(row) for row in declaration]
+
+        reader = _reader()
+        rows = reader.latest_account_metrics()
+        through = {
+            row['account']: row['day'] for row in rows
+            if row.get('account') is not None and row.get('day') is not None
+        }
+        return {
+            'base_currency': _base_currency(),
+            'declared': accounts is not None,
+            'accounts': [
+                summary.to_dict()
+                for summary in portfolio_view.build_accounts(
+                    declaration, rows, reader.transfer_fees_by_account(through))
+            ],
+        }
+
+    @mcp.tool(description=LIST_EVENTS_DESCRIPTION)
+    def list_events(symbol: Optional[str] = None,
+                    from_day: Optional[str] = None,
+                    to_day: Optional[str] = None,
+                    limit: int = DEFAULT_EVENT_LIMIT) -> Dict[str, Any]:
+        """The ledger, **bounded**, from the published snapshot (ADR-0031, ADR-0040).
+
+        **From the snapshot and not from the store**, which is ``/api/events``'
+        contract and is inherited whole: the rows served are the ones the
+        aggregator actually ran on, so the ledger an agent sees is the ledger
+        every other figure was computed from. It follows that this tool has no
+        store failure to report — it opens nothing — and that is deliberate
+        rather than an omission.
+
+        **The bound is this surface's one departure from** ``/api`` and the
+        reason is written on :data:`DEFAULT_EVENT_LIMIT`. ``total`` travels with
+        the slice because a bounded answer without one is worse than an
+        unbounded answer: it produces a reader that states *"you have made a
+        hundred operations"* in perfect confidence.
+
+        Newest first, which the resource is not: a page reads a ledger forwards,
+        and a bound that keeps the *oldest* hundred events of a ten-year history
+        answers a question nobody asked.
+        """
+        events = _snapshot().events
+
+        if symbol:
+            events = [event for event in events if event.symbol == symbol]
+        start = _day(from_day, 'from_day')
+        if start is not None:
+            events = [event for event in events
+                      if event.date is not None and event.date >= start]
+        stop = _day(to_day, 'to_day')
+        if stop is not None:
+            events = [event for event in events
+                      if event.date is not None and event.date <= stop]
+
+        total = len(events)
+        if limit < 0:
+            raise ToolError("limit must not be negative")
+        # ``date.min`` for an undated row rather than a tuple key: two of them
+        # would put ``None < None`` on the comparison path and raise, which is a
+        # crash a ledger produces and no test would think to write.
+        newest = sorted(events,
+                        key=lambda event: event.date or date.min,
+                        reverse=True)[:limit]
+
+        return {
+            'base_currency': _base_currency(),
+            'total': total,
+            'returned': len(newest),
+            'events': [_event_to_dict(event) for event in newest],
+        }
+
+    return mcp
+
+
+def _event_to_dict(event) -> Dict[str, Any]:
+    """One event, as ``/api/events`` puts it on the wire.
+
+    ``id`` is a string for the reason #764 records — a JSON number above 2^53 is
+    not the integer that was sent — and the four numbers go out through
+    :func:`store.finite`, because JSON has neither NaN nor infinity and a single
+    such value would make the whole answer unparseable.
+
+    There is no provenance here and none in the store (ADR-0032): a file is a
+    payload, so the row it wrote is a row.
+    """
+    return {key: store_module.finite(value) for key, value in {
+        'id': str(event.id) if event.id is not None else None,
+        'date': event.date.isoformat() if event.date else None,
+        'event_type': event.event_type.value,
+        'symbol': event.symbol,
+        'name': event.name,
+        'quantity': event.quantity,
+        'unit_price': event.unit_price,
+        'fee': event.fee,
+        'amount': event.amount,
+        'notes': event.notes,
+        'account': event.account,
+    }.items()}
+
+
+def _day(value: Optional[str], field: str) -> Optional[date]:
+    """One ISO calendar day on the way in, and only that spelling (#764).
+
+    ``date.fromisoformat`` accepts several others since 3.11 — a bare
+    ``20260210``, a whole instant — and the store's rule is that a day is a day
+    and never a midnight: a bound that arrived as an instant is what silently
+    drops the first day of every window.
+    """
+    if not value:
+        return None
+    text = value.strip()
+    try:
+        parsed = date.fromisoformat(text)
+    except ValueError:
+        raise ToolError(
+            f"{field} must be an ISO calendar day (YYYY-MM-DD), got {value!r}")
+    if parsed.isoformat() != text:
+        raise ToolError(
+            f"{field} must be an ISO calendar day (YYYY-MM-DD), got {value!r}")
+    return parsed
+
+
+def _window(from_day: Optional[str], to_day: Optional[str],
+            default: timedelta) -> tuple:
+    """Resolve two optional calendar days into a UTC instant window."""
+    stop_day = _day(to_day, 'to_day')
+    stop = (datetime.combine(stop_day, datetime.min.time(), timezone.utc)
+            if stop_day is not None else datetime.now(timezone.utc))
+    start_day = _day(from_day, 'from_day')
+    start = (datetime.combine(start_day, datetime.min.time(), timezone.utc)
+             if start_day is not None else stop - default)
+    if start >= stop:
+        raise ToolError("from_day must be earlier than to_day")
+    return start, stop
+
+
+__all__ = ['build_server', 'DEFAULT_EVENT_LIMIT', 'DEFAULT_HISTORY_WINDOW']

--- a/src/application/mcp_server.py
+++ b/src/application/mcp_server.py
@@ -34,6 +34,8 @@ a model as an empty portfolio, which means the message has to survive.
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
+import duckdb
+
 from mcp.server import MCPServer
 from mcp.server.mcpserver.exceptions import ToolError
 
@@ -224,6 +226,32 @@ def build_server(runtime, name: str = "suivibourse") -> MCPServer:
                 "a failure to read, not an empty portfolio")
         return runtime.store
 
+    def reading(work):
+        """Run a tool body, and let a storage fault arrive **in words**.
+
+        ``_store`` raises :class:`ToolError` for the store that is not there;
+        this is the other half, and without it the half above is decorative. A
+        query that fails raises ``duckdb.Error``, which is not a
+        :class:`ToolError` — so the SDK reports it as *"Error executing tool
+        <name>"* with the cause discarded, and a model cannot tell an unreadable
+        store from a malformed date. ADR-0040 asks for exactly that distinction
+        to survive, and it is this wrapper that makes it.
+
+        The message is the exception's own text and nothing constructed: a
+        DuckDB error names the table it could not read, which is the one thing
+        that turns *something failed* into a bug report.
+
+        A ``ToolError`` travels untouched — it is already the answer.
+        """
+        try:
+            return work()
+        except ToolError:
+            raise
+        except (store_module.StoreUnavailable, duckdb.Error) as exc:
+            raise ToolError(
+                f"the portfolio store could not answer this read, so there is "
+                f"no figure to give: {exc}") from exc
+
     def _snapshot():
         """The published configuration snapshot — the lock-free read (#658)."""
         return runtime.config_manager.current()
@@ -258,12 +286,14 @@ def build_server(runtime, name: str = "suivibourse") -> MCPServer:
         price yet* from *no price ever*, and the substitute it reached for was a
         diagnostic counter.
         """
-        currency = _base_currency()
-        return {
-            'base_currency': currency,
-            'positions': portfolio_view.build_positions(
-                _reader().positions(), currency, _carried()),
-        }
+        def _body():
+            currency = _base_currency()
+            return {
+                'base_currency': currency,
+                'positions': portfolio_view.build_positions(
+                    _reader().positions(), currency, _carried()),
+            }
+        return reading(_body)
 
     @mcp.tool(description=GET_PORTFOLIO_TOTALS_DESCRIPTION)
     def get_portfolio_totals() -> Dict[str, Any]:
@@ -273,19 +303,21 @@ def build_server(runtime, name: str = "suivibourse") -> MCPServer:
         on: on an install whose perf cache is empty they would each answer
         nothing, and asking is how a resource acquires queries it does not need.
         """
-        reader = _reader()
-        latest = reader.latest_totals()
+        def _body():
+            reader = _reader()
+            latest = reader.latest_totals()
 
-        totals = None
-        if latest is not None:
-            day = latest['day']
-            totals = portfolio_view.build_portfolio_totals(
-                latest,
-                reader.totals_on_or_before(portfolio_view.ytd_base_day(day)),
-                reader.twr_origin(),
-                reader.transfer_fees(day))
+            totals = None
+            if latest is not None:
+                day = latest['day']
+                totals = portfolio_view.build_portfolio_totals(
+                    latest,
+                    reader.totals_on_or_before(portfolio_view.ytd_base_day(day)),
+                    reader.twr_origin(),
+                    reader.transfer_fees(day))
 
-        return {'base_currency': _base_currency(), 'totals': totals}
+            return {'base_currency': _base_currency(), 'totals': totals}
+        return reading(_body)
 
     @mcp.tool(description=GET_PORTFOLIO_HISTORY_DESCRIPTION)
     def get_portfolio_history(from_day: Optional[str] = None,
@@ -296,22 +328,25 @@ def build_server(runtime, name: str = "suivibourse") -> MCPServer:
         both and a rebasing is written once (ADR-0019).
         """
         start, stop = _window(from_day, to_day, DEFAULT_HISTORY_WINDOW)
-        return {
-            'base_currency': _base_currency(),
-            'from': start.isoformat(),
-            'to': stop.isoformat(),
-            'points': [
-                {
-                    'day': instants.iso(row.get('day')),
-                    'cash_balance': row.get('cash_balance'),
-                    'holdings_value': row.get('holdings_value'),
-                    'total_value': row.get('total_value'),
-                    'net_contributed': row.get('net_contributed'),
-                    'twr_index': row.get('twr_index'),
-                }
-                for row in _reader().totals_series(start, stop)
-            ],
-        }
+
+        def _body():
+            return {
+                'base_currency': _base_currency(),
+                'from': start.isoformat(),
+                'to': stop.isoformat(),
+                'points': [
+                    {
+                        'day': instants.iso(row.get('day')),
+                        'cash_balance': row.get('cash_balance'),
+                        'holdings_value': row.get('holdings_value'),
+                        'total_value': row.get('total_value'),
+                        'net_contributed': row.get('net_contributed'),
+                        'twr_index': row.get('twr_index'),
+                    }
+                    for row in _reader().totals_series(start, stop)
+                ],
+            }
+        return reading(_body)
 
     @mcp.tool(description=LIST_ACCOUNTS_DESCRIPTION)
     def list_accounts() -> Dict[str, Any]:
@@ -322,27 +357,32 @@ def build_server(runtime, name: str = "suivibourse") -> MCPServer:
         capped in the past, and ADR-0018's identity only holds between terms
         measured at the same instant.
         """
-        accounts = _snapshot().accounts
-        declaration = (accounts.accounts if accounts is not None
-                       else [row for row in accounts_module.read_accounts(_store())
-                             if row.id == accounts_module.DEFAULT_ACCOUNT])
-        declaration = [accounts_module.as_declared(row) for row in declaration]
+        def _body():
+            accounts = _snapshot().accounts
+            declaration = (
+                accounts.accounts if accounts is not None
+                else [row for row in accounts_module.read_accounts(_store())
+                      if row.id == accounts_module.DEFAULT_ACCOUNT])
+            declaration = [accounts_module.as_declared(row)
+                           for row in declaration]
 
-        reader = _reader()
-        rows = reader.latest_account_metrics()
-        through = {
-            row['account']: row['day'] for row in rows
-            if row.get('account') is not None and row.get('day') is not None
-        }
-        return {
-            'base_currency': _base_currency(),
-            'declared': accounts is not None,
-            'accounts': [
-                summary.to_dict()
-                for summary in portfolio_view.build_accounts(
-                    declaration, rows, reader.transfer_fees_by_account(through))
-            ],
-        }
+            reader = _reader()
+            rows = reader.latest_account_metrics()
+            through = {
+                row['account']: row['day'] for row in rows
+                if row.get('account') is not None and row.get('day') is not None
+            }
+            return {
+                'base_currency': _base_currency(),
+                'declared': accounts is not None,
+                'accounts': [
+                    summary.to_dict()
+                    for summary in portfolio_view.build_accounts(
+                        declaration, rows,
+                        reader.transfer_fees_by_account(through))
+                ],
+            }
+        return reading(_body)
 
     @mcp.tool(description=LIST_EVENTS_DESCRIPTION)
     def list_events(symbol: Optional[str] = None,
@@ -351,12 +391,20 @@ def build_server(runtime, name: str = "suivibourse") -> MCPServer:
                     limit: int = DEFAULT_EVENT_LIMIT) -> Dict[str, Any]:
         """The ledger, **bounded**, from the published snapshot (ADR-0031, ADR-0040).
 
-        **From the snapshot and not from the store**, which is ``/api/events``'
-        contract and is inherited whole: the rows served are the ones the
+        **The rows come from the snapshot and not from the store**, which is
+        ``/api/events``' contract and is inherited whole: they are the ones the
         aggregator actually ran on, so the ledger an agent sees is the ledger
-        every other figure was computed from. It follows that this tool has no
-        store failure to report — it opens nothing — and that is deliberate
-        rather than an omission.
+        every other figure was computed from.
+
+        **The head is not**, and the docstring used to claim otherwise. The
+        reporting currency is a setting, the snapshot does not carry one, and
+        every amount below — a unit price, a fee, an amount — is meaningless
+        without it: this tool therefore reads the store for exactly one value
+        and fails like any other when it cannot. What `/api/events` gains from
+        opening nothing is the shares page's chart markers surviving a storage
+        fault; there is no equivalent stake here, where a broken store has
+        already taken the other four tools with it. The resilience was copied
+        along with the rule, and it never transferred.
 
         **The bound is this surface's one departure from** ``/api`` and the
         reason is written on :data:`DEFAULT_EVENT_LIMIT`. ``total`` travels with
@@ -392,7 +440,7 @@ def build_server(runtime, name: str = "suivibourse") -> MCPServer:
                         reverse=True)[:limit]
 
         return {
-            'base_currency': _base_currency(),
+            'base_currency': reading(_base_currency),
             'total': total,
             'returned': len(newest),
             'events': [_event_to_dict(event) for event in newest],
@@ -435,7 +483,11 @@ def _day(value: Optional[str], field: str) -> Optional[date]:
     and never a midnight: a bound that arrived as an instant is what silently
     drops the first day of every window.
     """
-    if not value:
+    # ``is None`` and not falsiness: the contract takes an absent argument or a
+    # calendar day, and ``''`` is neither. Read as an omission it silently
+    # widens the window a caller meant to narrow — the one wrong answer that
+    # looks like a right one.
+    if value is None:
         return None
     text = value.strip()
     try:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,395 @@
+"""The agent's five tools (ADR-0040, issue #749).
+
+**The store is real**, under ``tmp_path``, as it is everywhere else in this
+suite; the one faked external edge is still yfinance and nothing here needs it.
+The surface is exercised through the SDK's **in-memory client**, which is what
+proves a description exists at all — a tool called as a Python function would
+pass with an empty one, and the description is payload (ADR-0040).
+
+No test binds a socket. Speaking Streamable HTTP over a real port would re-test
+the SDK's transport and nothing of ours; what is ours is the routing, and that is
+held in ``test_mcp_wiring.py``.
+"""
+import asyncio
+from datetime import date
+
+import pytest
+from mcp import Client
+
+from application import entries
+from application import main
+from application import mcp_server
+from application import store as store_module
+from application.events.schemas import Event, EventType
+
+
+def build_runtime(tmp_path, events=None, currency='EUR', break_store=False):
+    """A runtime over a real store — ``build_runtime``'s shape, in miniature.
+
+    The events go in through :func:`entries.create_many`, which is the ledger's
+    one writer (ADR-0032) and the function the upload route calls: a fixture that
+    wrote rows itself would be writing through a road the product does not have.
+
+    ``manager.reload()`` is the first publication, as the boot performs it. It
+    matters here beyond ceremony: ``list_events`` answers from the **snapshot**
+    and not from the store, which is ``/api/events``' contract inherited whole.
+    """
+    opened = store_module.open_store(tmp_path / 'store.duckdb')
+    if currency is not None:
+        opened.execute(
+            'INSERT INTO setting (key, value) VALUES (?, ?) '
+            'ON CONFLICT (key) DO UPDATE SET value = excluded.value',
+            ['base_currency', currency])
+    if events:
+        entries.create_many(opened, events)
+    manager = main.ConfigurationManager(config_dir=str(tmp_path),
+                                        opened_store=opened)
+    runtime = main.Runtime(manager, None)
+    runtime.store = opened
+    manager.reload()
+    if break_store:
+        # A genuine storage fault rather than a simulated one, exactly as the
+        # web suite produces it: the query raises and nothing in between has to
+        # recognise an error message.
+        opened.execute('DROP TABLE position')
+        opened.execute('DROP TABLE account_metrics')
+        opened.execute('DROP TABLE portfolio_totals')
+        opened.execute('DROP TABLE price_point')
+    return runtime, opened
+
+
+def call(runtime, tool, arguments=None):
+    """Call one tool through the in-memory client and hand back the result."""
+    async def _run():
+        async with Client(mcp_server.build_server(runtime)) as client:
+            return await client.call_tool(tool, arguments or {})
+    return asyncio.run(_run())
+
+
+def payload(result):
+    """The structured payload of a successful call.
+
+    The SDK wraps a mapping return under ``result``; unwrapping it here keeps
+    that detail in one place rather than in every assertion.
+    """
+    assert result.is_error is False, _text(result)
+    return result.structured_content['result']
+
+
+def _text(result):
+    return result.content[0].text if result.content else ''
+
+
+LEDGER = [
+    Event(date(2024, 1, 15), EventType.BUY, "AAPL", "Apple Inc",
+          quantity=10, unit_price=150.00, fee=2.50),
+    Event(date(2024, 2, 1), EventType.BUY, "MSFT", "Microsoft",
+          quantity=5, unit_price=380.00, fee=2.50),
+    Event(date(2024, 3, 1), EventType.DIVIDEND, "AAPL", "Apple Inc",
+          amount=2.40),
+    Event(date(2024, 6, 15), EventType.BUY, "AAPL", "Apple Inc",
+          quantity=5, unit_price=175.00, fee=2.00),
+    Event(date(2024, 9, 15), EventType.SELL, "AAPL", "Apple Inc",
+          quantity=3, unit_price=190.00, fee=2.00),
+]
+
+
+# --------------------------------------------------------------------- #
+# The surface itself
+# --------------------------------------------------------------------- #
+
+def test_the_surface_is_five_tools_and_nothing_else(tmp_path):
+    """Five, named, and no sixth arriving by accident.
+
+    The list is asserted **whole** rather than by membership: ADR-0040 makes
+    these names a contract, so a tool appearing here is a promise made and a
+    tool leaving is a promise broken. Either should fail a test rather than a
+    user's setup.
+    """
+    runtime, _ = build_runtime(tmp_path)
+
+    async def _run():
+        async with Client(mcp_server.build_server(runtime)) as client:
+            return await client.list_tools()
+
+    names = sorted(tool.name for tool in asyncio.run(_run()).tools)
+    assert names == ['get_portfolio_history', 'get_portfolio_totals',
+                     'list_accounts', 'list_events', 'list_positions']
+
+
+def test_every_description_states_the_absence_rule(tmp_path):
+    """A description is payload, not documentation (ADR-0040).
+
+    This is the test that stops a description from being trimmed to a stub the
+    day somebody finds them long. What it holds is the **one** convention every
+    tool here can return and that a model gets wrong by default: a ``null`` is
+    not a zero. It is asserted on the text a client actually receives, which is
+    the only copy that reaches a model.
+    """
+    runtime, _ = build_runtime(tmp_path)
+
+    async def _run():
+        async with Client(mcp_server.build_server(runtime)) as client:
+            return await client.list_tools()
+
+    for tool in asyncio.run(_run()).tools:
+        description = tool.description or ''
+        assert len(description) > 200, tool.name
+        assert 'null' in description, tool.name
+        assert 'never zero' in description or 'not priced' in description, tool.name
+
+
+def test_the_positions_description_carries_both_terms_of_the_carrying_convention(tmp_path):
+    """``terminal`` is useless to a model that is not told what it separates.
+
+    ADR-0004's second term (#845) is the difference between *not priced yet* and
+    *never priced*, and a reader that has the field but not the sentence reports
+    an unpriced holding as worth nothing — which is the defect the field was
+    added against, met one layer further out.
+    """
+    runtime, _ = build_runtime(tmp_path)
+
+    async def _run():
+        async with Client(mcp_server.build_server(runtime)) as client:
+            return await client.list_tools()
+
+    described = {tool.name: tool.description or ''
+                 for tool in asyncio.run(_run()).tools}['list_positions']
+    assert 'terminal' in described
+    assert 'not fetched a price yet' in described
+    assert 'no price will ever come' in described
+    assert 'worth zero' in described
+
+
+# --------------------------------------------------------------------- #
+# The figures
+# --------------------------------------------------------------------- #
+
+def test_positions_name_the_reporting_currency_in_the_head(tmp_path):
+    """One reporting currency, on the payload and never on a row (ADR-0002)."""
+    runtime, _ = build_runtime(tmp_path, events=LEDGER, currency='EUR')
+
+    body = payload(call(runtime, 'list_positions'))
+
+    assert body['base_currency'] == 'EUR'
+    assert body['positions']
+    for row in body['positions']:
+        assert 'currency' not in row
+
+
+def test_a_null_currency_is_how_the_unanswered_question_is_said(tmp_path):
+    """No fourth kind of absence for it, and no error either (ADR-0021)."""
+    runtime, _ = build_runtime(tmp_path, events=LEDGER, currency=None)
+
+    assert payload(call(runtime, 'list_positions'))['base_currency'] is None
+
+
+def test_terminal_rides_on_every_position(tmp_path):
+    """Every row, not the priceless ones — a reader cannot ask for it per row."""
+    runtime, _ = build_runtime(tmp_path, events=LEDGER)
+
+    rows = payload(call(runtime, 'list_positions'))['positions']
+
+    assert rows
+    for row in rows:
+        assert 'terminal' in row
+
+
+def test_an_empty_ledger_is_a_successful_answer_that_still_names_the_currency(tmp_path):
+    """``200`` + nothing held, never an error and never a null head.
+
+    The distinction this holds is the one ADR-0040 says an agent cannot be
+    allowed to lose: owning nothing and being unable to read are two answers.
+    """
+    runtime, _ = build_runtime(tmp_path, events=None, currency='EUR')
+
+    body = payload(call(runtime, 'list_positions'))
+
+    assert body['positions'] == []
+    assert body['base_currency'] == 'EUR'
+
+
+def test_the_accounts_list_always_holds_at_least_one_row(tmp_path):
+    """ADR-0013: an install that declared nothing still has the seeded account.
+
+    ``declared`` is a designed state and not an empty one, and it is served
+    rather than left to a client to synthesise — a model asked *which accounts
+    are there* must not be answered *none*, which ADR-0013 says is impossible.
+    """
+    runtime, _ = build_runtime(tmp_path, events=LEDGER)
+
+    body = payload(call(runtime, 'list_accounts'))
+
+    assert body['declared'] is False
+    assert len(body['accounts']) >= 1
+
+
+def test_totals_are_null_rather_than_absent_when_nothing_is_computed(tmp_path):
+    """One shape for two causes, and the head keeps its subject either way."""
+    runtime, _ = build_runtime(tmp_path, events=None, currency='EUR')
+
+    body = payload(call(runtime, 'get_portfolio_totals'))
+
+    assert body['totals'] is None
+    assert body['base_currency'] == 'EUR'
+
+
+def test_the_history_defaults_to_a_year_and_honours_a_window(tmp_path):
+    """The global series is one point per calendar day, so a month of it is thirty."""
+    runtime, _ = build_runtime(tmp_path, events=LEDGER)
+
+    wide = payload(call(runtime, 'get_portfolio_history'))
+    narrow = payload(call(runtime, 'get_portfolio_history',
+                          {'from_day': '2024-01-01', 'to_day': '2024-02-01'}))
+
+    stop = date.fromisoformat(wide['to'][:10])
+    start = date.fromisoformat(wide['from'][:10])
+    assert (stop - start).days == 365
+    assert narrow['from'].startswith('2024-01-01')
+    assert narrow['to'].startswith('2024-02-01')
+
+
+# --------------------------------------------------------------------- #
+# The ledger — the one departure from /api (ADR-0040)
+# --------------------------------------------------------------------- #
+
+def test_the_ledger_is_bounded_and_says_how_much_it_left_out(tmp_path):
+    """A slice without its total is worse than no bound at all.
+
+    It produces a reader that states *"you have made two operations"* in perfect
+    confidence, which is the failure this member exists against.
+    """
+    runtime, _ = build_runtime(tmp_path, events=LEDGER)
+
+    body = payload(call(runtime, 'list_events', {'limit': 2}))
+
+    assert body['total'] == len(LEDGER)
+    assert body['returned'] == 2
+    assert len(body['events']) == 2
+
+
+def test_the_ledger_is_bounded_by_default(tmp_path):
+    """The default is a bound, not the absence of one."""
+    runtime, _ = build_runtime(tmp_path, events=LEDGER)
+
+    body = payload(call(runtime, 'list_events'))
+
+    assert body['returned'] == len(LEDGER)
+    assert mcp_server.DEFAULT_EVENT_LIMIT == 100
+
+
+def test_the_ledger_comes_back_newest_first(tmp_path):
+    """A bound that kept the oldest hundred of a ten-year history answers nothing."""
+    runtime, _ = build_runtime(tmp_path, events=LEDGER)
+
+    body = payload(call(runtime, 'list_events', {'limit': 2}))
+
+    dates = [event['date'] for event in body['events']]
+    assert dates == ['2024-09-15', '2024-06-15']
+
+
+def test_the_ledger_narrows_by_symbol_and_the_total_narrows_with_it(tmp_path):
+    """``total`` counts what matched the filters, not what the ledger holds."""
+    runtime, _ = build_runtime(tmp_path, events=LEDGER)
+
+    body = payload(call(runtime, 'list_events', {'symbol': 'MSFT'}))
+
+    assert body['total'] == 1
+    assert {event['symbol'] for event in body['events']} == {'MSFT'}
+
+
+def test_the_ledger_narrows_by_calendar_day(tmp_path):
+    """Both bounds are inclusive, and a day is a day and never a midnight."""
+    runtime, _ = build_runtime(tmp_path, events=LEDGER)
+
+    body = payload(call(runtime, 'list_events',
+                        {'from_day': '2024-02-01', 'to_day': '2024-06-15'}))
+
+    dates = [event['date'] for event in body['events']]
+    assert dates == ['2024-06-15', '2024-03-01', '2024-02-01']
+
+
+def test_the_ledger_reads_the_snapshot_and_therefore_survives_a_broken_store(tmp_path):
+    """``/api/events``' contract, inherited whole (ADR-0031).
+
+    It answers from process memory, so it has no storage failure to report — and
+    that is a decision rather than an omission: the rows served are the ones the
+    aggregator ran on, so the ledger an agent sees is the ledger every other
+    figure was computed from.
+    """
+    runtime, _ = build_runtime(tmp_path, events=LEDGER, break_store=True)
+
+    assert payload(call(runtime, 'list_events'))['total'] == len(LEDGER)
+
+
+# --------------------------------------------------------------------- #
+# Refusals — and the message surviving them
+# --------------------------------------------------------------------- #
+
+@pytest.mark.parametrize('tool', ['list_positions', 'get_portfolio_totals',
+                                  'get_portfolio_history', 'list_accounts'])
+def test_a_store_that_cannot_answer_is_an_error_and_never_an_empty_payload(tmp_path, tool):
+    """The distinction ADR-0040 will not let a model lose.
+
+    An agent handed ``[]`` reports that the owner holds nothing. Every tool that
+    opens the store therefore fails loudly when it cannot.
+    """
+    runtime, _ = build_runtime(tmp_path, events=LEDGER, break_store=True)
+
+    result = call(runtime, tool)
+
+    assert result.is_error is True
+    assert result.structured_content is None
+
+
+def test_an_absent_store_says_so_in_words_the_caller_receives(tmp_path):
+    """:class:`ToolError` and not a bare exception, or the message is dropped.
+
+    The SDK reports anything else as *"Error executing tool <name>"* with the
+    cause discarded — and a model told that much cannot tell an unreadable store
+    from a malformed date.
+    """
+    runtime, _ = build_runtime(tmp_path, events=LEDGER)
+    runtime.store = None
+
+    result = call(runtime, 'list_positions')
+
+    assert result.is_error is True
+    assert 'not available' in _text(result)
+    assert 'not an empty portfolio' in _text(result)
+
+
+@pytest.mark.parametrize('value', ['20240115', '2024-01-15T00:00:00Z',
+                                   'yesterday', '2024-1-15'])
+def test_only_one_spelling_of_a_calendar_day_is_taken(tmp_path, value):
+    """#764's rule, and the reason it is not ``date.fromisoformat`` alone.
+
+    That function accepts several other spellings since 3.11 — a bare
+    ``20260210``, a whole instant — and a bound that arrived as an instant is
+    what silently drops the first day of every window.
+    """
+    runtime, _ = build_runtime(tmp_path, events=LEDGER)
+
+    result = call(runtime, 'list_events', {'from_day': value})
+
+    assert result.is_error is True
+    assert 'YYYY-MM-DD' in _text(result)
+
+
+def test_an_inverted_window_is_refused_in_words(tmp_path):
+    runtime, _ = build_runtime(tmp_path, events=LEDGER)
+
+    result = call(runtime, 'get_portfolio_history',
+                  {'from_day': '2024-06-01', 'to_day': '2024-01-01'})
+
+    assert result.is_error is True
+    assert 'earlier' in _text(result)
+
+
+def test_a_negative_bound_is_refused_in_words(tmp_path):
+    runtime, _ = build_runtime(tmp_path, events=LEDGER)
+
+    result = call(runtime, 'list_events', {'limit': -1})
+
+    assert result.is_error is True
+    assert 'negative' in _text(result)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -309,17 +309,60 @@ def test_the_ledger_narrows_by_calendar_day(tmp_path):
     assert dates == ['2024-06-15', '2024-03-01', '2024-02-01']
 
 
-def test_the_ledger_reads_the_snapshot_and_therefore_survives_a_broken_store(tmp_path):
-    """``/api/events``' contract, inherited whole (ADR-0031).
+def test_the_ledgers_rows_come_from_the_snapshot_and_not_from_the_store(tmp_path):
+    """``/api/events``' contract for the rows, inherited whole (ADR-0031).
 
-    It answers from process memory, so it has no storage failure to report — and
-    that is a decision rather than an omission: the rows served are the ones the
-    aggregator ran on, so the ledger an agent sees is the ledger every other
-    figure was computed from.
+    The portfolio's tables are gone here and the ledger still answers, because
+    the rows are the ones the aggregator ran on rather than a fresh query — so
+    the ledger an agent sees is the ledger every other figure was computed from.
+
+    **The head is another matter**, and this test used to be named as though it
+    were not: the reporting currency is a setting, so this tool does open the
+    store for that one value and fails with it when it cannot. See the test
+    below.
     """
     runtime, _ = build_runtime(tmp_path, events=LEDGER, break_store=True)
 
     assert payload(call(runtime, 'list_events'))['total'] == len(LEDGER)
+
+
+def test_the_ledger_fails_like_the_rest_when_there_is_no_store_at_all(tmp_path):
+    """Because its head names a currency, and a currency is a setting.
+
+    The honest half of the test above. `/api/events` gains something real from
+    opening nothing — the shares page's chart markers survive a storage fault —
+    and there is no equivalent stake here, where a broken store has already
+    taken the other four tools with it.
+    """
+    runtime, _ = build_runtime(tmp_path, events=LEDGER)
+    runtime.store = None
+
+    result = call(runtime, 'list_events')
+
+    assert result.is_error is True
+    assert 'not available' in _text(result)
+
+
+def test_a_storage_fault_arrives_in_words_and_not_as_a_bare_failure(tmp_path):
+    """The other half of the ``ToolError`` rule, and the half that was missing.
+
+    ``_store`` raised :class:`ToolError` for the store that is not there, which
+    made the *absent* store speak — but a store whose **query** fails raises
+    ``duckdb.Error``, and the SDK reports anything that is not a ``ToolError`` as
+    *"Error executing tool <name>"* with the cause discarded. So the one case an
+    owner is most likely to meet said the least, and this asserts on the words
+    rather than only on the flag (issue #877 review).
+    """
+    runtime, _ = build_runtime(tmp_path, events=LEDGER, break_store=True)
+
+    result = call(runtime, 'list_positions')
+
+    assert result.is_error is True
+    assert 'could not answer this read' in _text(result)
+    assert 'no figure to give' in _text(result)
+    # The exception's own text rides along: a DuckDB error names the table it
+    # could not read, which is what turns "something failed" into a bug report.
+    assert 'position' in _text(result).lower()
 
 
 # --------------------------------------------------------------------- #
@@ -360,13 +403,18 @@ def test_an_absent_store_says_so_in_words_the_caller_receives(tmp_path):
 
 
 @pytest.mark.parametrize('value', ['20240115', '2024-01-15T00:00:00Z',
-                                   'yesterday', '2024-1-15'])
+                                   'yesterday', '2024-1-15', '', '   '])
 def test_only_one_spelling_of_a_calendar_day_is_taken(tmp_path, value):
     """#764's rule, and the reason it is not ``date.fromisoformat`` alone.
 
     That function accepts several other spellings since 3.11 — a bare
     ``20260210``, a whole instant — and a bound that arrived as an instant is
     what silently drops the first day of every window.
+
+    **The empty string is in this list and not in the omitted case** (issue #877
+    review). The contract takes an absent argument or a calendar day; ``''`` is
+    neither, and reading it as *no bound* widens a window the caller meant to
+    narrow — which is the one wrong answer that looks like a right one.
     """
     runtime, _ = build_runtime(tmp_path, events=LEDGER)
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -61,9 +61,24 @@ def build_runtime(tmp_path, events=None, currency='EUR', break_store=False):
 def call(runtime, tool, arguments=None):
     """Call one tool through the in-memory client and hand back the result."""
     async def _run():
+        """One session per call: the surface holds no state between them."""
         async with Client(mcp_server.build_server(runtime)) as client:
             return await client.call_tool(tool, arguments or {})
     return asyncio.run(_run())
+
+
+def listed(runtime):
+    """The tools a client sees, which is the only copy that reaches a model.
+
+    Through the client and not through the server object: a description read off
+    a Python attribute would pass whatever the wire carries, and the wire is what
+    a tool description is *for* (ADR-0040).
+    """
+    async def _run():
+        """One session, opened and closed around the listing."""
+        async with Client(mcp_server.build_server(runtime)) as client:
+            return await client.list_tools()
+    return asyncio.run(_run()).tools
 
 
 def payload(result):
@@ -77,6 +92,7 @@ def payload(result):
 
 
 def _text(result):
+    """The words a caller actually receives — where a refusal has to be legible."""
     return result.content[0].text if result.content else ''
 
 
@@ -108,11 +124,7 @@ def test_the_surface_is_five_tools_and_nothing_else(tmp_path):
     """
     runtime, _ = build_runtime(tmp_path)
 
-    async def _run():
-        async with Client(mcp_server.build_server(runtime)) as client:
-            return await client.list_tools()
-
-    names = sorted(tool.name for tool in asyncio.run(_run()).tools)
+    names = sorted(tool.name for tool in listed(runtime))
     assert names == ['get_portfolio_history', 'get_portfolio_totals',
                      'list_accounts', 'list_events', 'list_positions']
 
@@ -128,11 +140,7 @@ def test_every_description_states_the_absence_rule(tmp_path):
     """
     runtime, _ = build_runtime(tmp_path)
 
-    async def _run():
-        async with Client(mcp_server.build_server(runtime)) as client:
-            return await client.list_tools()
-
-    for tool in asyncio.run(_run()).tools:
+    for tool in listed(runtime):
         description = tool.description or ''
         assert len(description) > 200, tool.name
         assert 'null' in description, tool.name
@@ -149,12 +157,8 @@ def test_the_positions_description_carries_both_terms_of_the_carrying_convention
     """
     runtime, _ = build_runtime(tmp_path)
 
-    async def _run():
-        async with Client(mcp_server.build_server(runtime)) as client:
-            return await client.list_tools()
-
     described = {tool.name: tool.description or ''
-                 for tool in asyncio.run(_run()).tools}['list_positions']
+                 for tool in listed(runtime)}['list_positions']
     assert 'terminal' in described
     assert 'not fetched a price yet' in described
     assert 'no price will ever come' in described
@@ -425,6 +429,7 @@ def test_only_one_spelling_of_a_calendar_day_is_taken(tmp_path, value):
 
 
 def test_an_inverted_window_is_refused_in_words(tmp_path):
+    """An empty window is a mistake to report, never an empty answer to return."""
     runtime, _ = build_runtime(tmp_path, events=LEDGER)
 
     result = call(runtime, 'get_portfolio_history',
@@ -435,6 +440,7 @@ def test_an_inverted_window_is_refused_in_words(tmp_path):
 
 
 def test_a_negative_bound_is_refused_in_words(tmp_path):
+    """A negative slice would silently answer nothing, which reads as *you did nothing*."""
     runtime, _ = build_runtime(tmp_path, events=LEDGER)
 
     result = call(runtime, 'list_events', {'limit': -1})

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -428,6 +428,23 @@ def test_only_one_spelling_of_a_calendar_day_is_taken(tmp_path, value):
     assert 'YYYY-MM-DD' in _text(result)
 
 
+def test_a_window_of_one_day_is_a_window(tmp_path):
+    """The narrowest question the tool exists to answer, and it was refused.
+
+    ``from_day == to_day`` used to raise. The store bounds a series inclusively
+    at both ends, so an equal pair asks for exactly that day's point — and a
+    tool whose whole unit is the calendar day cannot decline to be asked for one
+    of them (issue #877 review).
+    """
+    runtime, _ = build_runtime(tmp_path, events=LEDGER)
+
+    body = payload(call(runtime, 'get_portfolio_history',
+                        {'from_day': '2024-06-15', 'to_day': '2024-06-15'}))
+
+    assert body['from'].startswith('2024-06-15')
+    assert body['to'].startswith('2024-06-15')
+
+
 def test_an_inverted_window_is_refused_in_words(tmp_path):
     """An empty window is a mistake to report, never an empty answer to return."""
     runtime, _ = build_runtime(tmp_path, events=LEDGER)
@@ -436,7 +453,7 @@ def test_an_inverted_window_is_refused_in_words(tmp_path):
                   {'from_day': '2024-06-01', 'to_day': '2024-01-01'})
 
     assert result.is_error is True
-    assert 'earlier' in _text(result)
+    assert 'later' in _text(result)
 
 
 def test_a_negative_bound_is_refused_in_words(tmp_path):

--- a/tests/test_web_boot.py
+++ b/tests/test_web_boot.py
@@ -25,6 +25,7 @@ defended against, and the bind is one argument of :func:`boot.serve`.
 """
 
 import asyncio
+import contextlib
 import logging
 import os
 import threading
@@ -33,6 +34,7 @@ from datetime import date
 from types import SimpleNamespace
 
 import pytest
+from mcp.server import MCPServer
 
 from application import boot
 from application import boot_conditions
@@ -929,7 +931,7 @@ def test_the_boot_serves_although_the_market_edge_raises(
     monkeypatch.setattr(market.yf, "Ticker", _refuses)
     answered = {}
 
-    def _serve(app, environment, on_shutdown):
+    def _serve(app, environment, on_shutdown, mcp=None):
         answered["status"] = app.test_client().get("/health").status_code
 
     monkeypatch.setattr(boot, "serve", _serve)
@@ -952,7 +954,7 @@ def test_the_health_probe_answers_within_a_second_of_a_hung_market(
     _a_ledger_holding(tmp_path, "AAPL", "MSFT", "ALO.PA")
     answered = {}
 
-    def _serve(app, environment, on_shutdown):
+    def _serve(app, environment, on_shutdown, mcp=None):
         answered["status"] = app.test_client().get("/health").status_code
         answered["elapsed"] = time.monotonic() - started
 
@@ -1109,3 +1111,189 @@ def test_the_teardown_survives_being_asked_twice(mocker, tmp_path):
     main.shutdown_runtime(runtime)
 
     assert runtime.store is None
+
+
+# ---------------------------------------------------------------------------
+# The agent's interface, mounted on the one socket (ADR-0040, issue #749)
+# ---------------------------------------------------------------------------
+#
+# Two applications, one bind, no fork. The branch in ``Serving`` is the whole of
+# the mount — and it is **the only new code on every request's path**, the page's
+# as much as the agent's, which is why it is held here as routing rather than
+# only through the tools in ``test_mcp_server.py``.
+
+
+class _FakeSessionManager:
+    """The SDK's session manager, reduced to what the mount has to do with it.
+
+    An internal double, and the case CLAUDE.md keeps them for: *entered* and
+    *exited* leave no row and no payload to read. The alternative — a real
+    ``MCPServer`` — would test the SDK's own context management and tell us
+    nothing about whether this file enters it.
+    """
+
+    def __init__(self, trace, fail=False):
+        self.trace = trace
+        self.fail = fail
+
+    @contextlib.asynccontextmanager
+    async def _run(self):
+        if self.fail:
+            raise RuntimeError("the session manager refused to start")
+        self.trace.append("sessions.entered")
+        try:
+            yield self
+        finally:
+            self.trace.append("sessions.exited")
+
+    def run(self):
+        return self._run()
+
+
+class _FakeMcp:
+    """An ``MCPServer`` as ``Serving`` uses it: an app to mount, a manager to hold."""
+
+    def __init__(self, trace, fail=False):
+        self.trace = trace
+        self.session_manager = _FakeSessionManager(trace, fail)
+        self.path = None
+
+    def streamable_http_app(self, *, streamable_http_path):
+        self.path = streamable_http_path
+
+        async def _app(scope, receive, send):
+            self.trace.append(f"mcp:{scope['path']}")
+        return _app
+
+
+def _reached(path, with_agent=True):
+    """Drive one HTTP scope through ``Serving`` and report which app answered.
+
+    The trace is the fake's own, so both branches write into one list and the
+    assertion reads which of the two ran — rather than which one a test
+    remembered to look at.
+    """
+    trace = []
+    serving = boot.Serving("the app", lambda: None,
+                           _FakeMcp(trace) if with_agent else None)
+
+    async def _wsgi(scope, receive, send):
+        trace.append(f"wsgi:{scope['path']}")
+    serving.wsgi = _wsgi
+
+    async def _receive():
+        return {}
+
+    async def _send(message):
+        pass
+
+    asyncio.run(serving({"type": "http", "path": path}, _receive, _send))
+    return trace
+
+
+def test_the_boot_hands_the_agents_interface_to_the_socket(tmp_path, monkeypatch):
+    """The wiring in ``sequence``, which no routing test can see.
+
+    Every test below builds a ``Serving`` itself, so the mount would go on
+    passing with the boot handing it ``None`` — and the whole interface would be
+    absent from a real process with nothing red. This is the one assertion that
+    the fifth step is given what the third built.
+
+    What the surface *is* belongs to ``test_mcp_server.py`` and is asserted
+    there, through a client. Here it is only that there is one.
+    """
+    _a_ledger_holding(tmp_path, "AAPL")
+    handed = {}
+
+    def _serve(app, environment, on_shutdown, mcp=None):
+        handed["mcp"] = mcp
+
+    monkeypatch.setattr(boot, "serve", _serve)
+
+    boot.sequence({})
+
+    assert isinstance(handed["mcp"], MCPServer)
+
+
+def test_the_agents_path_reaches_the_agents_application():
+    assert _reached("/mcp") == ["mcp:/mcp"]
+
+
+def test_everything_else_reaches_the_front_unchanged():
+    """The page, the API and the health probe are not touched by the mount.
+
+    ``/api`` above all: a branch that swallowed it would take the whole front
+    down for a feature it reads nothing about.
+    """
+    for path in ("/", "/api/positions", "/health", "/assets/index.js"):
+        assert _reached(path) == [f"wsgi:{path}"]
+
+
+def test_a_path_that_merely_begins_with_the_prefix_is_not_the_agents():
+    """``/mcpsomething`` is an ordinary unknown path and belongs to the SPA.
+
+    A ``startswith`` without the separator is the classic way a mount quietly
+    annexes names nobody gave it — and here it would annex them from the
+    catch-all that answers them today.
+    """
+    assert _reached("/mcpsomething") == ["wsgi:/mcpsomething"]
+    assert _reached("/mcp/messages") == ["mcp:/mcp/messages"]
+
+
+def test_the_mounted_application_is_asked_for_the_path_it_is_reached_at():
+    """No prefix is stripped, so the sub-app must route on the full path.
+
+    The SDK's default happens to be ``/mcp`` — this pins that the two agree,
+    rather than leaving the mount working by coincidence.
+    """
+    mcp = _FakeMcp([])
+    boot.Serving("the app", lambda: None, mcp)
+    assert mcp.path == boot.MCP_PATH
+
+
+def test_the_lifespan_enters_the_session_manager_and_leaves_it_before_the_teardown():
+    """The SDK requires the **host** app to enter it: a mounted lifespan never runs.
+
+    And the order on the way out is not interchangeable. The teardown closes the
+    store, so a tool still in flight would meet a store that is no longer there —
+    the shape of defect #858, met from the other side.
+    """
+    trace = []
+    app = boot.Serving("the app", lambda: trace.append("teardown"),
+                       _FakeMcp(trace))
+
+    _lifespan(app, trace)
+
+    assert trace == ["sessions.entered", "lifespan.startup.complete",
+                     "sessions.exited", "teardown",
+                     "lifespan.shutdown.complete"]
+
+
+def test_a_startup_that_cannot_arm_the_interface_is_a_boot_that_failed():
+    """``lifespan.startup.failed``, rather than a hang or a silent half-boot.
+
+    uvicorn exits on it, which is the one non-zero exit ``run`` owns: a process
+    that cannot arm the agent's interface has failed to boot like any other.
+    """
+    trace = []
+    app = boot.Serving("the app", lambda: trace.append("teardown"),
+                       _FakeMcp(trace, fail=True))
+
+    _lifespan(app, trace)
+
+    assert trace == ["lifespan.startup.failed"]
+    assert "teardown" not in trace
+
+
+def test_without_an_agents_interface_the_lifespan_is_what_it_always_was():
+    """The mount is an argument, so a runtime without one changes nothing.
+
+    Which is what keeps the branch honest: it is reached, or it is not there.
+    """
+    trace = []
+    app = boot.Serving("the app", lambda: trace.append("teardown"))
+
+    _lifespan(app, trace)
+
+    assert trace == ["lifespan.startup.complete", "teardown",
+                     "lifespan.shutdown.complete"]

--- a/tests/test_web_boot.py
+++ b/tests/test_web_boot.py
@@ -934,6 +934,7 @@ def test_the_boot_serves_although_the_market_edge_raises(
     answered = {}
 
     def _serve(app, environment, on_shutdown, mcp=None):
+        """Stand in for the socket: ask the built app instead of binding one."""
         answered["status"] = app.test_client().get("/health").status_code
 
     monkeypatch.setattr(boot, "serve", _serve)
@@ -957,6 +958,7 @@ def test_the_health_probe_answers_within_a_second_of_a_hung_market(
     answered = {}
 
     def _serve(app, environment, on_shutdown, mcp=None):
+        """Stand in for the socket: ask the built app instead of binding one."""
         answered["status"] = app.test_client().get("/health").status_code
         answered["elapsed"] = time.monotonic() - started
 
@@ -1135,11 +1137,13 @@ class _FakeSessionManager:
     """
 
     def __init__(self, trace, fail=False):
+        """``fail`` makes entering it raise, which is the startup this file asserts on."""
         self.trace = trace
         self.fail = fail
 
     @contextlib.asynccontextmanager
     async def _run(self):
+        """Record entry and exit, so the mount's ordering is readable in a list."""
         if self.fail:
             raise RuntimeError("the session manager refused to start")
         self.trace.append("sessions.entered")
@@ -1149,6 +1153,7 @@ class _FakeSessionManager:
             self.trace.append("sessions.exited")
 
     def run(self):
+        """The SDK's shape: a method returning the context, not the context itself."""
         return self._run()
 
 
@@ -1156,6 +1161,7 @@ class _FakeMcp:
     """An ``MCPServer`` as ``Serving`` uses it: an app to mount, a manager to hold."""
 
     def __init__(self, trace, fail=False):
+        """An MCPServer reduced to the two things the mount touches."""
         self.trace = trace
         self.session_manager = _FakeSessionManager(trace, fail)
         self.path = None
@@ -1163,6 +1169,7 @@ class _FakeMcp:
 
     def streamable_http_app(self, *, streamable_http_path,
                             transport_security="not passed"):
+        """Record what the mount asked for, and hand back something routable."""
         self.path = streamable_http_path
         # Recorded rather than ignored: *not passing* this is what silently
         # turns on a localhost-only host allowlist, so a default here would let
@@ -1170,6 +1177,7 @@ class _FakeMcp:
         self.security = transport_security
 
         async def _app(scope, receive, send):
+            """Note that this branch ran, and which path reached it."""
             self.trace.append(f"mcp:{scope['path']}")
         return _app
 
@@ -1186,14 +1194,16 @@ def _reached(path, with_agent=True):
                            _FakeMcp(trace) if with_agent else None)
 
     async def _wsgi(scope, receive, send):
+        """Stand in for the Flask half, and note that it was the one reached."""
         trace.append(f"wsgi:{scope['path']}")
     serving.wsgi = _wsgi
 
     async def _receive():
+        """Nothing is read: the assertion is on which app was handed the scope."""
         return {}
 
     async def _send(message):
-        pass
+        """Nothing is written, for the same reason."""
 
     asyncio.run(serving({"type": "http", "path": path}, _receive, _send))
     return trace
@@ -1214,6 +1224,7 @@ def test_the_boot_hands_the_agents_interface_to_the_socket(tmp_path, monkeypatch
     handed = {}
 
     def _serve(app, environment, on_shutdown, mcp=None):
+        """Keep what the boot handed over — the whole point of this test."""
         handed["mcp"] = mcp
 
     monkeypatch.setattr(boot, "serve", _serve)
@@ -1224,6 +1235,7 @@ def test_the_boot_hands_the_agents_interface_to_the_socket(tmp_path, monkeypatch
 
 
 def test_the_agents_path_reaches_the_agents_application():
+    """The branch exists and the agent's path is what takes it."""
     assert _reached("/mcp") == ["mcp:/mcp"]
 
 
@@ -1272,60 +1284,80 @@ def test_the_mount_always_states_a_host_policy():
     assert mcp.security.enable_dns_rebinding_protection is False
 
 
-def _post_mcp(host):
-    """POST an MCP `initialize` through a real mounted server under ``host``.
+def _drive(app, scope, body):
+    """Run one HTTP request through an ASGI app and return its status code.
 
-    Drives the ASGI scope by hand rather than binding a socket, and it is the
-    **real** ``MCPServer`` rather than the fake above: what is under test is the
-    SDK's own host policy, which a stand-in would not have.
+    Written once because it was written twice: the two tests below differ by a
+    header and by nothing else, and a second copy of the protocol plumbing is a
+    second place for it to drift.
+
+    Two details are what make it terminate. The receive channel yields the body
+    and then ``http.disconnect``: the MCP response is a ``text/event-stream``
+    that the app holds open for the life of a session, which is right in
+    production and a hang here. And the whole thing is bounded, because what is
+    under test is the **status**, which is sent first — how the stream ends
+    afterwards is the SDK's business, not this file's.
     """
-    from application import mcp_server
-    mcp = mcp_server.build_server(SimpleNamespace(store=None,
-                                                  config_manager=None))
-    serving = boot.Serving("the app", lambda: None, mcp)
-
-    body = json.dumps({
-        "jsonrpc": "2.0", "id": 1, "method": "initialize",
-        "params": {"protocolVersion": "2025-06-18", "capabilities": {},
-                   "clientInfo": {"name": "t", "version": "1"}},
-    }).encode()
-    scope = {
-        "type": "http", "asgi": {"version": "3.0"}, "http_version": "1.1",
-        "method": "POST", "path": boot.MCP_PATH, "raw_path": boot.MCP_PATH.encode(),
-        "query_string": b"", "root_path": "", "scheme": "http",
-        "headers": [
-            (b"host", host.encode()),
-            (b"content-type", b"application/json"),
-            (b"accept", b"application/json, text/event-stream"),
-            (b"content-length", str(len(body)).encode()),
-        ],
-        "client": ("10.0.0.9", 51234), "server": ("0.0.0.0", 8080),
-    }
+    incoming = [{"type": "http.request", "body": body, "more_body": False}]
     status = {}
 
-    incoming = [{"type": "http.request", "body": body, "more_body": False}]
-
     async def receive():
-        # The stream closes after the body: the response is `text/event-stream`
-        # and the app would otherwise hold it open for the life of a session,
-        # which is right in production and a hang in a test.
+        """The body once, then a disconnect that closes the SSE stream."""
         return incoming.pop(0) if incoming else {"type": "http.disconnect"}
 
     async def send(message):
+        """Keep the response status and discard the stream that follows it."""
         if message["type"] == "http.response.start":
             status["code"] = message["status"]
 
     async def _run():
-        async with mcp.session_manager.run():
-            await asyncio.wait_for(serving(scope, receive, send), timeout=10)
+        """Hold the session manager open for the length of the request."""
+        async with app.session_manager.run():
+            await asyncio.wait_for(app.serving(scope, receive, send), timeout=10)
 
     try:
         asyncio.run(_run())
     except (asyncio.TimeoutError, anyio.ClosedResourceError, RuntimeError):
-        # The status is what is under test and it is sent first; how the stream
-        # ends afterwards is the SDK's business.
         pass
     return status.get("code")
+
+
+def _mcp_scope(host, content_type):
+    """An HTTP scope aimed at the agent's interface, under ``host``."""
+    return {
+        "type": "http", "asgi": {"version": "3.0"}, "http_version": "1.1",
+        "method": "POST", "path": boot.MCP_PATH,
+        "raw_path": boot.MCP_PATH.encode(),
+        "query_string": b"", "root_path": "", "scheme": "http",
+        "headers": [(b"host", host.encode()),
+                    (b"content-type", content_type.encode()),
+                    (b"accept", b"application/json, text/event-stream")],
+        "client": ("10.0.0.9", 51234), "server": ("0.0.0.0", 8080),
+    }
+
+
+def _mounted():
+    """A real ``MCPServer`` behind a real ``Serving``, with no store under it.
+
+    The **real** server rather than the fake used elsewhere in this section:
+    what is under test here is the SDK's own host policy, which a stand-in does
+    not have. No store is needed — every request asserted on is refused or
+    accepted before a tool runs.
+    """
+    from application import mcp_server
+    mcp = mcp_server.build_server(SimpleNamespace(store=None,
+                                                  config_manager=None))
+    mcp.serving = boot.Serving("the app", lambda: None, mcp)
+    return mcp
+
+
+def _initialize_body():
+    """The one MCP call every client makes before any other."""
+    return json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": "2025-06-18", "capabilities": {},
+                   "clientInfo": {"name": "t", "version": "1"}},
+    }).encode()
 
 
 def test_the_agents_interface_answers_under_any_host_name():
@@ -1349,55 +1381,31 @@ def test_the_agents_interface_answers_under_any_host_name():
     point of the test.
     """
     for host in ("suivi.example.com", "192.168.1.50:8080", "my-container:8080"):
-        assert _post_mcp(host) == 200, host
+        code = _drive(_mounted(), _mcp_scope(host, "application/json"),
+                      _initialize_body())
+        assert code == 200, host
 
 
 def test_a_localhost_host_is_not_a_special_case_either():
     """The same answer, so the policy is *one* and not two."""
-    assert _post_mcp("127.0.0.1:8080") == 200
+    assert _drive(_mounted(), _mcp_scope("127.0.0.1:8080", "application/json"),
+                  _initialize_body()) == 200
 
 
 def test_a_post_that_is_not_json_is_still_refused():
-    """The structural defence the disabled check leans on (ADR-0040).
+    """The structural defence the disabled host check leans on (ADR-0040).
 
     ``Content-Type`` is validated **before** the DNS-rebinding setting is even
     read, so it holds whatever that setting says — and it is what a browser
     cannot satisfy cross-origin without a preflight this app answers no CORS
     header to. If this ever stops being true, the argument for disabling the
-    host allowlist stops with it.
+    host allowlist stops with it, which is why it is asserted here and not
+    merely written down in the record.
     """
-    from application import mcp_server
-    mcp = mcp_server.build_server(SimpleNamespace(store=None,
-                                                  config_manager=None))
-    serving = boot.Serving("the app", lambda: None, mcp)
-    scope = {
-        "type": "http", "asgi": {"version": "3.0"}, "http_version": "1.1",
-        "method": "POST", "path": boot.MCP_PATH, "raw_path": boot.MCP_PATH.encode(),
-        "query_string": b"", "root_path": "", "scheme": "http",
-        "headers": [(b"host", b"suivi.example.com"),
-                    (b"content-type", b"text/plain"),
-                    (b"content-length", b"2")],
-        "client": ("10.0.0.9", 51234), "server": ("0.0.0.0", 8080),
-    }
-    status = {}
-    incoming = [{"type": "http.request", "body": b"{}", "more_body": False}]
+    code = _drive(_mounted(), _mcp_scope("evil.example.com", "text/plain"),
+                  b"{}")
 
-    async def receive():
-        return incoming.pop(0) if incoming else {"type": "http.disconnect"}
-
-    async def send(message):
-        if message["type"] == "http.response.start":
-            status["code"] = message["status"]
-
-    async def _run():
-        async with mcp.session_manager.run():
-            await asyncio.wait_for(serving(scope, receive, send), timeout=10)
-
-    try:
-        asyncio.run(_run())
-    except (asyncio.TimeoutError, anyio.ClosedResourceError, RuntimeError):
-        pass
-    assert status.get("code") == 400
+    assert code == 400
 
 
 def test_the_lifespan_enters_the_session_manager_and_leaves_it_before_the_teardown():

--- a/tests/test_web_boot.py
+++ b/tests/test_web_boot.py
@@ -26,6 +26,7 @@ defended against, and the bind is one argument of :func:`boot.serve`.
 
 import asyncio
 import contextlib
+import json
 import logging
 import os
 import threading
@@ -33,6 +34,7 @@ import time
 from datetime import date
 from types import SimpleNamespace
 
+import anyio
 import pytest
 from mcp.server import MCPServer
 
@@ -1157,9 +1159,15 @@ class _FakeMcp:
         self.trace = trace
         self.session_manager = _FakeSessionManager(trace, fail)
         self.path = None
+        self.security = "not passed"
 
-    def streamable_http_app(self, *, streamable_http_path):
+    def streamable_http_app(self, *, streamable_http_path,
+                            transport_security="not passed"):
         self.path = streamable_http_path
+        # Recorded rather than ignored: *not passing* this is what silently
+        # turns on a localhost-only host allowlist, so a default here would let
+        # the mount stop passing it with every test still green.
+        self.security = transport_security
 
         async def _app(scope, receive, send):
             self.trace.append(f"mcp:{scope['path']}")
@@ -1249,6 +1257,147 @@ def test_the_mounted_application_is_asked_for_the_path_it_is_reached_at():
     mcp = _FakeMcp([])
     boot.Serving("the app", lambda: None, mcp)
     assert mcp.path == boot.MCP_PATH
+
+
+def test_the_mount_always_states_a_host_policy():
+    """Passing nothing is not *no policy*, so nothing is never passed.
+
+    The behavioural half is ``test_the_agents_interface_answers_under_any_host_name``
+    below; this is the structural half, and it is the one that stays legible
+    when a future SDK changes what its default does.
+    """
+    mcp = _FakeMcp([])
+    boot.Serving("the app", lambda: None, mcp)
+    assert mcp.security is boot.NO_HOST_ALLOWLIST
+    assert mcp.security.enable_dns_rebinding_protection is False
+
+
+def _post_mcp(host):
+    """POST an MCP `initialize` through a real mounted server under ``host``.
+
+    Drives the ASGI scope by hand rather than binding a socket, and it is the
+    **real** ``MCPServer`` rather than the fake above: what is under test is the
+    SDK's own host policy, which a stand-in would not have.
+    """
+    from application import mcp_server
+    mcp = mcp_server.build_server(SimpleNamespace(store=None,
+                                                  config_manager=None))
+    serving = boot.Serving("the app", lambda: None, mcp)
+
+    body = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": "2025-06-18", "capabilities": {},
+                   "clientInfo": {"name": "t", "version": "1"}},
+    }).encode()
+    scope = {
+        "type": "http", "asgi": {"version": "3.0"}, "http_version": "1.1",
+        "method": "POST", "path": boot.MCP_PATH, "raw_path": boot.MCP_PATH.encode(),
+        "query_string": b"", "root_path": "", "scheme": "http",
+        "headers": [
+            (b"host", host.encode()),
+            (b"content-type", b"application/json"),
+            (b"accept", b"application/json, text/event-stream"),
+            (b"content-length", str(len(body)).encode()),
+        ],
+        "client": ("10.0.0.9", 51234), "server": ("0.0.0.0", 8080),
+    }
+    status = {}
+
+    incoming = [{"type": "http.request", "body": body, "more_body": False}]
+
+    async def receive():
+        # The stream closes after the body: the response is `text/event-stream`
+        # and the app would otherwise hold it open for the life of a session,
+        # which is right in production and a hang in a test.
+        return incoming.pop(0) if incoming else {"type": "http.disconnect"}
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            status["code"] = message["status"]
+
+    async def _run():
+        async with mcp.session_manager.run():
+            await asyncio.wait_for(serving(scope, receive, send), timeout=10)
+
+    try:
+        asyncio.run(_run())
+    except (asyncio.TimeoutError, anyio.ClosedResourceError, RuntimeError):
+        # The status is what is under test and it is sent first; how the stream
+        # ends afterwards is the SDK's business.
+        pass
+    return status.get("code")
+
+
+def test_the_agents_interface_answers_under_any_host_name():
+    """The regression that a localhost client cannot see (issue #877 review).
+
+    Handing the SDK **no** ``transport_security`` is the one thing that does not
+    mean *no policy*: it reads its ``host`` argument, defaults it to
+    ``127.0.0.1``, and substitutes an allowlist of its own —
+
+        if transport_security is None and host in ("127.0.0.1", "localhost", "::1"):
+            transport_security = TransportSecuritySettings(
+                allowed_hosts=["127.0.0.1:*", "localhost:*", "[::1]:*"], ...)
+
+    — which answers ``421 Invalid Host header`` to a LAN address, a container
+    name and a reverse proxy's domain alike. Every one of those is how this app
+    is actually reached; the exception is the one a developer tests from, which
+    is why every client in this suite and every hand check passed while the
+    container was unusable for the very thing its documentation page describes.
+
+    So the assertion is on a name that is **not** localhost, and it is the whole
+    point of the test.
+    """
+    for host in ("suivi.example.com", "192.168.1.50:8080", "my-container:8080"):
+        assert _post_mcp(host) == 200, host
+
+
+def test_a_localhost_host_is_not_a_special_case_either():
+    """The same answer, so the policy is *one* and not two."""
+    assert _post_mcp("127.0.0.1:8080") == 200
+
+
+def test_a_post_that_is_not_json_is_still_refused():
+    """The structural defence the disabled check leans on (ADR-0040).
+
+    ``Content-Type`` is validated **before** the DNS-rebinding setting is even
+    read, so it holds whatever that setting says — and it is what a browser
+    cannot satisfy cross-origin without a preflight this app answers no CORS
+    header to. If this ever stops being true, the argument for disabling the
+    host allowlist stops with it.
+    """
+    from application import mcp_server
+    mcp = mcp_server.build_server(SimpleNamespace(store=None,
+                                                  config_manager=None))
+    serving = boot.Serving("the app", lambda: None, mcp)
+    scope = {
+        "type": "http", "asgi": {"version": "3.0"}, "http_version": "1.1",
+        "method": "POST", "path": boot.MCP_PATH, "raw_path": boot.MCP_PATH.encode(),
+        "query_string": b"", "root_path": "", "scheme": "http",
+        "headers": [(b"host", b"suivi.example.com"),
+                    (b"content-type", b"text/plain"),
+                    (b"content-length", b"2")],
+        "client": ("10.0.0.9", 51234), "server": ("0.0.0.0", 8080),
+    }
+    status = {}
+    incoming = [{"type": "http.request", "body": b"{}", "more_body": False}]
+
+    async def receive():
+        return incoming.pop(0) if incoming else {"type": "http.disconnect"}
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            status["code"] = message["status"]
+
+    async def _run():
+        async with mcp.session_manager.run():
+            await asyncio.wait_for(serving(scope, receive, send), timeout=10)
+
+    try:
+        asyncio.run(_run())
+    except (asyncio.TimeoutError, anyio.ClosedResourceError, RuntimeError):
+        pass
+    assert status.get("code") == 400
 
 
 def test_the_lifespan_enters_the_session_manager_and_leaves_it_before_the_teardown():

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,27 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
 name = "apscheduler"
 version = "3.11.3"
 source = { registry = "https://pypi.org/simple" }
@@ -26,6 +47,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8c/6b/eeff360196bb20b312c9e762a820fd1b2c6d809466c755ef57863478e454/apscheduler-3.11.3.tar.gz", hash = "sha256:cd2fcc9330039a81a5893472ad49facf23a6d5604cbe1d918c835c6de7834d5a", size = 110312, upload-time = "2026-06-28T19:39:22.493Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/c9/8638db32514dbb9157b3d82680c6faea89283523edf9ed2415ea3884f2ae/apscheduler-3.11.3-py3-none-any.whl", hash = "sha256:bbeb2ec02d23d3c06a6c07ed7f0f3939ada6680eb121fae809a69bb42c537a30", size = 66024, upload-time = "2026-06-28T19:39:20.982Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -194,6 +224,56 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "50.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20", size = 880381, upload-time = "2026-08-25T19:45:45.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/19/797e2aaac9df6a66f1550f49979dc1b1e39ecd2077501c30efa81e8d5d67/cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986", size = 4010153, upload-time = "2026-08-25T19:44:03.155Z" },
+    { url = "https://files.pythonhosted.org/packages/90/34/9ce9a62ed9dc82ca9fd6a34445b6904af56e5f38b3eae2ed32e49c36053d/cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f", size = 4723133, upload-time = "2026-08-25T19:44:05.461Z" },
+    { url = "https://files.pythonhosted.org/packages/57/26/e6d4fc8512a51a5f9ee7bfdbfb853bce1197087df40c9ad993ad370b846f/cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef", size = 4712478, upload-time = "2026-08-25T19:44:07.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/de/d3cdc2815697aae84126cbd6a030ca7b6b452e28a88b501b836bd3aa7a86/cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8", size = 4730726, upload-time = "2026-08-25T19:44:09.294Z" },
+    { url = "https://files.pythonhosted.org/packages/55/32/38c0d344b98c06d34b5df8946565a9c0d6dbf32c8e0730a7f05f0a3c6cab/cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45", size = 5353524, upload-time = "2026-08-25T19:44:11.96Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/1b/82f0f0d8858d4432be1af790477edf62aef90324041aa07c57e57bef1af7/cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad", size = 4746720, upload-time = "2026-08-25T19:44:14.051Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ba/042ca458b8c64348c768284b5d23e69b92ed53d057ab779fee628564676d/cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49", size = 4361866, upload-time = "2026-08-25T19:44:16.167Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/e96c1ef71edef71057c7e3c3d982ce8fda554e0c52d0cc19c18845cde3eb/cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f", size = 4730028, upload-time = "2026-08-25T19:44:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/45abd72ef63f2e7d0754a6cacf97bd8b69512ace7f6130d24c39ece65da2/cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527", size = 5308405, upload-time = "2026-08-25T19:44:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/85/66/6ccca4722987ddedaa7fc9c3f4708af7431f5535666c174350830888c6b7/cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a", size = 4746230, upload-time = "2026-08-25T19:44:22.376Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0e/b1f92e013228111413f2e6743948b80bc24dfd3c1b87ba98ceea16f5df89/cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959", size = 4862596, upload-time = "2026-08-25T19:44:24.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/c3654cccc856e9d682817b04ac3ee79731cb09ca6f95996a95c904de2883/cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b", size = 5014082, upload-time = "2026-08-25T19:44:26.709Z" },
+    { url = "https://files.pythonhosted.org/packages/42/8b/cb12b1b60c91b074ca6bf0fdd59aa8f10d8bc5f73af8faece86ef0421b37/cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648", size = 3842826, upload-time = "2026-08-25T19:44:28.784Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f0/424cb557d99aa86ac55da5e2add02e2882e44047b6264f93ade1b975a993/cryptography-50.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30a125032e5642a21ff816e021152bd4e7e94f03eff3f4b7fca41cd22bc3110f", size = 3973525, upload-time = "2026-08-25T19:44:30.7Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/72/3a2711d967977ab5fc80b782837c7e8d1ac7445e764c20c381a265c57ef3/cryptography-50.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a0b1a59e3a089064a0ec309e9428c8e3ae4e161419d20ac33600767e83fc658a", size = 4708817, upload-time = "2026-08-25T19:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f2/bb1f56e10815b789df0b409a69fa4992ff3d3fef9c72747f4a6b26fed38e/cryptography-50.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8921d58f426793c5f1b47f0b59575780de9a095214958d0eb37d909593db8367", size = 4697300, upload-time = "2026-08-25T19:44:35.144Z" },
+    { url = "https://files.pythonhosted.org/packages/08/bd/ed5396be499ffcf8807a585bfe38b71a1fbdd1c342b4f9b6d0ef5162a946/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a8f40ea47330e71b594a7e246898f93177c259490c63183dbaf9e571d71ed9a5", size = 4716039, upload-time = "2026-08-25T19:44:37.192Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6e/1cf405c5c8e8df7545378048e954792f00b7f2367af8863ce8b8f3e10607/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:a255449073358275b64b67d3f595f268bbef70e72b6edb65e0c70c735bf739c9", size = 5332388, upload-time = "2026-08-25T19:44:39.16Z" },
+    { url = "https://files.pythonhosted.org/packages/47/92/b4317e8c32c4f47b062f5398bd79106b220a124546f42be83bf32b761e2a/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8df2de9102026855887e4587084f6eabd80ed0f345b8ad8a7ac27ab9bf4723e0", size = 4730293, upload-time = "2026-08-25T19:44:41.298Z" },
+    { url = "https://files.pythonhosted.org/packages/39/0d/a1e7633e2c744d0f2983320a27e924ef2264c79c56e1a58d5fb0a1cfd413/cryptography-50.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:ac02b07824d4d1001bd4367599f839c19cb171924c796e52c23508ac14c2c0cc", size = 4346031, upload-time = "2026-08-25T19:44:43.245Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/b215616f9bab3fc18510c78a4e5c9f362d77838503c363dc747c7d4f5c6f/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:cbf74a81765ee67413503ca6e26dcc4f6f5a519822436cc0a1b97aab6c1b8a17", size = 4715344, upload-time = "2026-08-25T19:44:45.291Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1b/ec3ebd31741d0e963612c4fe43caa39341b9b1e031e469820e42e4c83918/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:16c5ecd954b3330ebfb6605eca4fd952da8bef376551d5cc264534e3770a9ee6", size = 5287201, upload-time = "2026-08-25T19:44:47.297Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/01/0127d11a762b31a9ee0221894f540318761783f3fdc4bc5d057698caebd5/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:79bf008d1f9af6071c797ad133e39915dfee7614f18f18f4db9072eb715064a3", size = 4730023, upload-time = "2026-08-25T19:44:49.435Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b9/e7425ebfb599241a0c1d7000f1b466c3062da66c19d9525031315dff7213/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:330fbb252391c596f1ae42c5754449dc924e6ad012dca8efe0d703f9f2d12ec6", size = 4847362, upload-time = "2026-08-25T19:44:51.94Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/fd/60d0ddf4defa12e482c9d5e0f554384d6e8ab25341fd15f060028fd92e6a/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:42be3bb70596b3abe4ac097b75be223e8b3ab614a0e5de068e3dcc54d71d6149", size = 4999247, upload-time = "2026-08-25T19:44:53.876Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/56/bc4f2b209e766c93372cfcd59b781a0b2b59700f62a969580415b699c2b2/cryptography-50.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f74455bb086a85d5e81246412602aaa97ed095e504cd40dd261ef50be42205bf", size = 3825806, upload-time = "2026-08-25T19:44:56.209Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a9/ee16a903f13755e914d1eecc482fe64d1f10761c3960e5d8fa6837377aff/cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0", size = 4035307, upload-time = "2026-08-25T19:44:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a5/9ec7e81e8526c0d7a387d73386b2daed3f39e10d81a85930bd1b6bfba65c/cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23", size = 4751900, upload-time = "2026-08-25T19:45:00.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3c/0e77bd5ffcf078e9dd27d3074aad6c030d9b10d0bf69329d573c927a188c/cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733", size = 4738357, upload-time = "2026-08-25T19:45:02.786Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/3c5f80daa4dcd47323c7af8a2fcb90de27a33564d4fcac69846c0972691a/cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88", size = 4758474, upload-time = "2026-08-25T19:45:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2b/214cf0cf93db9628c3c20c896b229f327f6fb1b20e4b3743d8ad3f00af8b/cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054", size = 5375862, upload-time = "2026-08-25T19:45:07.163Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/51/3f9701867a46b6c1740c9b52fc4d3bed6cbdcfedcc9b6e64305c07f39cff/cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5", size = 4772942, upload-time = "2026-08-25T19:45:09.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/13ea642e08e2544d0f5396122055f4820cfacb3203562197b5967125ea97/cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361", size = 4383347, upload-time = "2026-08-25T19:45:11.659Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d5/7d1fe1cb93f91c428093ff234e128c89ba8ea61a6f26aab406081f9b996e/cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71", size = 4758050, upload-time = "2026-08-25T19:45:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/04/557fc5ead96a829e0bc812a3b9dc4a52a2f27e4f7f5950da7ff27653a805/cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80", size = 5332955, upload-time = "2026-08-25T19:45:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/eb/5d7124083e8d8cda8f5b348f544b71ad6f707ad63193758ef4d8e569da02/cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239", size = 4772694, upload-time = "2026-08-25T19:45:18.315Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/f1f955e0921dd2b6d22eae7e8d24a4c4b638d10735ffbf6a71f99eb0fcb8/cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558", size = 4888413, upload-time = "2026-08-25T19:45:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ab/89e2b798d2c3925f82e2bb72d5979f3d2f6da2dd22ef4a8cd8b70d920039/cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e", size = 5044355, upload-time = "2026-08-25T19:45:22.353Z" },
+    { url = "https://files.pythonhosted.org/packages/99/89/87ef49ffe383ef4e147d27b7bf2088fb0b54ea409dd87b5a89442e5828a5/cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2", size = 3875429, upload-time = "2026-08-25T19:45:24.418Z" },
+]
+
+[[package]]
 name = "curl-cffi"
 version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -291,6 +371,44 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -327,6 +445,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -390,6 +535,44 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx2" },
+    { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6e/21fb8e5d579dbe21d96ea4d5034200d46d8bdf2261053b5bd041f3c2f612/mcp-2.1.1.tar.gz", hash = "sha256:50b7ba1ebbe117008ea7bdd288234043e69c20b403d6851d19661e6d431a75ef", size = 3984589, upload-time = "2026-08-25T16:14:02.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/af/8644cc5fa26a59afd2df2e98eeb19e72926887fa4b7441aba4ff661140db/mcp-2.1.1-py3-none-any.whl", hash = "sha256:1c6c31c5d6471c58db76af3af8af67f46d11d01f0a59077d0a308cbdb3d3e915", size = 357912, upload-time = "2026-08-25T16:13:59.024Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674, upload-time = "2026-08-25T16:14:03.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656, upload-time = "2026-08-25T16:14:00.667Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -446,6 +629,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -569,6 +764,62 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/ef/fc4f868f4e2cee79f863883abffceff107875f569b848507319842d2a681/pydantic-2.13.5.tar.gz", hash = "sha256:51a9c5f7b2f8e636f04c6cada605d9b6a3bf1348fdf945a3d8869b19bba0ee08", size = 845750, upload-time = "2026-08-28T14:04:00.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/47/c95ffc2009878c7aac0c5e08528022dcb885933252a88b5f170058014464/pydantic-2.13.5-py3-none-any.whl", hash = "sha256:346a034f080da3755d8e9cb5e00e8b07de1d39e4f6e2c87d8ab7cafa0b269a73", size = 472589, upload-time = "2026-08-28T14:03:59.136Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/f9/8a06bea35ef8daf588f707784c973a7046e0034c8d8cfb08828eeffb8b75/pydantic_core-2.46.5.tar.gz", hash = "sha256:10416c15b8839ecc4ef4d0885da76da6fd0f67333a0eb8aff6d93c4b8f2910fc", size = 472262, upload-time = "2026-08-28T10:01:31.677Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/8a/14596f2a8367da50cf7cbac48169ee5d9c8e11d486a3b527082384630c72/pydantic_core-2.46.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c1c43ad4339643d70ebb8124e1305a7dab423001eff58bb41a0f731adbc98355", size = 2074081, upload-time = "2026-08-28T09:59:16.141Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d5/d8a4eb6d6c7f66b91dd37c576d76e9e60fba900caf5372c17bcf949febc2/pydantic_core-2.46.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1a353f84de772f423b5ffb11d7ae352fbbef0f446f3c0b0af0f8236d7233606e", size = 1920497, upload-time = "2026-08-28T09:59:18.065Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/26/092079428f86e927e030b2c0ced87df69dbb1c875cdeaa67bf42ea2be746/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5086029a57366b8cf81b130a43908738095c270c21a8d7f0e8bdfdb89718e2f3", size = 1952130, upload-time = "2026-08-28T09:59:20.476Z" },
+    { url = "https://files.pythonhosted.org/packages/08/c3/8ec0e290a9ebaebd64047bf5fda94be835c6b1551b02437e4b76778fbcd7/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:46c25dda9d092a06c08db76ffe0a197107904d0dfac653f7d5306bbcd6d6119c", size = 2026371, upload-time = "2026-08-28T09:59:22.227Z" },
+    { url = "https://files.pythonhosted.org/packages/01/72/4fd20ad520fb8da0157f95b27a7eb05a72790ef08138e7701ac972c342ea/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:37ea7b83c935e5b0d68c9449b82651accf78a10828b2c02b2f2d9e9496446c21", size = 2202822, upload-time = "2026-08-28T09:59:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b0/d16e0771206b29314f0d52198b720be21e8a99ab2bf11e3bc0d7c9cebdff/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e64e88d5585bea9ce95861079de72006c7fa6d3df4e3a3b65ba31eb979c15c9f", size = 2262756, upload-time = "2026-08-28T09:59:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9b/59634b7ac631c63b2a37760eb6943af3e29573d6b59a4abc5e7f019d4cee/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d510bac3ee52247af28ed4bb18a1e799f040ac60fd2bf5ccd4c92f1fbe786f", size = 2068352, upload-time = "2026-08-28T09:59:29.044Z" },
+    { url = "https://files.pythonhosted.org/packages/08/7c/570abb1ad2155348dc754ea91be22e5aaa18eb6d69a6068f7c6f2679a6ed/pydantic_core-2.46.5-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:a2a5e1d0ff29adddc9f6d6821a66302e4493f8ca898b715b6b1182c2c201ea0a", size = 2104777, upload-time = "2026-08-28T09:59:30.95Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/25/5bf74adc65a1ac5b7be3f6cb0bcb5433615c1598a801c19d830d84c98ded/pydantic_core-2.46.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:03b9666e41e35d8909852ba191a0607520f81b74eaf12ccf8737005dbb313821", size = 2156312, upload-time = "2026-08-28T09:59:32.604Z" },
+    { url = "https://files.pythonhosted.org/packages/90/6a/2ef38830675e050121040618135564ed56b860b45433b02d9b4ebece46f3/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:a91c17edf6eea2402cb5457b4c89e99bc5ed1004aa34c4adf1d4258c1a5c22c2", size = 2150067, upload-time = "2026-08-28T09:59:34.453Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/a7dbb03a14a64c2a4621f989c615ed9a892535a6cad938fc27079f919d80/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b49924c73a235e969511bf2aabdff3beebf9820931f646c80274d5d780010c47", size = 2304516, upload-time = "2026-08-28T09:59:36.194Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f8/6bb4c4b80e8a6fde1904c64a51c62a1d04fcdfa3ea521a66b2ddefa1d885/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:2cbd9a5eff05e51c447c34dfa4632145b26b09120cf04bd0c871e44c1a5e1c9a", size = 2335223, upload-time = "2026-08-28T09:59:37.931Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/80/f46b8c681195190b2c1f1c7c0a81abce60663e987613e09ef64d433dd96b/pydantic_core-2.46.5-cp314-cp314-win32.whl", hash = "sha256:2d5d76654becf5efd62c9e51c3756c67b49498b0c9a40884934c40807adbd074", size = 1934827, upload-time = "2026-08-28T09:59:39.836Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/3c/60674207246bc0a4009d2391b7c7251c7159f279c8d2ab8aae8ef46f3dee/pydantic_core-2.46.5-cp314-cp314-win_amd64.whl", hash = "sha256:fa10ef4112775900e7a0661068635eb67b2ab824fbde764de6e0e21982a93db0", size = 2042648, upload-time = "2026-08-28T09:59:41.792Z" },
+    { url = "https://files.pythonhosted.org/packages/69/0c/117c562c7c1babdf44576b72a5e496906506c93690387ecfbca7c729ae2e/pydantic_core-2.46.5-cp314-cp314-win_arm64.whl", hash = "sha256:045ab3b6d308439e32b81cc173bba5b9018bc6ed896afd0c65b3b009b1699af5", size = 1989652, upload-time = "2026-08-28T09:59:43.702Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/66/9336ae58f9eb68c41d121894e52c4c89eccb07eb8f602a04ee9c3f37736a/pydantic_core-2.46.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8816f3d218beb4b787de5c9759c259b8fa61f9dec42dc7811f320a33771778b7", size = 2065829, upload-time = "2026-08-28T09:59:45.364Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/02/bc19b47a96c2d3109760711acf22369e56bd7e405ca52f7ade164d2ead57/pydantic_core-2.46.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bce57638e08ac148e5778cce7feb968307a727d66f8e2274a543d0cf0c9ad6a3", size = 1905716, upload-time = "2026-08-28T09:59:47.18Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a4/70b47c0509923dd98ccfed04fb3e32ea3849c82a0ff2205bb41009b43c00/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:976e1128455aa595ea04c79ccfedff1aaeab96ee013fcc916bed120c4f0ad94f", size = 1934216, upload-time = "2026-08-28T09:59:49.241Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ab/aa03b65f7bb198585edf806b906c3223ecf1795543e39e23aec4cce27ad2/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b891faeedeafba41b2983e5001a81b6a915b69544c7e7570d1989ce1c36ac7", size = 2010635, upload-time = "2026-08-28T09:59:51.692Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/8b/0da06343f30b84ec549aafd309c6456223d5dc8bd36af504c573faad561d/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f194189415698233dd1114a093a9b56e61e2c57e11b469be3b0506f46f0771c", size = 2209369, upload-time = "2026-08-28T09:59:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5b/844c4defaa34a3df66eb9257087d121d70c201298b96abdf9f492fc2f1bf/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82a36973cf8a2ef5406f4fe2edbf8ed0c99629535d959e0b100c76a32535a111", size = 2253238, upload-time = "2026-08-28T09:59:55.484Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/64/a4e536cb16d7f61a7fd3120b46c577fc7fa7325992f69c4f52bc786d77d8/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdbb78909f52b981d3b2d56b97328d71eb0b974c36bd77c920123a7ebb192829", size = 2065740, upload-time = "2026-08-28T09:59:58.038Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/75/aaa38c6bc2d085f6605b34eabdc6a8a4e0b2e61fc9c8e6e52b28e97b3125/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:52e24eacdb536cade636aa90fb851835222becff8484b7001fdc78cb0290f2aa", size = 2087425, upload-time = "2026-08-28T09:59:59.898Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ae/fcab4cfc39aba3689e1d20c8b5250ad280957022c09af2ed9cd585602a5e/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:37ae34309d7bd8c0d61ab839668058f2a7962ea1fc51d105d2db228fe0618034", size = 2139306, upload-time = "2026-08-28T10:00:03.057Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f4/f1d03a4bc9d9acbc62f4d742b8a319af52f71885079868b2ff8e48a651ee/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:0cdbada856a1c69a7624a64d3d9aefe79300bd6ef827b43a4f265010b9b55184", size = 2144589, upload-time = "2026-08-28T10:00:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/83/f3/7a53bb1356de514a4cd295f25b6ac39237895620c0462d2592b76c16e114/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:545f26c504b27c3758439a5e6d9349931f0a04f855668d5fe323c89e82300a38", size = 2288882, upload-time = "2026-08-28T10:00:07.931Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/94/5a81583660c175c59d49ffb09f4b3a44debeaf86a19fca664ae1cdd9ee32/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:ff218293c9c806138dca139765e3b067621be52bcd93cdc14c7711be7ddc90a9", size = 2335210, upload-time = "2026-08-28T10:00:10.177Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/9f/5d685c2693b972d1a59c998586e8823712b66603aeff47ee60a4bdaafd37/pydantic_core-2.46.5-cp314-cp314t-win32.whl", hash = "sha256:97cf3eb53a8cccacf9d46686a0926186c9bfb5574f2ed66d3639d5fe117cd3a9", size = 1921180, upload-time = "2026-08-28T10:00:12.35Z" },
+    { url = "https://files.pythonhosted.org/packages/70/12/5c94ee16d65a37a15f9e869f5e6256df111154491173801a4c5e800ab548/pydantic_core-2.46.5-cp314-cp314t-win_amd64.whl", hash = "sha256:d2f9fc07a8042a8f95925b35c4f04f469707c981fc33245b6ca187cf5d2dd290", size = 2020515, upload-time = "2026-08-28T10:00:14.774Z" },
+    { url = "https://files.pythonhosted.org/packages/63/19/67830dda664e6bdf9285ee2e40f355d0d7d6b92aa0c42e8d217bb8d33d36/pydantic_core-2.46.5-cp314-cp314t-win_arm64.whl", hash = "sha256:acf8a67ba51f4ca9ddbd0e6b3000a65ac51ab734661778b3e7ba64d99a710f2f", size = 1989276, upload-time = "2026-08-28T10:00:16.984Z" },
+]
+
+[[package]]
 name = "pyflakes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -584,6 +835,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -641,12 +906,47 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
 ]
 
 [[package]]
@@ -678,6 +978,72 @@ wheels = [
 ]
 
 [[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "82.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -705,6 +1071,31 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/00/b42a44342a054d58cb1115d7c8aa9cb4290dd9442f9c1b91a4b8173dba22/sse_starlette-3.4.8.tar.gz", hash = "sha256:ed89ffbb75cbf78a5fe2f2109cd584792ee7f9dfac96f791db546df8f15f3f9c", size = 32548, upload-time = "2026-08-05T11:19:49.982Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/3a/764912c58293d95b6dcdf4cc255f9d10de310580ced547b082eb9d72018c/sse_starlette-3.4.8-py3-none-any.whl", hash = "sha256:6e82314c786709a3cd9520f2285cf9fff90e181e598e8a357b0cf80f66afba0d", size = 16516, upload-time = "2026-08-05T11:19:48.748Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
 name = "suivi-bourse"
 version = "5.0.0"
 source = { virtual = "." }
@@ -714,6 +1105,7 @@ dependencies = [
     { name = "duckdb" },
     { name = "flask" },
     { name = "logfmt-logger" },
+    { name = "mcp" },
     { name = "numpy" },
     { name = "openpyxl" },
     { name = "pandas" },
@@ -739,6 +1131,7 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.4.0" },
     { name = "flask", specifier = "==3.1.3" },
     { name = "logfmt-logger", specifier = "==0.1.2" },
+    { name = "mcp", specifier = ">=2.1.0" },
     { name = "numpy", specifier = ">=1.22.2" },
     { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "pandas", specifier = ">=2.0.0" },
@@ -758,12 +1151,33 @@ dev = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
 ]
 
 [[package]]

--- a/website/docs/connect-your-own-agent.mdx
+++ b/website/docs/connect-your-own-agent.mdx
@@ -1,0 +1,109 @@
+---
+title: Connect your own agent
+description: The MCP server — what an AI agent can ask this app about your portfolio, and what it cannot
+---
+
+*Available from **5.1**. On 5.0 the address below answers nothing.*
+
+SuiviBourse speaks [MCP](https://modelcontextprotocol.io), so an AI agent — Claude
+Desktop, an editor's assistant, something you wrote yourself — can ask it about
+your portfolio and get real figures back rather than a guess.
+
+The app's own chat uses the very same tools. There is one surface, and pointing
+your own client at it gets you exactly what the built-in assistant sees.
+
+## The address
+
+The server is part of the app. There is no second container, no second port and
+nothing to start:
+
+```
+http://<your-host>:8080/mcp
+```
+
+Same host and same port as the page you already open in a browser. If you changed
+`SB_WEB_PORT`, change it here too.
+
+Most clients want that URL under a name. The shape varies, but it comes down to:
+
+```json
+{
+  "mcpServers": {
+    "suivibourse": {
+      "url": "http://localhost:8080/mcp"
+    }
+  }
+}
+```
+
+## What it can answer
+
+Five tools, and your agent picks between them on its own:
+
+| Tool | What it answers |
+| --- | --- |
+| `list_positions` | what you hold right now — quantity, average cost, value, unrealised gain |
+| `get_portfolio_totals` | the whole portfolio on its most recent day: value, contributions, XIRR, TWR, and the gain in its four terms |
+| `get_portfolio_history` | value and return day by day, over a window you choose |
+| `list_accounts` | the split across your accounts — the one to ask about allocation |
+| `list_events` | your ledger: what you actually did, and when |
+
+They read the same figures the pages show, through the same code. An agent and a
+screen cannot disagree about what a holding is worth.
+
+## What it cannot do
+
+**It cannot change anything.** There is no tool that records an event, edits one,
+creates an account or turns a dial. Every one of the five reads. If an agent tells
+you it has recorded a purchase, it has not — type it in the app.
+
+**It cannot tell you what to buy.** The server is built for questions about
+strategy and allocation: how you are spread, what you have been contributing, how
+a decision has worked out. It publishes no research and no price series for a
+security you do not hold, so an agent asking it for a stock tip gets nothing to
+answer with.
+
+## Who can reach it
+
+**Anyone who can reach the port.** There is no password, no token and no login —
+exactly as there is none for the page itself. That is the app's whole security
+model: it is one person's application, and reaching its address *is* the
+permission.
+
+So the rule is the one that already applies to the app: **do not publish the port
+to the open internet**. On your own machine or your own network, nothing more is
+needed. If you want to reach it from outside, put it behind whatever you already
+use for that — a VPN, a reverse proxy with authentication, a tunnel — the same way
+you would for the page.
+
+If your client connects over anything but plain HTTP on your own network, be aware
+that this app terminates no TLS itself. That, too, belongs to the proxy in front
+of it.
+
+## Your figures leave your machine
+
+Worth saying plainly, because it is the whole point of the feature: an agent you
+connect will send what it reads to whatever model it runs on. If that model is a
+hosted one, **your positions and your ledger go to that provider.** Nothing in
+SuiviBourse redacts them, and nothing should — you asked for the connection.
+
+That is a choice you make once, per client, and it is yours. The app itself sends
+nothing anywhere.
+
+## These tool names are a promise
+
+Unlike the app's internal HTTP interface, which changes whenever the page it
+serves changes, **the five names above and the shape of what they return are held
+across 5.x**. Your client will not break under a patch release. A tool that has to
+change will be announced in the release notes.
+
+## When something is not there
+
+The figures an agent gets back are careful about absence, and the tools tell it
+so. A holding with no price is not worth zero — it is a holding the app has not
+priced, either because it has not fetched one yet or because none will ever come.
+A portfolio with no totals is one the app has not computed yet, usually because
+the reporting currency has not been answered.
+
+A good agent will repeat that distinction back to you. If yours reports a
+suspicious zero, that is the thing to double-check on the page.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -13,6 +13,12 @@
  * It was eleven until `headless-gauges` went with `/metrics` (ADR-0033). The
  * thread lost an entry rather than gaining a rewritten one: there is one
  * interface now, so there is no second usage to give a page to.
+ *
+ * It is eleven again since ADR-0040, and the difference is the reason the first
+ * one left. `/metrics` was a second usage of the product; the agent's interface
+ * is the *same* usage reached by something other than a browser — and it is the
+ * first thing on this site that a machine reads, which is why a page that
+ * describes it is not the same kind of page as the one that went.
  */
 
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
@@ -26,6 +32,7 @@ const sidebars = {
     'install-without-docker',
     'rebuild-and-resolution',
     'how-prices-are-collected',
+    'connect-your-own-agent',
     'coming-from-v4',
     'release-notes',
   ],


### PR DESCRIPTION
Closes #749.

The first ticket of milestone 5.1. A **read-only** MCP server, mounted on the existing socket, exposing five tools over figures the app already computes.

## The decision first: ADR-0040

ADR-0033 removed the last non-browser consumer and settled that `/api` is the front's interface. This ticket reopens exactly one half of that, in the way 0033 asked to be answered — *"the API's status is decided here rather than left to erode."*

**This is not `/metrics` coming back**, and the difference is the very reason that endpoint left: the gauges had no internal consumer ("whoever wants something very simple" — a person with no existence). This surface has one, and it is the headline feature of the same milestone: the built-in chat (#750) will be defined on **the same tool functions**, called in process, with no HTTP hop in a loopback. A surface the app's own feature runs on cannot quietly rot.

What the external client buys on top is the case named during triage: somebody who already has their own agent and wants their figures in it, without going through ours.

## The surface

| Tool | Answers | Boundary |
|---|---|---|
| `list_positions` | what is held: quantity, weighted-average cost, market value, unrealised gain, `terminal` | `PortfolioReader.positions` + `build_positions` |
| `get_portfolio_totals` | the most recent day, XIRR, TWR, YTD, the gain's four terms | `latest_totals` + `build_portfolio_totals` |
| `get_portfolio_history` | the global series over a window | `totals_series` |
| `list_accounts` | the per-account split — the allocation primitive | `latest_account_metrics` + `build_accounts` |
| `list_events` | the ledger, filtered and **bounded** | the published snapshot, as `/api/events` does |

No new arithmetic: every figure is one a route already returns, reached through the same primitive. The two interfaces cannot drift into disagreeing about what a holding is worth.

No per-security price series — that is the stock-picking surface, which #750's product goal excludes.

## Three choices worth the review

**A tool description is payload, not documentation.** The `description=` is what a *model* reads before choosing; the docstring is what the next maintainer reads. This app has three states of absence (ADR-0026), `terminal` separating *not priced yet* from *never priced* (ADR-0004), one reporting currency in the head and never on a row (ADR-0002), and a sold position that stays at quantity zero (ADR-0017). A model without those says "you own €0 of AAPL" in perfect confidence. A test holds the descriptions on the text a client actually receives.

**One departure from `/api`, and it is the ledger.** ADR-0031 answers `GET /api/events` entire and argues it: the forty rows are a rendering budget, not a fetch. A browser's constraint is the pixel; a model's is the context window. `list_events` is therefore bounded (default 100, newest first) and carries `total` — a slice without one produces a reader that asserts "you have made a hundred operations".

**Refusals travel as `ToolError`.** The SDK reports any other exception as `Error executing tool <name>` with the message dropped: an agent could not tell an unreadable store from a malformed date. That is precisely the distinction the ADR insists on — a failure to read must never reach a model as an empty portfolio.

## The mount

One branch in `boot.Serving`, which **already** intercepted the lifespan protocol for the teardown. The hook the SDK requires — `session_manager.run()` entered by the *host* app, a mounted sub-application's own lifespan never running — was therefore already there, for another reason.

One socket, one process, no fork. `SB_WEB_PORT` stays the only port and the boot variables stay three.

The order on the way out is not interchangeable: the session manager **before** the runtime, or a tool still in flight meets a closed store — the shape of #858, met from the other side. Verified in the log of a real `SIGTERM`.

## Access

Nothing. The socket **is** the authorization, as it already is for `/api` (ADR-0033: *whoever reaches the socket reaches the whole app*), and that is defensible **only because the surface is read-only**. `_refuse_a_foreign_origin` says nothing about a client with no `Origin` — that is the rule's deliberate shape — so an MCP write would be an exposure no guard covers, and the answer is not to write.

`transport_security` is passed **explicitly**, and the review caught why that matters — see below.

## The image shrinks

The SDK added 36 MB, 14.6 of them `cryptography` — `pyjwt[crypto]` is a hard dependency of `mcp`, for the OAuth the ADR declines. Nothing to shave there; there was three times as much elsewhere, and there always had been.

```
610 MB   before
645 MB   with the SDK
529 MB   after the two cuts    ← −116, and 81 below the baseline
```

Bundled test suites (61 MB, `pandas/tests` is 37 of them) and debug symbols in the `.so` files (57 MB, `_duckdb.so` is 52 of them). Two details invisible when reading the diff, both recorded in the Dockerfile: the cleanup lives **inside** the `uv sync` RUN (in a separate RUN it measured **+237 MB** — a layer only ever adds), and the pattern is `tests`/`test` but **never `testing`**, `numpy.testing` being a public API pandas imports at load.

## Review round (CodeRabbit)

Five findings, all acted on. One was serious and correct.

**The interface answered `421 Invalid Host header` to every host but localhost.** Handing the SDK no `transport_security` is the one thing that does not mean *no policy*: `TransportSecurityMiddleware` does disable the check on `None` settings — which is what I read — but the application never passes it `None`, because `streamable_http_app` substitutes settings first:

```python
if transport_security is None and host in ("127.0.0.1", "localhost", "::1"):
    transport_security = TransportSecuritySettings(
        allowed_hosts=["127.0.0.1:*", "localhost:*", "[::1]:*"], ...)
```

`host` defaults to `127.0.0.1`, so the branch always fired. Every client in the suite and every check by hand connected over loopback — the one address the allowlist admits — so nothing went red while the container was unusable for exactly what its own documentation page describes. Settings are now passed explicitly; three tests drive the real server through the ASGI scope, and the first fails with `421 == 200` without the change.

**A failed query said nothing.** `_store` raised `ToolError` for the absent store, but a store whose *query* fails raises `duckdb.Error` — reported as "Error executing tool &lt;name&gt;" with the cause discarded. The case an owner is most likely to meet said the least. Every store-backed body now converts a storage fault and carries the exception's own text.

**`from_day=""` was read as an omission** and silently widened the window. The guard is `is None` now.

**`list_events` claimed a resilience it does not have.** Its rows do come from the snapshot; its head names the reporting currency, which is a setting, so it opens the store for that one value. The old test passed only because the fixture drops the portfolio's tables and not `setting`. The claim is withdrawn rather than the code bent to it — what `/api/events` gains from opening nothing is the chart markers surviving a fault, and there is no equivalent stake here.

**The `autoremove` in the strip step does not reproduce**, and was checked rather than argued: `libstdc++6` and `libgcc-s1` ship with `python:3.14-slim` at the version the final image carries, held by packages that stay, and no extension in `/opt/venv` has an unresolved dependency. But it is a property of a base image this project does not own, and it would fail green — so **container-contract assertion 11** now resolves every compiled extension and imports the wheels the app boots on. Verified non-vacuous by hiding `libstdc++.so.6`: the pipeline reports `not found` and `import duckdb` raises.

## Verification

- `flake8 src/application src/api` — clean
- `pytest tests/` — **1586 passed**, 39 of them new
- `pnpm build` (website) — both locales, no broken link
- `container-contract.sh` — **11/11**, including *"the web port is the only socket the app binds"*
- Real boot + a real MCP client on `/mcp` — the five tools listed and called, `/api`, `/health` and the SPA untouched; and `Host:` set to a domain, a LAN address and localhost all answered `200`, with a non-JSON POST still refused `400`
- Heavy imports inside the slimmed image, `numpy.testing` included, and the `fetch_arrow_table()` that justifies pyarrow's 140 MB

No test binds a socket: the tools are tested as functions over a **real** store in `tmp_path`, the surface through the SDK's in-memory client — which is what proves a description exists at all, since a Python call would pass with an empty one. `Serving`'s routing is held separately because it is the only new code on *every* request's path.

## Out of scope

Any write; `get_prices(symbol)`; the metrics of #751/#752/5.2, each of which will ship its own tool in its own ticket; the chat itself (#750); MCP resources and prompts; authentication. And `pyarrow`, 140 MB for a single call — an architectural trade-off `pyproject.toml` documents, not a packaging problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MyyejDzVkyQc8B55rQtxT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only MCP interface at `/mcp` for connecting AI agents.
  - Exposed tools for positions, portfolio totals, history, accounts, and events.
  - Added validation and clear errors for invalid requests and unavailable data.
  - Reduced the documented container image size from 645 MB to 529 MB.

- **Documentation**
  - Added setup guidance for connecting an external agent, including security considerations.
  - Documented the agent interface and its stable tool formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->