### PR TITLE
fix(web): unblock the image build after a same-day lucide-react bump

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "config:recommended"
   ],
   "ignorePresets": [":semanticPrefixFixDepsChoreOthers"],
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],

--- a/src/web/pnpm-lock.yaml
+++ b/src/web/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 11.2.14
       lucide-react:
         specifier: ^1.28.0
-        version: 1.39.0(react@19.2.8)
+        version: 1.28.0(react@19.2.8)
       radix-ui:
         specifier: ^1.6.7
         version: 1.6.7(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1761,8 +1761,8 @@ packages:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
-  lucide-react@1.39.0:
-    resolution: {integrity: sha512-y8nXoEwvqqIsF927NBWXODa4bfMrcUeEb/9sgpwFqg0gUjgn3j5Hznk+v7STmPgZ2iQ11JKlbQGdFRuTOwvYkA==}
+  lucide-react@1.28.0:
+    resolution: {integrity: sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -3779,7 +3779,7 @@ snapshots:
 
   lru-cache@11.5.2: {}
 
-  lucide-react@1.39.0(react@19.2.8):
+  lucide-react@1.28.0(react@19.2.8):
     dependencies:
       react: 19.2.8
 


### PR DESCRIPTION
`pnpm install --frozen-lockfile` fails in the image build:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
  lucide-react@1.39.0 was published at 2026-09-01T13:36:08.000Z, within the
  minimumReleaseAge cutoff (2026-08-31T16:35:22.261Z)
```

pnpm 11 defaults `minimumReleaseAge` to 1440 minutes. #884 landed at 16:18Z, less than three hours after the release was published — its own `Front` and `Container` jobs were already red when Renovate automerged it, because neither is a required check on `master`.

Two commits:

- the lockfile goes back to `lucide-react@1.28.0`, which unblocks the deploy now rather than at 13:36Z tomorrow. `package.json` keeps `^1.28.0`, so Renovate proposes the bump again once the release has aged;
- `renovate.json` gains `minimumReleaseAge: "3 days"`, clearing pnpm's own cutoff with room to spare.

`Front` and `Container` are being added to the required checks on `master` separately, so no automerge can ride over a red build again.