### PR TITLE
docs: the root CLAUDE.md carries the named exception of reassignment.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,8 +116,8 @@ Four workloads write to the store, each owning its own tables:
 
 - **Scrape** — one self-rescheduling job per held symbol, cadenced by the
   market's `marketState`;
-- **Ingestion** — not a job: the boot or a write, and `entries.py` is its one
-  writer of the ledger (ADR-0032);
+- **Ingestion** — not a job: the boot or a write, and it reaches the ledger
+  through `entries.py` (ADR-0032);
 - **Backfill** — reconstructs history (backward, forward and lateral passes) and
   applies the retention ladder;
 - **Performance** — replays the ledger and rewrites the return series.
@@ -138,7 +138,11 @@ advisories together. There is no banner and no status dot.
   exactly one writer, and several tests assert that on the source. **`event` has
   one writer too, and it is `entries.py`** (ADR-0032): there is one population of
   rows, so a line that came out of a file is corrected and deleted like any
-  other, and no code anywhere asks a row where it came from.
+  other, and no code anywhere asks a row where it came from. **One named
+  exception apart, `reassignment.py`** (#725): it rewrites the `account` column
+  in bulk, addresses no row by its key, and is a module of its own precisely so
+  that a reader counting the writers finds it. `tests/test_entries.py` names the
+  two on the source, and there is no third.
 - **The DDL is applied with `IF NOT EXISTS` and there is no migration
   machinery.** A new column would exist on no store created before it — so derive
   at read time rather than adding one.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -242,10 +242,10 @@ _Avoid_: onboarding (as a phase), setup, installation wizard, first boot
 
 **Agent**:
 Something that reads the portfolio without a person watching each read. It reaches the app
-over its own interface, not the front's, and it only ever reads: the ledger has one writer
-and it is reached by a gesture, never by a tool. Two of them are in view and they are the
-same shape — the chat inside the app, and whatever the owner has already built and wants
-their own figures in.
+over its own interface, not the front's, and it only ever reads: the ledger is written by a
+person's gesture, never by a tool. Two of them are in view and they are the same shape —
+the chat inside the app, and whatever the owner has already built and wants their own
+figures in.
 _Avoid_: AI, bot, assistant, LLM
 
 **Tool**:

--- a/docs/adr/0040-the-app-gets-a-second-reader-and-it-is-an-agent.md
+++ b/docs/adr/0040-the-app-gets-a-second-reader-and-it-is-an-agent.md
@@ -39,8 +39,9 @@ It is the reason the surface is documented on the site: ADR-0033 counted *"nothi
 site describes an API"* as an economy, and this is the first thing there that describes a
 machine interface. A contract nobody can read is not one.
 
-**It reads, and it does not write.** `entries.py` remains the ledger's one writer
-([ADR-0032](./0032-the-import-is-a-gesture-not-a-mount.md)), reached by a person's gesture.
+**It reads, and it does not write.** The ledger's writers stay where they were — `entries.py`
+([ADR-0032](./0032-the-import-is-a-gesture-not-a-mount.md)) and the named exception of
+`reassignment.py` — and each of them is reached by a person's gesture.
 This is not caution for its own sake — it is what makes the access model honest. The
 `before_request` guard refuses a *foreign origin*, which is a statement about browsers; a
 client with no `Origin` at all is not refused, and never will be, because that is the rule's


### PR DESCRIPTION
Closes #863

## The choice, and why

The ticket leaves two ways out. This PR takes the first — **the root carries the
exception** — and does not take the second, for a reason that is written down
rather than assumed: the docstring of `src/application/reassignment.py` is a
sixty-line argument against folding the module into `entries.py`. Doing so would
make *the four gestures and what they refuse* read as five, one of which answers
to no key at all. The code, `src/application/CLAUDE.md` and
`tests/test_entries.py:345` already agree with each other; only the root said
something else, and it is the root an agent working on the front, the API or the
site reads, since the sub-tree files load on demand.

## What changed

| File | Before | After |
|---|---|---|
| `CLAUDE.md` § *rules that are expensive to break* | `event` has one writer, `entries.py`, full stop | the aside names `reassignment.py` (#725), says what makes it bounded, and points at the assertion on the source |
| `CLAUDE.md` § *architecture*, the Ingestion bullet | "`entries.py` is its one writer of the ledger" | "it reaches the ledger through `entries.py`" — the workload bullet no longer re-counts the writers, so the rule is stated once |
| `CONTEXT.md`, the **Agent** entry | "the ledger has one writer and it is reached by a gesture, never by a tool" | "the ledger is written by a person's gesture, never by a tool" — which is what the sentence was actually claiming |
| `docs/adr/0040`, *It reads, and it does not write* | "`entries.py` remains the ledger's one writer" | both writers named, each reached by a person's gesture; the ADR's decision is untouched |

## Acceptance criteria

- [x] The rule is stated with its exception, in the same place.
- [x] `tests/test_entries.py:345` reflects the state chosen — it already asserted
      `['application/entries.py', 'application/reassignment.py']`, so it is
      unchanged, which is the point.
- [x] No other document carries the version without the exception. `CONTEXT.md`
      and `docs/adr/0040` were the only two, both fixed above; `website/` never
      states the rule, and `docs/v5-decisions.md` (archive) only mentions the
      module on its own account.

## Verification

- `uv run pytest tests/test_entries.py` — 28 passed.
- No test reads the markdown, so nothing else was held on these files (the
  references in `tests/test_suite_conventions.py` are prose).

Documentation only; no source file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
