### PR TITLE
refactor: five names the v5 rewrite left with no reader

### DIFF
--- a/src/application/events/schemas.py
+++ b/src/application/events/schemas.py
@@ -234,12 +234,13 @@ class AccountMetricPoint:
     and never mixes them (spec #695 § 3), so the field says what it is and every
     reader stops having to un-stamp it.
 
-    ``account_type`` has **no column** — it was an InfluxDB tag, and the
-    declaration is where a page reads it from (ADR-0013). It survived on the
-    point for the exporter's account label alone, and that reader left with
-    ``/metrics`` (ADR-0033): the field is now carried and read by nobody.
-    Dropping it is a change to a typed seam that ADR-0033 does not ask for, so
-    it is written down here rather than done in passing.
+    ``account_type`` is **gone** (issue #862). It had no column — it was an
+    InfluxDB tag, and the declaration is where a page reads it from (ADR-0013) —
+    and it survived on the point for the exporter's account label alone, a
+    reader that left with ``/metrics`` (ADR-0033). It was then built on every
+    point of every account of every day, and read by nobody. A point of the
+    series says what the day is worth; what kind of account it is, is the
+    declaration's answer and stays there.
 
     ``account_currency`` is **gone** with ``Account.currency`` (issue #702,
     ADR-0002): an account has no currency of its own, there is one reporting
@@ -253,7 +254,6 @@ class AccountMetricPoint:
     ledger"* and *"a ledger at zero"* the same row.
     """
     account: str
-    account_type: str
     day: date
     cash_balance: Optional[float] = None
     holdings_value: Optional[float] = None

--- a/src/application/main.py
+++ b/src/application/main.py
@@ -44,8 +44,16 @@ from application.events.schemas import Portfolio
 LOG_LEVEL = boot_env.text(os.environ, boot_env.LOG_LEVEL,
                           boot_env.DEFAULT_LOG_LEVEL)
 app_logger = getLogger("suivi_bourse", level=LOG_LEVEL)
-scheduler_logger = getLogger("apscheduler.scheduler", level=LOG_LEVEL)
-yfinance_logger = getLogger("yfinance", level=LOG_LEVEL)
+
+# The two dependencies' loggers are **configured and not held** (#862). The call
+# is the whole of the point — ``logfmt_logger.getLogger`` sets the named logger's
+# level and attaches the formatter — and the names it used to be assigned to were
+# read nowhere: a module-level `scheduler_logger` reads as *"this is where
+# APScheduler is logged from"*, which is exactly what it is not. Nothing here
+# emits under those names; :data:`MANAGED_LOGGERS` below is what turns them
+# afterwards, and it names them as strings like every other.
+getLogger("apscheduler.scheduler", level=LOG_LEVEL)
+getLogger("yfinance", level=LOG_LEVEL)
 
 #: Every logger the app names, across all its modules. The list is explicit
 #: rather than a walk of ``logging.root.manager``, so turning the app to DEBUG

--- a/src/application/perf_job.py
+++ b/src/application/perf_job.py
@@ -569,7 +569,6 @@ class PerfJob:
                     last = i == len(perf.daily) - 1
                     pt = AccountMetricPoint(
                         account=account.id,
-                        account_type=account.type,
                         day=dp.date,
                         **value_kwargs(dp, last, perf),
                     )

--- a/src/application/workloads.py
+++ b/src/application/workloads.py
@@ -201,13 +201,20 @@ class Workloads:
     # The scrape's own state, seen from here (issue #847)
     # ------------------------------------------------------------------ #
     #
-    # The five attributes that left with the workload. A window and never a
+    # The three *memories* that left with the workload. A window and never a
     # second copy: a copy would be a second answer to "how many times has this
     # symbol failed", and the #617 back-off is the one guard that cannot afford
     # two. The ``info`` cache is here for one reason more: **two** workloads
     # hold it since #848, so the setter assigns both — one that moved only the
     # scrape's would split the memory under the one name that looks like it
     # cannot happen.
+    #
+    # The **two locks that guard them are not windowed** (#862). There were
+    # windows onto them, read by nobody, and the door was worse than shut: the
+    # facade is not where the synchronisation happens, and a name here saying
+    # ``_failure_counts_lock`` invited a caller to take the lock at the level
+    # above the state it guards. :mod:`scrape` takes its own locks, beside the
+    # dictionaries they stand for.
 
     @property
     def _share_info_cache(self) -> share_info.ShareInfoCache:
@@ -227,20 +234,12 @@ class Workloads:
         self._scrape.failure_counts = counts
 
     @property
-    def _failure_counts_lock(self):
-        return self._scrape.failure_counts_lock
-
-    @property
     def _sonde_state(self) -> Dict[str, scheduling.SondeState]:
         return self._scrape.sonde_state
 
     @_sonde_state.setter
     def _sonde_state(self, state: Dict[str, scheduling.SondeState]) -> None:
         self._scrape.sonde_state = state
-
-    @property
-    def _sonde_lock(self):
-        return self._scrape.sonde_lock
 
     # ------------------------------------------------------------------ #
     # The backfill's own state, seen from here (issue #848)

--- a/src/web/src/lib/accounts.test.ts
+++ b/src/web/src/lib/accounts.test.ts
@@ -24,7 +24,6 @@ import {
   declaredLabel,
   declaredType,
   degradedReason,
-  DEFAULT_RANGE,
   dividendPayers,
   firstDay,
   LAST_EVENTS,
@@ -78,7 +77,6 @@ describe('the one range control', () => {
     // other curve on the plot.
     expect([...RANGES]).toEqual(['1M', 'YTD', '1Y', 'SINCE_OPENING'])
     expect(RANGES).not.toContain('MAX')
-    expect(DEFAULT_RANGE).toBe('1Y')
   })
 
   it('stops the longest window at the youngest account’s opening', () => {

--- a/src/web/src/lib/accounts.ts
+++ b/src/web/src/lib/accounts.ts
@@ -153,13 +153,11 @@ export const RANGES = ['1M', 'YTD', '1Y', 'SINCE_OPENING'] as const
 
 export type Range = (typeof RANGES)[number]
 
-/**
- * The default, and it is the one preset that does **not** depend on the data:
- * *since the opening* is a `max` over the accounts, so a page opening on it
- * would render a different window depending on how old an account happens to
- * be, before the reader has asked anything.
- */
-export const DEFAULT_RANGE: Range = '1Y'
+// There is **no default here** (#862). A `DEFAULT_RANGE` stood beside `RANGES`
+// and was read by nobody: since #838 the card has no control of its own, so the
+// preset it opens on is the page's — `DEFAULT_DASHBOARD_RANGE`, mapped through
+// `ACCOUNT_RANGE` — and a second default under this name would be a second
+// answer to a question ADR-0019 settles with one control on the surface.
 
 /** A calendar day in UTC — the shape every perf point carries. */
 function day(at: Date): string {

--- a/tests/test_cash.py
+++ b/tests/test_cash.py
@@ -235,7 +235,7 @@ def test_account_metrics_are_upserted_on_the_day_they_describe(store):
     store.execute("INSERT INTO account (id, type, label) VALUES "
                   "('PEA', 'PEA', 'Mon PEA')")
     point = AccountMetricPoint(
-        account="PEA", account_type="PEA",
+        account="PEA",
         day=date(2024, 1, 15), cash_balance=100.0, holdings_value=900.0,
         total_value=1000.0, net_contributed=800.0)
 
@@ -260,7 +260,7 @@ def test_a_field_that_was_never_computable_is_null_not_missing(store):
     store.execute("INSERT INTO account (id, type, label) VALUES "
                   "('PEA', 'PEA', 'Mon PEA')")
     perf_series.write_account_metrics(store, [AccountMetricPoint(
-        account="PEA", account_type="PEA",
+        account="PEA",
         day=date(2024, 1, 15), cash_balance=100.0, holdings_value=900.0,
         total_value=1000.0, net_contributed=800.0)])
 

--- a/tests/test_log_level.py
+++ b/tests/test_log_level.py
@@ -11,7 +11,10 @@ on an unknown level. A ``set_log_level`` that moved no handler at all would pass
 that test, which is precisely the bug the first test below exists to catch.
 """
 import logging
+import os
 import re
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -67,6 +70,35 @@ class TestLogLevel:
                                           path.read_text(encoding='utf-8'))}
 
         assert named - set(main.MANAGED_LOGGERS) == set()
+
+    def test_the_boot_turns_the_two_dependencies_to_the_environment_s_level(self):
+        """The side effect of a call whose *name* was dead (#862).
+
+        `main` used to bind `scheduler_logger` and `yfinance_logger` and read
+        neither back. Removing the assignments must not remove the calls: they
+        are what carries `LOG_LEVEL` to APScheduler's and yfinance's own
+        loggers at boot, before `MANAGED_LOGGERS` has anything to turn. Nothing
+        in the running process can answer for that — the suite has imported
+        `main` long ago and `set_log_level` has moved every one of them since —
+        so this asks a **subprocess**, on the same reasoning as
+        `test_the_pure_modules_are_pure_at_the_import`: a level nobody would
+        set by accident, read straight off `logging` after the import alone.
+        """
+        program = (
+            'import sys; sys.path.insert(0, %r)\n'
+            'import logging\n'
+            'import application.main\n'
+            'print(",".join(logging.getLevelName(logging.getLogger(n).level)\n'
+            '               for n in ("suivi_bourse", "apscheduler.scheduler",\n'
+            '                         "yfinance")))\n'
+        ) % str(Path(main.__file__).resolve().parents[1])
+
+        result = subprocess.run(
+            [sys.executable, '-c', program], capture_output=True, text=True,
+            env={**os.environ, 'LOG_LEVEL': 'CRITICAL'})
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == 'CRITICAL,CRITICAL,CRITICAL'
 
     def test_an_unknown_level_is_refused(self):
         with pytest.raises(ValueError):

--- a/tests/test_quotes.py
+++ b/tests/test_quotes.py
@@ -793,7 +793,7 @@ def test_a_window_on_an_account_series_keeps_it_too(store):
                   "VALUES ('pea', 'PEA', 'PEA')")
     for day in (date(2025, 8, 10), date(2025, 8, 11)):
         perf_series.write_account_metrics(store, [AccountMetricPoint(
-            account='pea', account_type='PEA',
+            account='pea',
             day=day, cash_balance=1.0, holdings_value=1.0, total_value=1.0,
             net_contributed=1.0)])
     reader = store_reads.PortfolioReader(store)
@@ -865,7 +865,7 @@ def test_deleting_an_account_takes_its_cached_figures_with_it(store):
     store.execute("INSERT INTO account (id, type, label) "
                   "VALUES ('pea', 'PEA', 'PEA')")
     perf_series.write_account_metrics(store, [AccountMetricPoint(
-        account='pea', account_type='PEA',
+        account='pea',
         day=date(2024, 1, 1), cash_balance=1.0, holdings_value=1.0,
         total_value=1.0, net_contributed=1.0)])
 
@@ -901,7 +901,7 @@ def test_the_perf_write_rewrites_its_own_key_rather_than_appending(store, mocker
 
     for cycle in range(3):
         perf_series.write_account_metrics(store, [AccountMetricPoint(
-            account='pea', account_type='PEA',
+            account='pea',
             day=day, cash_balance=float(cycle), holdings_value=1.0,
             total_value=1.0, net_contributed=1.0) for day in days])
         perf_series.write_portfolio_totals(store, [PortfolioTotalPoint(

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -313,8 +313,7 @@ def seed_account_metrics(opened, account='pea', day=date(2026, 8, 5),
     opened.execute("INSERT INTO account (id, type, label) VALUES (?, 'CTO', ?) "
                    "ON CONFLICT (id) DO NOTHING", [account, account])
     perf_series.write_account_metrics(opened, [AccountMetricPoint(
-        account=account, account_type='CTO',
-        day=day, **values)])
+        account=account, day=day, **values)])
 
 
 #: A declared setup — the `accounts` mode's precondition. An accounts **file**


### PR DESCRIPTION
Closes #862.

Five leftovers of the v5 rewrite: names defined and read by nobody. Each goes;
none of them cost anything at runtime, and what they cost is reading.

| Name | Where | What happened |
|---|---|---|
| `Workloads._failure_counts_lock` | `src/application/workloads.py` | removed |
| `Workloads._sonde_lock` | `src/application/workloads.py` | removed |
| `AccountMetricPoint.account_type` | `src/application/events/schemas.py` | field removed; `perf_job.py` and five test constructions follow |
| `DEFAULT_RANGE` | `src/web/src/lib/accounts.ts` | removed, with the two lines of its own test |
| `scheduler_logger` / `yfinance_logger` | `src/application/main.py` | **the names go, the calls stay** |

### The two locks

They were windows onto the scrape's mutexes, and the door was worse than shut:
the facade is not where the synchronisation happens, so a name reading
`_failure_counts_lock` there invited a caller to take the lock at the level
above the state it guards. `scrape.py` takes its own, beside the dictionaries
they stand for. The block comment above said *"the five attributes"*; it now
says the three memories, and writes why the locks are not among them.

### `account_type`

The field's own docstring already said it: no column, an InfluxDB tag that
survived on the point for the exporter's account label alone, and that reader
left with `/metrics` (ADR-0033). It was still built on every point of every
account of every day. A point of the series says what the day is worth; what
kind of account it is stays the declaration's answer.

### `DEFAULT_RANGE`

Read only by its own test, which asserted it is `'1Y'`. Since #838 the accounts
card has no control of its own, so the preset it opens on is the page's —
`DEFAULT_DASHBOARD_RANGE` through `ACCOUNT_RANGE` — and a second default under
this name would be a second answer to a question ADR-0019 settles with one
control on the surface.

### The two loggers, and the acceptance criterion

The careful one. `getLogger(name, level=LOG_LEVEL)` **sets the named logger's
level**, which is how `LOG_LEVEL` reaches APScheduler and yfinance at boot,
before `MANAGED_LOGGERS` has anything to turn. So removing the assignment is
not removing the call: the assignments go, the calls stay, and a comment says
which is which.

*"Verified, not assumed"* is a new test —
`test_the_boot_turns_the_two_dependencies_to_the_environment_s_level`. Nothing
in the running process can answer for a boot-time side effect: the suite
imported `main` long ago and `set_log_level` has moved every logger since. So
it asks a **subprocess**, on the same reasoning as
`test_the_pure_modules_are_pure_at_the_import` — import `application.main`
under `LOG_LEVEL=CRITICAL`, read the three levels straight off `logging`.
Commenting the two calls out makes it fail, which was checked rather than
hoped. `test_the_list_names_every_logger_the_tree_creates` still covers them
too: it reads `getLogger(` off the source, not the assignments.

### Checks

- `uv run flake8 src/application src/api --ignore=E501` — clean
- `uv run pytest tests/` — 1588 passed
- `pnpm lint` (`tsc -b --noEmit`) — clean
- `pnpm test` — 42 files, 785 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)