### PR TITLE
fix(store): a deleted key is never handed to the next writer (#785)

### DIFF
--- a/.github/scripts/conventions.sh
+++ b/.github/scripts/conventions.sh
@@ -23,6 +23,9 @@ grep -rnE --include='*.py' "['\"]undefined['\"]" $SRC tests && rule "the sentine
 [ "$(grep -rlE --include='*.py' '(INSERT INTO|UPDATE|DELETE FROM) event\b' $SRC | sort | tr '\n' ' ')" = "src/application/entries.py src/application/reassignment.py " ] || rule "a third writer of the event table"
 [ "$(grep -rliE --include='*.py' '(INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+(position|account_state)\b' $SRC | tr '\n' ' ')" = "src/application/positions.py " ] || rule "a second writer of position/account_state"
 
+# One allocator, and it is Store.reserve (ADR-0027, #785).
+[ "$(grep -rlE --include='*.py' 'SELECT.*max\(id\)' $SRC | tr '\n' ' ')" = "src/application/store.py " ] || rule "a key allocated outside Store.reserve"
+
 # The pure modules import neither the store nor the market.
 PYTHONPATH=src uv run python -c '
 import sys, importlib

--- a/.github/scripts/conventions.sh
+++ b/.github/scripts/conventions.sh
@@ -24,7 +24,7 @@ grep -rnE --include='*.py' "['\"]undefined['\"]" $SRC tests && rule "the sentine
 [ "$(grep -rliE --include='*.py' '(INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+(position|account_state)\b' $SRC | tr '\n' ' ')" = "src/application/positions.py " ] || rule "a second writer of position/account_state"
 
 # One allocator, and it is Store.reserve (ADR-0027, #785).
-[ "$(grep -rlE --include='*.py' 'SELECT.*max\(id\)' $SRC | tr '\n' ' ')" = "src/application/store.py " ] || rule "a key allocated outside Store.reserve"
+[ "$(grep -rliE --include='*.py' 'max\(id\)' $SRC tests | sort | tr '\n' ' ')" = "src/application/store.py " ] || rule "a key allocated outside Store.reserve"
 
 # The pure modules import neither the store nor the market.
 PYTHONPATH=src uv run python -c '

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -632,7 +632,7 @@ def update_event(event_id: str):
         with runtime.config_manager.writing() as opened:
             updated = entries.update(opened, key, draft)
     except entries.UnknownEntry as exc:
-        return entry_gone(str(exc))
+        return entry_gone(str(exc)) if exc.issued else not_found(str(exc))
     except entries.InvalidEntry as exc:
         return unprocessable_entry(str(exc), key=exc.field)
     except AggregationError as exc:
@@ -654,7 +654,7 @@ def delete_event(event_id: str):
         with runtime.config_manager.writing() as opened:
             entries.remove(opened, key)
     except entries.UnknownEntry as exc:
-        return entry_gone(str(exc))
+        return entry_gone(str(exc)) if exc.issued else not_found(str(exc))
     except AggregationError as exc:
         return _unreplayable(exc, GESTURE_REMOVE)
 

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -36,6 +36,7 @@ from api.problem import (
     GESTURE_WRITE,
     bad_request,
     conflict,
+    entry_gone,
     foreign_origin,
     internal_error,
     not_found,
@@ -631,7 +632,7 @@ def update_event(event_id: str):
         with runtime.config_manager.writing() as opened:
             updated = entries.update(opened, key, draft)
     except entries.UnknownEntry as exc:
-        return not_found(str(exc))
+        return entry_gone(str(exc))
     except entries.InvalidEntry as exc:
         return unprocessable_entry(str(exc), key=exc.field)
     except AggregationError as exc:
@@ -653,7 +654,7 @@ def delete_event(event_id: str):
         with runtime.config_manager.writing() as opened:
             entries.remove(opened, key)
     except entries.UnknownEntry as exc:
-        return not_found(str(exc))
+        return entry_gone(str(exc))
     except AggregationError as exc:
         return _unreplayable(exc, GESTURE_REMOVE)
 

--- a/src/api/problem.py
+++ b/src/api/problem.py
@@ -7,6 +7,7 @@ CONTENT_TYPE = 'application/problem+json'
 
 TYPE_UNAVAILABLE = '/problems/storage-unavailable'
 TYPE_NOT_FOUND = '/problems/not-found'
+TYPE_ENTRY_GONE = '/problems/entry-gone'
 TYPE_BAD_REQUEST = '/problems/bad-request'
 TYPE_INTERNAL = '/problems/internal-error'
 TYPE_CONFLICT = '/problems/conflict'
@@ -43,6 +44,19 @@ def storage_unavailable(detail: str):
 def not_found(detail: str):
     """404 — for a resource that genuinely does not exist."""
     return problem(404, 'Not found', detail, TYPE_NOT_FOUND)
+
+
+def entry_gone(detail: str):
+    """404 — the event was there and is not any more (#785, ADR-0027).
+
+    Its own identifier because the two are opposite pieces of news and only the
+    server can tell them apart: a key it once issued is never handed to another
+    row for the life of its process, so a write that misses names a row that
+    **left**. *This does not exist* is the sentence for an address that never
+    was one, and it reads, on a row the page is still displaying, as the app
+    contradicting its reader.
+    """
+    return problem(404, 'Event no longer in the ledger', detail, TYPE_ENTRY_GONE)
 
 
 def bad_request(detail: str):

--- a/src/application/entries.py
+++ b/src/application/entries.py
@@ -23,7 +23,16 @@ AMOUNT_PRECISION = '%.16g'
 
 
 class UnknownEntry(Exception):
-    """No event has that id."""
+    """No event has that id — and ``issued`` says whether one ever did.
+
+    *It was there* and *it never was* are opposite pieces of news, and the store
+    is the only side that can tell them apart (#785, ADR-0027): a key it handed
+    out named a row once, a key past its mark has never named anything.
+    """
+
+    def __init__(self, message: str, issued: bool = False):
+        super().__init__(message)
+        self.issued = issued
 
 
 class InvalidEntry(Exception):
@@ -250,7 +259,8 @@ def _require_known(store, event_id: int) -> None:
     """Refuse an id no row answers to. **One refusal, and it is the only one.**"""
     rows = store.query('SELECT 1 FROM event WHERE id = ?', [event_id])
     if not rows:
-        raise UnknownEntry(f"No event with id {event_id}")
+        raise UnknownEntry(f"No event with id {event_id}",
+                           issued=store.issued('event', event_id))
 
 
 def _stamp_write(store) -> None:

--- a/src/application/entries.py
+++ b/src/application/entries.py
@@ -49,8 +49,7 @@ def create(store, draft: Event) -> Event:
         _refuse(store, event)
         account = event.account or DEFAULT_ACCOUNT
 
-        (next_id,) = store.query(
-            'SELECT coalesce(max(id), 0) + 1 FROM event')[0:1][0]
+        next_id = store.reserve('event')
         _insert_symbol(store, event)
         store.execute(
             'INSERT INTO event (id, date, event_type, account, symbol, name, '
@@ -96,8 +95,7 @@ def create_many(store, drafts: Sequence[Event], *,
         if not settled:
             return []
 
-        (next_id,) = store.query(
-            'SELECT coalesce(max(id), 0) + 1 FROM event')[0:1][0]
+        next_id = store.reserve('event', len(settled))
         store.executemany(
             'INSERT INTO symbol (symbol) VALUES (?) ON CONFLICT DO NOTHING',
             [[symbol] for symbol in sorted({event.symbol for event in settled

--- a/src/application/events/schemas.py
+++ b/src/application/events/schemas.py
@@ -27,7 +27,26 @@ CASH_EVENT_TYPES = frozenset({EventType.DEPOSIT, EventType.WITHDRAWAL})
 
 @dataclass
 class Event:
-    """Represents a single portfolio event."""
+    """One dated line of the ledger — and ``id`` is its **address** (ADR-0027).
+
+    A key names one row for as long as that row lives, and promises nothing
+    beyond it: the id is absent from the CSV export, so an event exported and
+    re-imported comes back under another one.
+
+    What makes an address safe to hold between the read and the write is not
+    the key — it is **the allocator**. :meth:`store.Store.reserve` climbs and
+    never descends, so a deleted row's key is not handed to the next writer,
+    and a write aiming at a row that has gone meets ``UnknownEntry`` rather
+    than landing on a stranger.
+
+    That is why #662's apparatus — the opaque token over ``(file, sheet, row)``,
+    the content fingerprint as an ``ETag`` and its ``409`` — has no successor
+    here: the refusal it existed to buy is bought by the allocator, and bought
+    **for the life of the process**. A restart re-seeds from ``max(id)`` and can
+    reissue a key freed before it; a client holding a key across a restart is
+    holding it across an app that went down. Were that bound ever to prove too
+    short, the token is what comes back.
+    """
     date: date
     event_type: EventType
     symbol: Optional[str] = None

--- a/src/application/events/schemas.py
+++ b/src/application/events/schemas.py
@@ -42,8 +42,8 @@ class Event:
     That is why #662's apparatus — the opaque token over ``(file, sheet, row)``,
     the content fingerprint as an ``ETag`` and its ``409`` — has no successor
     here: the refusal it existed to buy is bought by the allocator, and bought
-    **for the life of the process**. A restart re-seeds from ``max(id)`` and can
-    reissue a key freed before it; a client holding a key across a restart is
+    **for the life of the process**. A restart re-seeds from the highest key the
+    table still holds and can reissue one freed before it; a client holding a key across a restart is
     holding it across an app that went down. Were that bound ever to prove too
     short, the token is what comes back.
     """

--- a/src/application/store.py
+++ b/src/application/store.py
@@ -187,6 +187,18 @@ class Store:
             self._reserved[table] = mark + count
             return mark + 1
 
+    def issued(self, table: str, key: int) -> bool:
+        """Whether this store has ever handed ``key`` out for ``table``.
+
+        The other half of :meth:`reserve`, and the reason a refusal can say
+        *which* refusal it is: a key at or below the mark named a row once, and
+        a key above it has never named anything. The bound is the mark's own —
+        a store reopened has forgotten the keys it retired, so an old one reads
+        as never issued, which is the window ADR-0027 declines to buy.
+        """
+        with self._lock:
+            return 0 < key <= self._reserved.get(table, 0)
+
     @contextmanager
     def transaction(self):
         """``BEGIN`` … ``COMMIT``, with every other thread kept outside it."""

--- a/src/application/store.py
+++ b/src/application/store.py
@@ -4,7 +4,7 @@ import os
 import threading
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 import duckdb
 from logfmt_logger import getLogger
@@ -144,6 +144,36 @@ class Store:
         self.path = path
         self._connection = connection
         self._lock = threading.RLock()
+        #: The high-water mark per table — memory, never a row (ADR-0027).
+        self._reserved: Dict[str, int] = {}
+
+    def reserve(self, table: str, count: int = 1) -> int:
+        """The first of ``count`` fresh keys for ``table`` (ADR-0027, #785).
+
+        **The one allocator, and it only ever climbs.** ``max(id) + 1`` handed
+        the highest deleted row's key straight to the next writer, so a client
+        holding a key it had just read could correct or delete *the row that
+        took its place*. This is seeded from ``max(id)`` on first use and never
+        descends afterwards, which is what makes ``UnknownEntry`` mean what it
+        says: a write aiming at a row that has gone is refused rather than
+        landing on a stranger.
+
+        **The guarantee is scoped to the life of the process.** The mark is
+        memory: a restart re-seeds from ``max(id)`` and can reissue a key freed
+        before it. A client holding a key across a restart is holding it across
+        an app that went down, which is not the window this buys.
+
+        It takes the store's own lock — reentrant, so its callers pay nothing —
+        rather than trusting every caller to already hold one.
+        """
+        if table not in TABLES:
+            raise KeyError(f"no table named {table!r}")
+        with self._lock:
+            mark = self._reserved.get(table)
+            if mark is None:
+                mark = self.query(f'SELECT coalesce(max(id), 0) FROM {table}')[0][0]
+            self._reserved[table] = mark + count
+            return mark + 1
 
     @contextmanager
     def transaction(self):

--- a/src/application/store.py
+++ b/src/application/store.py
@@ -134,6 +134,11 @@ TABLES = (
     'setting', 'installation_fact', 'advisory_ack',
 )
 
+#: The tables whose surrogate key this store hands out — see
+#: :meth:`Store.reserve`. ``event`` is the only one, and the tuple is what says
+#: so: every other table is keyed by something the domain already names.
+KEYED_TABLES = ('event',)
+
 DEFAULT_ACCOUNT_ROW = ('default', 'OTHER', 'Default account')
 
 
@@ -144,8 +149,15 @@ class Store:
         self.path = path
         self._connection = connection
         self._lock = threading.RLock()
-        #: The high-water mark per table — memory, never a row (ADR-0027).
-        self._reserved: Dict[str, int] = {}
+        #: The high-water mark per keyed table — memory, never a row
+        #: (ADR-0027), and read **at the open**: seeded on first use instead,
+        #: a row deleted before this store had written anything would seed the
+        #: mark *below its own key* and hand it straight back — which is the
+        #: defect, inside the very window the mark exists to hold.
+        self._reserved: Dict[str, int] = {
+            table: connection.execute(
+                f'SELECT coalesce(max(id), 0) FROM {table}').fetchone()[0]
+            for table in KEYED_TABLES}
 
     def reserve(self, table: str, count: int = 1) -> int:
         """The first of ``count`` fresh keys for ``table`` (ADR-0027, #785).
@@ -153,10 +165,10 @@ class Store:
         **The one allocator, and it only ever climbs.** ``max(id) + 1`` handed
         the highest deleted row's key straight to the next writer, so a client
         holding a key it had just read could correct or delete *the row that
-        took its place*. This is seeded from ``max(id)`` on first use and never
-        descends afterwards, which is what makes ``UnknownEntry`` mean what it
-        says: a write aiming at a row that has gone is refused rather than
-        landing on a stranger.
+        took its place*. The mark is read from ``max(id)`` **when the store is
+        opened** and never descends afterwards, which is what makes
+        ``UnknownEntry`` mean what it says: a write aiming at a row that has
+        gone is refused rather than landing on a stranger.
 
         **The guarantee is scoped to the life of the process.** The mark is
         memory: a restart re-seeds from ``max(id)`` and can reissue a key freed
@@ -166,12 +178,12 @@ class Store:
         It takes the store's own lock — reentrant, so its callers pay nothing —
         rather than trusting every caller to already hold one.
         """
-        if table not in TABLES:
-            raise KeyError(f"no table named {table!r}")
+        if table not in self._reserved:
+            raise KeyError(f"{table!r} is not a table this store keys")
+        if count < 1:
+            raise ValueError(f"a range of {count} keys is not a range")
         with self._lock:
-            mark = self._reserved.get(table)
-            if mark is None:
-                mark = self.query(f'SELECT coalesce(max(id), 0) FROM {table}')[0][0]
+            mark = self._reserved[table]
             self._reserved[table] = mark + count
             return mark + 1
 
@@ -315,6 +327,6 @@ def open_store(path: Optional[Path] = None) -> Store:
 __all__ = [
     'Store', 'StoreUnavailable', 'open_store', 'prepare', 'store_path',
     'file_size', 'finite',
-    'DDL', 'TABLES', 'STORE_FILENAME', 'STORE_DIR_VAR', 'DEFAULT_STORE_DIR',
+    'DDL', 'TABLES', 'KEYED_TABLES', 'STORE_FILENAME', 'STORE_DIR_VAR', 'DEFAULT_STORE_DIR',
     'DEFAULT_ACCOUNT_ROW',
 ]

--- a/src/web/src/components/data/EventForm.tsx
+++ b/src/web/src/components/data/EventForm.tsx
@@ -169,6 +169,19 @@ export function EventForm({ open, event, accounts, accountsFailed, onClose }: Ev
     },
   })
 
+  /**
+   * **Every way out of the panel, and there are three**: the cancel button, the
+   * sheet's own close, and the write that succeeded. The refusal is forgotten
+   * with the gesture that carried it — the panel is mounted once for all the
+   * rows, so a sentence left standing is read as being about the next row
+   * opened, and *this event is no longer in the ledger* over a row that is
+   * perfectly alive is a precise untruth.
+   */
+  function close() {
+    write.reset()
+    onClose()
+  }
+
   const fields = type === null ? null : FIELDS[type]
   const choice = accountChoice(accounts, accountsFailed)
   // The two states nothing in this panel can repair: the declaration is not
@@ -246,12 +259,7 @@ export function EventForm({ open, event, accounts, accountsFailed, onClose }: Ev
       open={open}
       onOpenChange={(next) => {
         if (next) return
-        // The refusal is forgotten with the panel that carried it: a mutation
-        // error outlives its gesture, so reopening on another row would show a
-        // sentence about the previous one — and *this event is no longer in the
-        // ledger* over a row that is perfectly alive is a precise untruth.
-        write.reset()
-        onClose()
+        close()
       }}
     >
       <SheetContent className="w-full gap-6 overflow-y-auto sm:max-w-md">
@@ -503,7 +511,7 @@ export function EventForm({ open, event, accounts, accountsFailed, onClose }: Ev
                 <Button type="submit" disabled={write.isPending || blocked}>
                   {t('data.form.submit')}
                 </Button>
-                <Button type="button" variant="outline" onClick={onClose}>
+                <Button type="button" variant="outline" onClick={close}>
                   {t('data.form.cancel')}
                 </Button>
               </div>

--- a/src/web/src/components/data/EventForm.tsx
+++ b/src/web/src/components/data/EventForm.tsx
@@ -66,7 +66,7 @@ import {
 } from '@/lib/accounts'
 import { useI18n, type MessageKey } from '@/lib/i18n'
 import { accountOf, FIELDS, parseDay, parseDecimal } from '@/lib/ledger'
-import { problemSentence } from '@/lib/problem'
+import { entryGone, entrySentence } from '@/lib/problem'
 import { cn } from '@/lib/utils'
 
 /** Everything the reader typed, as typed — parsing happens once, on submit. */
@@ -160,6 +160,12 @@ export function EventForm({ open, event, accounts, accountsFailed, onClose }: Ev
       // would drift from the pages reading them.
       void queryClient.invalidateQueries()
       onClose()
+    },
+    onError: (error) => {
+      // The row being corrected left the ledger somewhere else (#785): the
+      // panel stays open holding what was typed, and the list behind it is
+      // re-read so the row it is about stops being displayed.
+      if (entryGone(error)) void queryClient.invalidateQueries()
     },
   })
 
@@ -475,7 +481,7 @@ export function EventForm({ open, event, accounts, accountsFailed, onClose }: Ev
                 )}
               </Field>
 
-              {write.error ? <Refusal>{problemSentence(t, write.error)}</Refusal> : null}
+              {write.error ? <Refusal>{entrySentence(t, write.error)}</Refusal> : null}
 
               <div className="flex gap-2">
                 {/* Withheld rather than offered and refused — the same rule the

--- a/src/web/src/components/data/EventForm.tsx
+++ b/src/web/src/components/data/EventForm.tsx
@@ -66,7 +66,7 @@ import {
 } from '@/lib/accounts'
 import { useI18n, type MessageKey } from '@/lib/i18n'
 import { accountOf, FIELDS, parseDay, parseDecimal } from '@/lib/ledger'
-import { entryGone, entrySentence } from '@/lib/problem'
+import { entryGone, problemSentence } from '@/lib/problem'
 import { cn } from '@/lib/utils'
 
 /** Everything the reader typed, as typed — parsing happens once, on submit. */
@@ -163,9 +163,9 @@ export function EventForm({ open, event, accounts, accountsFailed, onClose }: Ev
     },
     onError: (error) => {
       // The row being corrected left the ledger somewhere else (#785): the
-      // panel stays open holding what was typed, and the list behind it is
-      // re-read so the row it is about stops being displayed.
-      if (entryGone(error)) void queryClient.invalidateQueries()
+      // panel stays open holding what was typed, and the one list that went
+      // stale is re-read so the row it is about stops being displayed.
+      if (entryGone(error)) void queryClient.invalidateQueries({ queryKey: ['events'] })
     },
   })
 
@@ -242,7 +242,18 @@ export function EventForm({ open, event, accounts, accountsFailed, onClose }: Ev
   }
 
   return (
-    <Sheet open={open} onOpenChange={(next) => (next ? undefined : onClose())}>
+    <Sheet
+      open={open}
+      onOpenChange={(next) => {
+        if (next) return
+        // The refusal is forgotten with the panel that carried it: a mutation
+        // error outlives its gesture, so reopening on another row would show a
+        // sentence about the previous one — and *this event is no longer in the
+        // ledger* over a row that is perfectly alive is a precise untruth.
+        write.reset()
+        onClose()
+      }}
+    >
       <SheetContent className="w-full gap-6 overflow-y-auto sm:max-w-md">
         <SheetHeader>
           <SheetTitle>
@@ -481,7 +492,7 @@ export function EventForm({ open, event, accounts, accountsFailed, onClose }: Ev
                 )}
               </Field>
 
-              {write.error ? <Refusal>{entrySentence(t, write.error)}</Refusal> : null}
+              {write.error ? <Refusal>{problemSentence(t, write.error)}</Refusal> : null}
 
               <div className="flex gap-2">
                 {/* Withheld rather than offered and refused — the same rule the

--- a/src/web/src/components/data/RowDelete.tsx
+++ b/src/web/src/components/data/RowDelete.tsx
@@ -36,7 +36,7 @@ import { api, type LedgerEvent } from '@/lib/api'
 import { ABSENT, useFormatters } from '@/lib/format'
 import { useI18n } from '@/lib/i18n'
 import { identityOf } from '@/lib/ledger'
-import { problemSentence } from '@/lib/problem'
+import { entryGone, entrySentence } from '@/lib/problem'
 import { receiptMessage } from '@/lib/receipts'
 
 interface RowDeleteProps {
@@ -60,6 +60,13 @@ export function RowDelete({ event, onClose }: RowDeleteProps) {
       // replays synchronously before answering — so what is invalidated is
       // everything rather than a list somebody has to keep in step.
       void queryClient.invalidateQueries()
+    },
+    onError: (error) => {
+      // **The row left the ledger somewhere else** (#785): nothing was written,
+      // and what is stale is this page. Re-reading is what makes the sentence
+      // true — the phantom row goes while the reader is still looking at the
+      // box that named it.
+      if (entryGone(error)) void queryClient.invalidateQueries()
     },
   })
 
@@ -99,7 +106,7 @@ export function RowDelete({ event, onClose }: RowDeleteProps) {
 
             {/* Rendered **here** and not on the page: the box stays open on a
                 failure, and everything behind the overlay is `aria-hidden`. */}
-            {remove.error ? <Refusal>{problemSentence(t, remove.error)}</Refusal> : null}
+            {remove.error ? <Refusal>{entrySentence(t, remove.error)}</Refusal> : null}
 
             <div className="flex flex-wrap justify-end gap-2">
               <Button

--- a/src/web/src/components/data/RowDelete.tsx
+++ b/src/web/src/components/data/RowDelete.tsx
@@ -36,7 +36,7 @@ import { api, type LedgerEvent } from '@/lib/api'
 import { ABSENT, useFormatters } from '@/lib/format'
 import { useI18n } from '@/lib/i18n'
 import { identityOf } from '@/lib/ledger'
-import { entryGone, entrySentence } from '@/lib/problem'
+import { entryGone, problemSentence } from '@/lib/problem'
 import { receiptMessage } from '@/lib/receipts'
 
 interface RowDeleteProps {
@@ -63,10 +63,11 @@ export function RowDelete({ event, onClose }: RowDeleteProps) {
     },
     onError: (error) => {
       // **The row left the ledger somewhere else** (#785): nothing was written,
-      // and what is stale is this page. Re-reading is what makes the sentence
-      // true — the phantom row goes while the reader is still looking at the
-      // box that named it.
-      if (entryGone(error)) void queryClient.invalidateQueries()
+      // so the whole cache is not what went stale — the list is. The phantom
+      // row goes while the reader is still looking at the box that named it,
+      // and `/health`, the accounts and the installation facts are not re-read
+      // for a row that left a page.
+      if (entryGone(error)) void queryClient.invalidateQueries({ queryKey: ['events'] })
     },
   })
 
@@ -106,7 +107,7 @@ export function RowDelete({ event, onClose }: RowDeleteProps) {
 
             {/* Rendered **here** and not on the page: the box stays open on a
                 failure, and everything behind the overlay is `aria-hidden`. */}
-            {remove.error ? <Refusal>{entrySentence(t, remove.error)}</Refusal> : null}
+            {remove.error ? <Refusal>{problemSentence(t, remove.error)}</Refusal> : null}
 
             <div className="flex flex-wrap justify-end gap-2">
               <Button

--- a/src/web/src/data.test.tsx
+++ b/src/web/src/data.test.tsx
@@ -983,6 +983,52 @@ describe('a row is removed at the unit', () => {
       within(box).getByRole('heading', { name: 'Supprimer cet événement ?' }),
     ).toBeInTheDocument()
   })
+
+  it('says the row left the ledger elsewhere, and re-reads it under the reader', async () => {
+    // **#785's criterion, on the reachable half.** The list is 30 s old and the
+    // row it shows was deleted in another tab; the `404` that comes back is not
+    // *this does not exist* — a sentence that contradicts what the reader is
+    // looking at — but *it was deleted elsewhere*. And the ledger is re-read on
+    // the failure, so the phantom row is gone the moment the box comes down.
+    let gone = false
+    const { user } = renderData()
+    await waitFor(() => expect(ledger()).toBeInTheDocument())
+
+    server.use(
+      http.get(ROUTES.events, () =>
+        HttpResponse.json(aLedgerPayload(gone ? ledgerEvents().slice(0, 3) : ledgerEvents())),
+      ),
+      http.delete(`${ROUTES.events}/:id`, () => {
+        gone = true
+        return HttpResponse.json(
+          { status: 404, type: PROBLEM_TYPES.notFound, title: 'Not found' },
+          { status: 404, headers: { 'Content-Type': 'application/problem+json' } },
+        )
+      }),
+    )
+
+    const row = within(ledger()).getByText('ZZC').closest('tr') as HTMLElement
+    await user.click(within(row).getByRole('button', { name: 'Supprimer cet événement' }))
+    await user.click(
+      within(await screen.findByRole('dialog')).getByRole('button', {
+        name: 'Supprimer cet événement',
+      }),
+    )
+
+    const box = await screen.findByRole('dialog')
+    expect(await within(box).findByRole('status')).toHaveTextContent(
+      'Cet événement n’est plus dans le grand livre : il a été supprimé ailleurs. ' +
+        'Rien n’a été modifié ici, et le grand livre vient d’être relu.',
+    )
+    // Not the generic sentence, which is the whole point of the second key.
+    expect(within(box).queryByText(/n’existe pas/)).not.toBeInTheDocument()
+
+    // The table is `aria-hidden` under the overlay, so what the re-read bought
+    // is read where the reader reads it: the box comes down on a ledger that
+    // no longer shows the row it was about.
+    await user.click(within(box).getByRole('button', { name: 'Le garder' }))
+    await waitFor(() => expect(rowsOf(ledger())).toHaveLength(3))
+  })
 })
 
 describe('the create form, which is the onboarding', () => {
@@ -1082,6 +1128,43 @@ describe('the create form, which is the onboarding', () => {
     await user.click(screen.getByRole('button', { name: 'Ce que veut dire Prix unitaire' }))
     expect(await screen.findByText(/ajoute seulement des titres/)).toBeInTheDocument()
     expect(screen.getByText(/vos versements et dans votre base de coût/)).toBeInTheDocument()
+  })
+
+  it('says a corrected row left the ledger elsewhere, in the panel that holds it', async () => {
+    // The same news, on the other gesture that addresses a row by its key
+    // (#785): *corriger* rewrites what the reader was looking at, so a `404`
+    // here means the row went — not that the address was never anything.
+    const { user } = renderData()
+    await waitFor(() => expect(ledger()).toBeInTheDocument())
+
+    let gone = false
+    server.use(
+      http.get(ROUTES.events, () =>
+        HttpResponse.json(aLedgerPayload(gone ? ledgerEvents().slice(0, 3) : ledgerEvents())),
+      ),
+      http.patch(`${ROUTES.events}/:id`, () => {
+        gone = true
+        return HttpResponse.json(
+          { status: 404, type: PROBLEM_TYPES.notFound, title: 'Not found' },
+          { status: 404, headers: { 'Content-Type': 'application/problem+json' } },
+        )
+      }),
+    )
+
+    await user.click(within(ledger()).getByRole('button', { name: 'ZZC' }))
+    expect(await screen.findByLabelText('Quantité')).toHaveValue('2')
+    await user.click(screen.getByRole('button', { name: 'Enregistrer cet événement' }))
+
+    const panel = screen.getByRole('dialog')
+    expect(await within(panel).findByRole('status')).toHaveTextContent(
+      'Cet événement n’est plus dans le grand livre : il a été supprimé ailleurs. ' +
+        'Rien n’a été modifié ici, et le grand livre vient d’être relu.',
+    )
+    // The panel stays open holding what was typed — the reader has not lost it.
+    expect(screen.getByLabelText('Quantité')).toHaveValue('2')
+
+    await user.click(within(panel).getByRole('button', { name: 'Fermer' }))
+    await waitFor(() => expect(rowsOf(ledger())).toHaveLength(3))
   })
 
   it('records the event and puts it in the ledger', async () => {

--- a/src/web/src/data.test.tsx
+++ b/src/web/src/data.test.tsx
@@ -1001,7 +1001,7 @@ describe('a row is removed at the unit', () => {
       http.delete(`${ROUTES.events}/:id`, () => {
         gone = true
         return HttpResponse.json(
-          { status: 404, type: PROBLEM_TYPES.notFound, title: 'Not found' },
+          { status: 404, type: PROBLEM_TYPES.entryGone, title: 'Event no longer in the ledger' },
           { status: 404, headers: { 'Content-Type': 'application/problem+json' } },
         )
       }),
@@ -1017,8 +1017,8 @@ describe('a row is removed at the unit', () => {
 
     const box = await screen.findByRole('dialog')
     expect(await within(box).findByRole('status')).toHaveTextContent(
-      'Cet événement n’est plus dans le grand livre : il a été supprimé ailleurs. ' +
-        'Rien n’a été modifié ici, et le grand livre vient d’être relu.',
+      'Cet événement n’est plus dans le grand livre : il a été supprimé ailleurs, ' +
+        'et rien n’a été modifié ici.',
     )
     // Not the generic sentence, which is the whole point of the second key.
     expect(within(box).queryByText(/n’existe pas/)).not.toBeInTheDocument()
@@ -1145,7 +1145,7 @@ describe('the create form, which is the onboarding', () => {
       http.patch(`${ROUTES.events}/:id`, () => {
         gone = true
         return HttpResponse.json(
-          { status: 404, type: PROBLEM_TYPES.notFound, title: 'Not found' },
+          { status: 404, type: PROBLEM_TYPES.entryGone, title: 'Event no longer in the ledger' },
           { status: 404, headers: { 'Content-Type': 'application/problem+json' } },
         )
       }),
@@ -1157,14 +1157,24 @@ describe('the create form, which is the onboarding', () => {
 
     const panel = screen.getByRole('dialog')
     expect(await within(panel).findByRole('status')).toHaveTextContent(
-      'Cet événement n’est plus dans le grand livre : il a été supprimé ailleurs. ' +
-        'Rien n’a été modifié ici, et le grand livre vient d’être relu.',
+      'Cet événement n’est plus dans le grand livre : il a été supprimé ailleurs, ' +
+        'et rien n’a été modifié ici.',
     )
     // The panel stays open holding what was typed — the reader has not lost it.
     expect(screen.getByLabelText('Quantité')).toHaveValue('2')
 
     await user.click(within(panel).getByRole('button', { name: 'Fermer' }))
     await waitFor(() => expect(rowsOf(ledger())).toHaveLength(3))
+
+    // **The refusal does not outlive its gesture.** The panel is mounted once
+    // for every row, so a sentence left standing would be read as being about
+    // the next row opened — and *this event is no longer in the ledger* over a
+    // row that is perfectly alive is a precise untruth, which is worse than the
+    // vague one it replaced.
+    const alive = within(ledger()).getByText('Versement programmé mensuel').closest('tr')
+    await user.click(within(alive as HTMLElement).getAllByRole('cell')[0])
+    expect(await screen.findByLabelText('Quantité')).toHaveValue('3')
+    expect(screen.queryByText(/n’est plus dans le grand livre/)).not.toBeInTheDocument()
   })
 
   it('records the event and puts it in the ledger', async () => {

--- a/src/web/src/data.test.tsx
+++ b/src/web/src/data.test.tsx
@@ -1163,7 +1163,11 @@ describe('the create form, which is the onboarding', () => {
     // The panel stays open holding what was typed — the reader has not lost it.
     expect(screen.getByLabelText('Quantité')).toHaveValue('2')
 
-    await user.click(within(panel).getByRole('button', { name: 'Fermer' }))
+    // **Every way out of the panel forgets it**, and the cancel button is the
+    // one a reader actually presses — it closes without going through the
+    // sheet's own close, so a reset held there alone would leave the sentence
+    // standing on exactly the commonest path.
+    await user.click(within(panel).getByRole('button', { name: 'Annuler' }))
     await waitFor(() => expect(rowsOf(ledger())).toHaveLength(3))
 
     // **The refusal does not outlive its gesture.** The panel is mounted once

--- a/src/web/src/i18n/en.json
+++ b/src/web/src/i18n/en.json
@@ -570,7 +570,7 @@
 
   "problem.storageUnavailable": "Your data cannot be read right now. The app is running, but its store is not answering.",
   "problem.notFound": "The app answered that this does not exist.",
-  "problem.entryGone": "This event is no longer in the ledger: it was deleted elsewhere. Nothing was changed here, and the ledger has just been re-read.",
+  "problem.entryGone": "This event is no longer in the ledger: it was deleted elsewhere, and nothing was changed here.",
   "problem.badRequest": "The app refused the request this page made.",
   "problem.conflict": "Refused: that name already exists, or something still depends on it.",
   "problem.unreplayableLedger": "Refused, and nothing changed: the ledger would end up selling shares it does not hold.",

--- a/src/web/src/i18n/en.json
+++ b/src/web/src/i18n/en.json
@@ -570,6 +570,7 @@
 
   "problem.storageUnavailable": "Your data cannot be read right now. The app is running, but its store is not answering.",
   "problem.notFound": "The app answered that this does not exist.",
+  "problem.entryGone": "This event is no longer in the ledger: it was deleted elsewhere. Nothing was changed here, and the ledger has just been re-read.",
   "problem.badRequest": "The app refused the request this page made.",
   "problem.conflict": "Refused: that name already exists, or something still depends on it.",
   "problem.unreplayableLedger": "Refused, and nothing changed: the ledger would end up selling shares it does not hold.",

--- a/src/web/src/i18n/fr.json
+++ b/src/web/src/i18n/fr.json
@@ -570,7 +570,7 @@
 
   "problem.storageUnavailable": "Vos données sont illisibles pour l’instant. L’application tourne, mais son magasin ne répond pas.",
   "problem.notFound": "L’application répond que cela n’existe pas.",
-  "problem.entryGone": "Cet événement n’est plus dans le grand livre : il a été supprimé ailleurs. Rien n’a été modifié ici, et le grand livre vient d’être relu.",
+  "problem.entryGone": "Cet événement n’est plus dans le grand livre : il a été supprimé ailleurs, et rien n’a été modifié ici.",
   "problem.badRequest": "L’application a refusé la requête faite par cette page.",
   "problem.conflict": "Refusé : ce nom existe déjà, ou quelque chose en dépend encore.",
   "problem.unreplayableLedger": "Refusé, rien n’a changé : le grand livre vendrait des titres qu’il ne porte pas.",

--- a/src/web/src/i18n/fr.json
+++ b/src/web/src/i18n/fr.json
@@ -570,6 +570,7 @@
 
   "problem.storageUnavailable": "Vos données sont illisibles pour l’instant. L’application tourne, mais son magasin ne répond pas.",
   "problem.notFound": "L’application répond que cela n’existe pas.",
+  "problem.entryGone": "Cet événement n’est plus dans le grand livre : il a été supprimé ailleurs. Rien n’a été modifié ici, et le grand livre vient d’être relu.",
   "problem.badRequest": "L’application a refusé la requête faite par cette page.",
   "problem.conflict": "Refusé : ce nom existe déjà, ou quelque chose en dépend encore.",
   "problem.unreplayableLedger": "Refusé, rien n’a changé : le grand livre vendrait des titres qu’il ne porte pas.",

--- a/src/web/src/lib/api.ts
+++ b/src/web/src/lib/api.ts
@@ -1097,9 +1097,14 @@ export interface HealthState {
 //    address is a **primary key**, which is the whole of what killed #662's
 //    apparatus: the opaque token over `(file, sheet, row)`, the content
 //    fingerprint as an `ETag` and its `409` existed because the *file* was the
-//    address and a file address goes stale between the read and the write.
-//    Absent, the editor is not offered on that row — a shape today's server
-//    never sends, and one the type has to allow all the same.
+//    address, and a file was re-read. A key is not safe because keys cannot go
+//    stale — this one went stale for a whole release, `max(id) + 1` handing a
+//    deleted row's key to the next writer. It is safe because the server's
+//    allocator only climbs (ADR-0027, #785), for the life of its process, and
+//    refuses a write aimed at a row that has gone instead of landing it on the
+//    row that took the key. Absent, the editor is not offered on that row — a
+//    shape today's server never sends, and one the type has to allow all the
+//    same.
 //
 // **And the provenance is gone** (#816, ADR-0032): the three columns and the
 // sentence composed from them described a row a *mounted* file had provisioned,

--- a/src/web/src/lib/problem.ts
+++ b/src/web/src/lib/problem.ts
@@ -19,6 +19,18 @@ import type { MessageKey, MessageValues } from '@/lib/i18n'
 export const PROBLEM_TYPES = {
   storageUnavailable: '/problems/storage-unavailable',
   notFound: '/problems/not-found',
+  /**
+   * **The event was there and is not any more** (#785, ADR-0027).
+   *
+   * Its own identifier rather than `notFound`'s, and the server is what tells
+   * the two apart: a key it issued is not handed to another row for the life of
+   * its process, so a write that misses names a row that *left*. Inferring that
+   * here from a `404` would be branching on what a status happens to mean at
+   * two routes, which is the thing this module exists not to do — and it would
+   * say *deleted elsewhere* about an account, an advisory, or a create that
+   * never had a row to miss.
+   */
+  entryGone: '/problems/entry-gone',
   badRequest: '/problems/bad-request',
   /**
    * The request is well formed and the **store's state** refuses it (#698): an
@@ -58,6 +70,7 @@ export const PROBLEM_TYPES = {
 const MESSAGES: Record<string, MessageKey> = {
   [PROBLEM_TYPES.storageUnavailable]: 'problem.storageUnavailable',
   [PROBLEM_TYPES.notFound]: 'problem.notFound',
+  [PROBLEM_TYPES.entryGone]: 'problem.entryGone',
   [PROBLEM_TYPES.badRequest]: 'problem.badRequest',
   [PROBLEM_TYPES.conflict]: 'problem.conflict',
   // The sentence with **no** values in it — what is left to say when the
@@ -155,34 +168,14 @@ export function problemMessage(error: unknown): {
 }
 
 /**
- * **A write aimed at a row that has gone** (#785, ADR-0027).
+ * The row this gesture addressed has left the ledger (#785).
  *
- * The two gestures that address an event by its key — the delete box and the
- * correction — are the only callers that can meet a `notFound` at all: the key
- * they send came off a row the server itself served. So the `404` says one
- * thing here and it is not *this does not exist*, which is the generic
- * sentence and reads as the app contradicting what the reader is looking at.
- * It says the row left the ledger somewhere else — another tab, another
- * session — while this page held a list 30 s old.
- *
- * The server's allocator is what makes that reading safe: a key it retired is
- * not handed to the next writer for the life of its process, so a `404` is a
- * row that is *gone* rather than a row that has been replaced.
+ * The sentence needs nothing but the table — the type is in it — so what this
+ * answers is the *other* question the two gestures ask: whether to re-read the
+ * ledger under the reader, the list they are looking at being the stale thing.
  */
 export function entryGone(error: unknown): boolean {
-  return error instanceof ApiProblem && error.type === PROBLEM_TYPES.notFound
-}
-
-/**
- * {@link problemSentence} for those same two gestures: the *gone* sentence when
- * the row left, and the table's otherwise. Written once, because the branch is
- * the same one in both surfaces and a second copy would drift.
- */
-export function entrySentence(
-  t: (key: MessageKey, values?: MessageValues) => string,
-  error: unknown,
-): string {
-  return entryGone(error) ? t('problem.entryGone') : problemSentence(t, error)
+  return error instanceof ApiProblem && error.type === PROBLEM_TYPES.entryGone
 }
 
 /**

--- a/src/web/src/lib/problem.ts
+++ b/src/web/src/lib/problem.ts
@@ -155,6 +155,37 @@ export function problemMessage(error: unknown): {
 }
 
 /**
+ * **A write aimed at a row that has gone** (#785, ADR-0027).
+ *
+ * The two gestures that address an event by its key — the delete box and the
+ * correction — are the only callers that can meet a `notFound` at all: the key
+ * they send came off a row the server itself served. So the `404` says one
+ * thing here and it is not *this does not exist*, which is the generic
+ * sentence and reads as the app contradicting what the reader is looking at.
+ * It says the row left the ledger somewhere else — another tab, another
+ * session — while this page held a list 30 s old.
+ *
+ * The server's allocator is what makes that reading safe: a key it retired is
+ * not handed to the next writer for the life of its process, so a `404` is a
+ * row that is *gone* rather than a row that has been replaced.
+ */
+export function entryGone(error: unknown): boolean {
+  return error instanceof ApiProblem && error.type === PROBLEM_TYPES.notFound
+}
+
+/**
+ * {@link problemSentence} for those same two gestures: the *gone* sentence when
+ * the row left, and the table's otherwise. Written once, because the branch is
+ * the same one in both surfaces and a second copy would drift.
+ */
+export function entrySentence(
+  t: (key: MessageKey, values?: MessageValues) => string,
+  error: unknown,
+): string {
+  return entryGone(error) ? t('problem.entryGone') : problemSentence(t, error)
+}
+
+/**
  * {@link problemMessage} rendered, for the callers that hold a `t` and want a
  * string. One line, and written once: a component doing the two steps itself is
  * a component that can forget to pass the values, and the sentence would then

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,8 +171,12 @@ def declare_ledger():
             opened.execute(
                 'INSERT INTO symbol (symbol) VALUES (?) '
                 'ON CONFLICT (symbol) DO NOTHING', [symbol])
-        (next_id,) = opened.query(
-            'SELECT coalesce(max(id), 0) + 1 FROM event')[0]
+        if not events:
+            return
+        # Through the store's own allocator, never beside it: a fixture that
+        # numbers its own rows writes keys `Store.reserve` does not know it
+        # gave away, and the next `entries.create` lands on a key that is taken.
+        next_id = opened.reserve('event', len(events))
         for offset, event in enumerate(events):
             opened.execute(
                 'INSERT INTO event (id, date, event_type, account, symbol, '

--- a/tests/test_entries.py
+++ b/tests/test_entries.py
@@ -18,6 +18,7 @@ import pytest
 from application import accounts as accounts_module
 from application import entries
 from application import ledger
+from application import store as store_module
 from application.events.loader import EventLoader
 from application.events import export as events_export
 from application.events.aggregator import AggregationError
@@ -506,3 +507,57 @@ def test_the_duplicate_key_is_declared_in_no_constraint_of_the_store(store):
     assert enforced == [('PRIMARY KEY', ['id'])]
     keyed = {column for _, columns in enforced for column in columns}
     assert keyed.isdisjoint(entries.DUPLICATE_KEY_COLUMNS)
+
+
+# --------------------------------------------------------------------------- #
+# A key names a row for as long as the row lives (ADR-0027, #785)
+# --------------------------------------------------------------------------- #
+
+def test_a_deleted_key_is_not_reissued_to_the_next_row(store):
+    """The defect, at the unit: the highest row's key freed nothing.
+
+    Three rows, the last removed, a fourth typed — and it takes 4. Under
+    ``max(id) + 1`` it took 3, so an open tab whose *delete* still named row 3
+    deleted an event it had never displayed.
+    """
+    keys = [entries.create(store, _draft(notes=str(day))).id
+            for day in (1, 2, 3)]
+    assert keys == [1, 2, 3]
+
+    entries.remove(store, keys[-1])
+
+    assert entries.create(store, _draft(notes='after')).id == 4
+
+
+def test_a_deleted_key_is_not_reissued_to_the_next_file(store, tmp_path):
+    """The same, through the gesture that takes a **range** of keys.
+
+    ``create_many`` allocated its range the same way, so a file landing after a
+    removal re-used the released key and every row of the file shifted onto
+    keys the reader had just seen. The range starts past the high-water mark
+    instead.
+    """
+    _upload(store, tmp_path, body=ONE_BUY + TWO_MORE)
+    assert [event.id for event in ledger.read_events(store)] == [1, 2, 3]
+
+    entries.remove(store, 3)
+    entries.remove(store, 2)
+
+    landed = _upload(store, tmp_path, body=ONE_BUY.replace('AAPL', 'MSFT'),
+                     name='again.csv')
+    assert [event.id for event in landed] == [4]
+
+
+def test_the_mark_is_the_process_and_a_reopen_re_seeds_it(store):
+    """The bound ADR-0027 accepted, asserted rather than left to be assumed.
+
+    The mark is memory: a second :class:`Store` over the same file starts from
+    ``max(id)``, and the key the first one retired is issued again. That is the
+    window a client loses by holding a key across a restart — which is holding
+    it across an app that went down.
+    """
+    entries.create(store, _draft())
+    entries.remove(store, 1)
+    assert store.reserve('event') == 2
+
+    assert store_module.open_store(store.path).reserve('event') == 1

--- a/tests/test_entries.py
+++ b/tests/test_entries.py
@@ -517,7 +517,7 @@ def test_a_deleted_key_is_not_reissued_to_the_next_row(store):
     """The defect, at the unit: the highest row's key freed nothing.
 
     Three rows, the last removed, a fourth typed — and it takes 4. Under
-    ``max(id) + 1`` it took 3, so an open tab whose *delete* still named row 3
+    the retired allocator it took 3, so an open tab whose *delete* named row 3
     deleted an event it had never displayed.
     """
     keys = [entries.create(store, _draft(notes=str(day))).id
@@ -552,12 +552,37 @@ def test_the_mark_is_the_process_and_a_reopen_re_seeds_it(store):
     """The bound ADR-0027 accepted, asserted rather than left to be assumed.
 
     The mark is memory: a second :class:`Store` over the same file starts from
-    ``max(id)``, and the key the first one retired is issued again. That is the
-    window a client loses by holding a key across a restart — which is holding
-    it across an app that went down.
+    the highest key the table still holds, and the one the first store retired
+    is issued again. That is the window a client loses by holding a key across
+    a restart — which is holding it across an app that went down.
     """
     entries.create(store, _draft())
     entries.remove(store, 1)
-    assert store.reserve('event') == 2
+    store.close()
 
-    assert store_module.open_store(store.path).reserve('event') == 1
+    reopened = store_module.open_store(store.path)
+    try:
+        assert entries.create(reopened, _draft()).id == 1
+    finally:
+        reopened.close()
+
+
+def test_a_row_deleted_before_this_store_has_written_keeps_its_key(store):
+    """**The window a mark read on first use would not have held.**
+
+    A store is opened on a ledger somebody else filled, and the first gesture of
+    its life is a removal. Read lazily, the mark would be taken *after* that
+    removal — below the key it just freed — and the very next row would take it
+    back, inside the process the guarantee is scoped to. So the mark is read at
+    the open, and this is the case that says so.
+    """
+    for day in (1, 2, 3):
+        entries.create(store, _draft(notes=str(day)))
+    store.close()
+
+    reopened = store_module.open_store(store.path)
+    try:
+        entries.remove(reopened, 3)
+        assert entries.create(reopened, _draft(notes='after')).id == 4
+    finally:
+        reopened.close()

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -2526,9 +2526,16 @@ def test_a_row_that_left_the_ledger_has_its_own_type(tmp_path):
         assert response.status_code == 404
         assert response.get_json()['type'] == '/problems/entry-gone'
 
-    # An address that never named a row keeps the generic one: a client reading
-    # *deleted elsewhere* there would be told about a row that never existed.
+    # An address that never named a row keeps the generic one — whether it is
+    # unreadable or simply past the mark. A client reading *deleted elsewhere*
+    # there would be told about a row that never existed.
     assert client.delete('/api/events/nope').get_json()['type'] == \
+        '/problems/not-found'
+    assert client.delete('/api/events/9999').get_json()['type'] == \
+        '/problems/not-found'
+    assert client.patch('/api/events/9999',
+                        json={'date': '2024-01-15', 'event_type': 'DEPOSIT',
+                              'amount': 10}).get_json()['type'] == \
         '/problems/not-found'
 
 

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -2506,6 +2506,32 @@ def test_an_unaddressable_event_is_a_named_404(tmp_path):
     assert 'nope' in unaddressable.get_json()['detail']
 
 
+def test_a_row_that_left_the_ledger_has_its_own_type(tmp_path):
+    """*It was there* and *it never was* are opposite news (#785, ADR-0027).
+
+    The server is the only side that can tell them apart — a key it issued is
+    not handed to another row for the life of its process — so it says which
+    one on the wire rather than leaving a client to read it off a status. Both
+    gestures that address a row by its key answer with it.
+    """
+    client, opened = build_client_and_store(tmp_path, events=_ONE_BUY)
+    (key,) = opened.query('SELECT id FROM event')[0]
+    assert client.delete(f'/api/events/{key}').status_code == 200
+
+    for response in (client.delete(f'/api/events/{key}'),
+                     client.patch(f'/api/events/{key}',
+                                  json={'date': '2024-01-15',
+                                        'event_type': 'DEPOSIT',
+                                        'amount': 10})):
+        assert response.status_code == 404
+        assert response.get_json()['type'] == '/problems/entry-gone'
+
+    # An address that never named a row keeps the generic one: a client reading
+    # *deleted elsewhere* there would be told about a row that never existed.
+    assert client.delete('/api/events/nope').get_json()['type'] == \
+        '/problems/not-found'
+
+
 def test_a_removal_that_would_leave_an_oversell_is_refused(tmp_path):
     """Overselling is a property of the **ledger**, never of a row.
 


### PR DESCRIPTION
`event.id` was allocated by `SELECT coalesce(max(id), 0) + 1 FROM event`, an
expression copied to the two write sites of `entries.py`, so deleting the
highest row freed its key for the next writer. Reachable from the interface
since #834: with a 30 s `staleTime` and no refetch on focus, a tab holding the
ledger it read could delete — or correct — **the row that took the key** of the
one it was displaying.

Closes #785 · Decision: [ADR-0027](docs/adr/0027-a-key-names-a-row-for-as-long-as-the-row-lives.md)

## What changed

**One allocator, `Store.reserve(table, count=1)`.** The mark is read from the
table's highest key **at the open** — not on first use, which would let a row
deleted before this store had written anything re-seed the mark below the key
it had just freed — and it never descends. It takes the store's own reentrant
lock, so its callers pay nothing. The two sites of `entries.py` call it, and
`.github/scripts/conventions.sh` refuses a second one on the source, `tests/`
included.

**A row that has gone says so on the wire.** `UnknownEntry` now answers
`/problems/entry-gone` rather than the generic `/problems/not-found`: the
server is the only side that can tell *it was there* from *it never was*, since
a key it issued is not handed to another row for the life of its process. The
front branches on that `type` — as ADR-0024 asks and as `problem.ts` states in
its own header — so the delete box and the correction render *this event is no
longer in the ledger: it was deleted elsewhere* and re-read the ledger, while
an unknown account, an advisory or a create keep the generic sentence.

**The prose that rested on the opposite is rewritten, not deleted.** `Event`'s
docstring and `lib/api.ts` said a key does not go stale between the read and
the write; they now say it holds **because the allocator retains it**, with the
bound ADR-0027 accepts — the life of the process — and that is why #662's
opaque token has no successor here.

## Scope

The guarantee is scoped to the process: a restart re-seeds and can reissue a
key freed before it, which ADR-0027 accepts and a test pins. Persisting the
mark and returning an opaque token are both out of scope by the ticket.

`reserve` keeps its `table` parameter — `KEYED_TABLES` is what says `event` is
the only one today — and `count` keeps its user, the batch write taking a range
at once.

## Verification

- `pytest tests/` — 1590 passed
- `pnpm test` — 792 passed · `pnpm lint` (`tsc -b --noEmit`) clean
- `flake8 src/application src/api --ignore=E501` clean
- `.github/scripts/conventions.sh` exit 0

Two commits: the change, then the fixes an adversarial review found in it —
the lazy seed above, a second allocator surviving in `conftest.declare_ledger`,
a refusal outliving its panel in `EventForm`, and a client-side inference of
the `404` that this PR replaces with the server-side type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Event identifiers are now allocated consistently and remain monotonic, preventing reuse during a store session.
  - API responses distinguish events deleted elsewhere from events that never existed.
  - Editing and deleting stale rows now refreshes the event list and displays a clear localized message.

- **Bug Fixes**
  - Cleared stale error messages when reopening the event editor.
  - Preserved edit-panel contents during concurrent deletion conflicts.

- **Documentation**
  - Clarified event identifier behavior and allocation guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->