### PR TITLE
fix(backfill): a failed write does not move the anchor (#853)

### DIFF
--- a/src/application/backfill.py
+++ b/src/application/backfill.py
@@ -101,7 +101,14 @@ class BackfillWorkload:
         return written, repaired
 
     def fetch_and_store(self, symbol, start_date, end_date):
-        """Fetch one ``[start, end]`` chunk and, if non-empty, write it."""
+        """Fetch one ``[start, end]`` chunk and, if non-empty, write it.
+
+        Four outcomes, and the caller can tell them apart (issue #853):
+        ``(None, 0)`` the fetch failed; ``([], 0)`` the window is empty;
+        ``(prices, n)`` fetched and ``n`` points written; ``(prices, None)``
+        fetched, but the **write failed** — nothing of the window reached the
+        store, so the window has not been tried and its anchor must not move.
+        """
         prices = self.facade._fetch_historical_data(symbol, start_date, end_date)
         if prices is None:
             return None, 0
@@ -116,6 +123,7 @@ class BackfillWorkload:
             with self.facade.config_manager.writing() as opened:
                 written = quotes.record_history(opened, symbol, prices)
         except Exception as e:
+            written = None
             app_logger.error(
                 f"Failed to write historical prices for {symbol}: {e}")
         time.sleep(self.facade.backfill_delay)
@@ -201,6 +209,16 @@ class BackfillWorkload:
                           f"{start_date.date()} → {end_date.date()}")
             return 0
 
+        if written is None:
+            app_logger.warning(
+                f"Failed to store the history of {symbol}, will retry next cycle")
+            publish(anchor=end_date, oldest=oldest_timestamp,
+                    window=(start_date, end_date), failed=True,
+                    error=f"the history of {symbol} over "
+                          f"{start_date.date()} → {end_date.date()} was fetched "
+                          f"but could not be written to the store")
+            return 0
+
         self.facade._record_window_tried(symbol, start_date.date())
 
         if not prices:
@@ -268,6 +286,16 @@ class BackfillWorkload:
             publish(window=(start_date, end_date), failed=True,
                     error=f"yfinance returned no history for {symbol} over "
                           f"{start_date.date()} → {end_date.date()}")
+            return 0
+
+        if written is None:
+            app_logger.warning(
+                f"Failed to store the forward history of {symbol}, will retry "
+                f"next cycle")
+            publish(window=(start_date, end_date), failed=True,
+                    error=f"the history of {symbol} over "
+                          f"{start_date.date()} → {end_date.date()} was fetched "
+                          f"but could not be written to the store")
             return 0
 
         if not prices:

--- a/src/application/backfill.py
+++ b/src/application/backfill.py
@@ -210,8 +210,6 @@ class BackfillWorkload:
             return 0
 
         if written is None:
-            app_logger.warning(
-                f"Failed to store the history of {symbol}, will retry next cycle")
             publish(anchor=end_date, oldest=oldest_timestamp,
                     window=(start_date, end_date), failed=True,
                     error=f"the history of {symbol} over "
@@ -289,9 +287,6 @@ class BackfillWorkload:
             return 0
 
         if written is None:
-            app_logger.warning(
-                f"Failed to store the forward history of {symbol}, will retry "
-                f"next cycle")
             publish(window=(start_date, end_date), failed=True,
                     error=f"the history of {symbol} over "
                           f"{start_date.date()} → {end_date.date()} was fetched "

--- a/tests/test_runtime_wiring.py
+++ b/tests/test_runtime_wiring.py
@@ -408,7 +408,6 @@ def test_a_failed_write_leaves_the_anchor_where_it_was_and_is_recorded(
     assert quotes.oldest_window_tried(store, "AAPL") is None
     record = m.recorder.backfill_of("AAPL", runtime_state.BACKWARD)
     assert record.failed is True
-    assert record.written == 0
     assert "could not be written" in record.error
 
 

--- a/tests/test_runtime_wiring.py
+++ b/tests/test_runtime_wiring.py
@@ -383,6 +383,35 @@ def test_an_empty_window_is_recorded_without_raising_the_counter(
     assert record.terminal is None
 
 
+def test_a_failed_write_leaves_the_anchor_where_it_was_and_is_recorded(
+        store, mocker):
+    """Issue #853: the window was fetched, not written, so it was not tried.
+
+    ``fetch_and_store`` used to return ``(prices, 0)`` on a refused write —
+    the shape of an empty but successful chunk. The backward pass moved its
+    anchor past a year it never stored, ``backward_anchor`` never goes back,
+    and the hole is permanent for the life of the store. The anchor now stays
+    put, and the pass says it failed.
+    """
+    events = [Event(datetime(2020, 1, 15).date(), EventType.BUY, "AAPL",
+                    "Apple", quantity=10, unit_price=150.0)]
+    m = _metrics([_share()], store, mocker, events=events)
+    quotes.record_history(store, "AAPL", [
+        {"timestamp": datetime(2024, 1, 10, tzinfo=UTC), "price": 100.0}])
+    mocker.patch.object(m, "_fetch_historical_data", return_value=[
+        {"timestamp": datetime(2023, 6, 1, tzinfo=UTC), "price": 90.0}])
+    mocker.patch.object(quotes, "record_history",
+                        side_effect=RuntimeError("connection refused"))
+
+    m.backfill()
+
+    assert quotes.oldest_window_tried(store, "AAPL") is None
+    record = m.recorder.backfill_of("AAPL", runtime_state.BACKWARD)
+    assert record.failed is True
+    assert record.written == 0
+    assert "could not be written" in record.error
+
+
 def test_the_forward_pass_tells_an_unseeded_series_from_the_live_no_op(
         store, mocker):
     """Two no-ops meaning opposite things.

--- a/tests/test_runtime_wiring.py
+++ b/tests/test_runtime_wiring.py
@@ -406,9 +406,11 @@ def test_a_failed_write_leaves_the_anchor_where_it_was_and_is_recorded(
     m.backfill()
 
     assert quotes.oldest_window_tried(store, "AAPL") is None
-    record = m.recorder.backfill_of("AAPL", runtime_state.BACKWARD)
-    assert record.failed is True
-    assert "could not be written" in record.error
+    # Both passes read the same return value, so both are held here.
+    for direction in (runtime_state.BACKWARD, runtime_state.FORWARD):
+        record = m.recorder.backfill_of("AAPL", direction)
+        assert record.failed is True
+        assert "could not be written" in record.error
 
 
 def test_the_forward_pass_tells_an_unseeded_series_from_the_live_no_op(


### PR DESCRIPTION
Closes #853.

## What was wrong

`fetch_and_store` returned `(prices, 0)` when the store refused the write — the exact shape of an **empty but successful** chunk. The backward pass read it as "the window was tried", persisted its anchor past a year it had never stored, and `carrying.backward_anchor` never goes back: the hole was permanent for the life of the store, not of the process. It was reported healthy on top of that — `written=0` with no `failed=True`, so `/api/runtime` showed a pass that went fine and had nothing to write.

## What changed

- The write failure has its own shape in the return value, `written = None`, stated in the docstring beside the three others: `(None, 0)` fetch failed, `([], 0)` empty window, `(prices, n)` written, `(prices, None)` **write failed**.
- The backward pass guards on it **before** `record_window_tried`, so the anchor stays where it was.
- Both passes publish `failed=True` with the error the log alone used to carry.

The forward pass gets the same repair; its own missing-anchor defect is a separate ticket.

## How it is held

A test in `tests/test_runtime_wiring.py` makes `quotes.record_history` raise, then reads **the contents of the store** — `symbol_quote.oldest_window_tried` still `None` — and the `BackfillRecord`, which carries `failed=True`. Verified red without the fix.

`uv run flake8 src/application src/api --ignore=E501` clean, `uv run pytest tests/` 1591 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PpRztkcSVharzTk1fRTct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backfill operations now clearly report when fetched history could not be saved.
  * Failed writes no longer advance the backfill anchor, preventing unsaved time windows from being skipped.
  * Failed backfill records now include an appropriate error status and message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->