### PR TITLE
chore: version CodeRabbit's configuration instead of holding it in the UI

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,42 @@
+# CodeRabbit — https://docs.coderabbit.ai/reference/configuration
+#
+# This file is the source of truth. `inheritance` is false, so a key absent
+# here falls back to CodeRabbit's own default and **not** to the value set in
+# the repository UI. Every key below is therefore one that differs from a
+# default: naming the defaults again would only make this file rot.
+
+reviews:
+  # Lets CodeRabbit submit a formal CHANGES_REQUESTED — and, the half that
+  # actually matters, lets `@coderabbitai approve` clear its own refusal once
+  # the findings are addressed. Without it a PR whose comments are all settled
+  # stays blocked on a stale review that nothing but a human dismissal lifts.
+  request_changes_workflow: true
+
+  # The walkthrough is the first thing worth reading on a PR. Leave it open.
+  collapse_walkthrough: false
+
+  auto_review:
+    labels:
+      - fix
+      - feat
+
+  tools:
+    # The app lints with `flake8 --ignore=E501` and the repo carries no flake8
+    # nor pylint configuration file, so both would run on their defaults and
+    # flag a line length the project has explicitly refused. The `Lint` check
+    # is the authority on this tree; these two could only contradict it.
+    flake8:
+      enabled: false
+    pylint:
+      enabled: false
+
+knowledge_base:
+  code_guidelines:
+    # The architecture is written in the nested CLAUDE.md files, the glossary
+    # and the ADRs. CodeRabbit already reaches for them — it cited "Source:
+    # Coding guidelines" on #909 — and naming them makes that deliberate.
+    filePatterns:
+      - CLAUDE.md
+      - '**/CLAUDE.md'
+      - CONTEXT.md
+      - docs/adr/*.md


### PR DESCRIPTION
The CodeRabbit settings lived in the repository UI, where nothing reviews them, nothing explains them, and nothing tells you what changed. This moves them into `.coderabbit.yaml`.

## What is in the file, and why only that

`inheritance` is `false`, so **a key absent from this file falls back to CodeRabbit's own default, not to the UI value**. I dumped the effective configuration (`@coderabbitai configuration` on #909) and compared all 438 lines against the [published schema](https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json): exactly three settings differ from a default. Those three are named here; repeating the defaults would only make the file rot.

| Setting | Default | Here | Why |
|---|---|---|---|
| `reviews.request_changes_workflow` | `false` | `true` | The expensive one. It is what lets `@coderabbitai approve` clear CodeRabbit's own `CHANGES_REQUESTED` once the findings are settled — #909 sat blocked on a stale refusal until that command ran. Dropping it would have silently broken that path. |
| `reviews.collapse_walkthrough` | `true` | `false` | The walkthrough is the first thing worth reading on a PR. |
| `reviews.auto_review.labels` | `[]` | `fix`, `feat` | Preserved as-is from the UI. |

## Two additions

- **flake8 and pylint off.** The app lints with `flake8 --ignore=E501` and the repo carries no configuration file for either tool, so both would run on their defaults and flag a line length the project has explicitly refused. The `Lint` check is the authority on this tree; these two could only contradict it. Reverting is one line each if they turn out to earn their place.
- **The coding guidelines are named.** `CLAUDE.md` and its nested copies, `CONTEXT.md` and `docs/adr/*.md`. CodeRabbit already reaches for them — it cited *"Source: Coding guidelines"* when reviewing #909 — so this makes deliberate what was incidental.

## Checked

The YAML parses, and every key above was verified to exist in the published schema with the default value stated in the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PpRztkcSVharzTk1fRTct