### PR TITLE
fix(web): the same dash is the same grey (#860)

### DIFF
--- a/src/web/src/components/dashboard/Head.tsx
+++ b/src/web/src/components/dashboard/Head.tsx
@@ -83,9 +83,9 @@ import {
   portfolioTerms,
   sumRendering,
   termAmount,
-  termCarriesSign,
   termIsRendered,
   termRendering,
+  termTone,
   type GainTermName,
 } from '@/lib/gain'
 import { dayMove } from '@/lib/dashboard'
@@ -327,17 +327,10 @@ export function DashboardHead({
                     () => f.currency(value, currency),
                     t,
                   )}
-                  // Colour only where the sign can turn. A dividend received is
-                  // never negative and a transfer fee never positive; painting them
-                  // steals the signal from the red of a realised loss. An absent
-                  // value keeps the grey of absence whatever the term.
-                  valueClassName={
-                    value === null
-                      ? signClass(null)
-                      : termCarriesSign(term)
-                        ? signClass(value)
-                        : signClass(0)
-                  }
+                  // Colour only where the sign can turn, and absence wherever
+                  // the *rendering* says absence — both decided in `gain.ts`,
+                  // once for the four surfaces (#860).
+                  valueClassName={termTone(terms, term)}
                 />
               )
             })}

--- a/src/web/src/components/shares/ShareSheet.tsx
+++ b/src/web/src/components/shares/ShareSheet.tsx
@@ -65,8 +65,8 @@ import {
   securityTerms,
   sumRendering,
   termAmount,
-  termCarriesSign,
   termRendering,
+  termTone,
   type GainTermName,
 } from '@/lib/gain'
 import { useI18n, type MessageKey } from '@/lib/i18n'
@@ -79,7 +79,7 @@ import {
   unrealised,
   type ShareRow,
 } from '@/lib/shares'
-import { signClass } from '@/lib/sign'
+import { signClass, toneOf } from '@/lib/sign'
 import { cn } from '@/lib/utils'
 
 /** Three terms and not four: no security carries the fees taken from a transfer. */
@@ -253,11 +253,7 @@ export function ShareSheet({ row, positions, failures, currency, onClose }: Shar
                     <span
                       className={cn(
                         'tabular font-mono text-md font-semibold',
-                        amount === null
-                          ? signClass(null)
-                          : termCarriesSign(term as GainTermName)
-                            ? signClass(amount)
-                            : signClass(0),
+                        termTone(terms, term as GainTermName),
                       )}
                     >
                       {renderFigure(
@@ -389,9 +385,7 @@ export function ShareSheet({ row, positions, failures, currency, onClose }: Shar
                         </TableCell>
                         <TableCell
                           className={`text-right tabular ${
-                            lineRenderings.unrealised.kind === 'figure'
-                              ? signClass(lineGain)
-                              : signClass(null)
+                            toneOf(lineRenderings.unrealised, lineGain)
                           }`}
                         >
                           {renderFigure(

--- a/src/web/src/components/shares/SharesHead.tsx
+++ b/src/web/src/components/shares/SharesHead.tsx
@@ -43,12 +43,11 @@ import {
   securityTerms,
   sumRendering,
   termAmount,
-  termCarriesSign,
   termRendering,
+  termTone,
   type GainTermName,
 } from '@/lib/gain'
 import { useI18n, type MessageKey } from '@/lib/i18n'
-import { signClass } from '@/lib/sign'
 import { cn } from '@/lib/utils'
 
 /**
@@ -105,13 +104,7 @@ export function SharesHead({ positions, rows, currency }: SharesHeadProps) {
                 () => f.currency(value, currency),
                 t,
               )}
-              tone={
-                value === null
-                  ? signClass(null)
-                  : termCarriesSign(term as GainTermName)
-                    ? signClass(value)
-                    : signClass(0)
-              }
+              tone={termTone(terms, term as GainTermName)}
             />
           )
         })}

--- a/src/web/src/components/shares/SharesTable.tsx
+++ b/src/web/src/components/shares/SharesTable.tsx
@@ -64,7 +64,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { positionRenderings, renderFigure, type Rendering } from '@/lib/absence'
+import { positionRenderings, renderFigure } from '@/lib/absence'
 import type { DocsAnchor } from '@/lib/docs'
 import { ABSENT, useFormatters } from '@/lib/format'
 import { sumRendering } from '@/lib/gain'
@@ -81,13 +81,8 @@ import {
   type ShareSort,
   type SortColumn,
 } from '@/lib/shares'
-import { signClass } from '@/lib/sign'
+import { signClass, toneOf } from '@/lib/sign'
 import { cn } from '@/lib/utils'
-
-/** The colour of a cell whose content is not a number at all. */
-function toneOf(rendering: Rendering, value: number | null): string {
-  return rendering.kind === 'figure' ? signClass(value) : signClass(null)
-}
 
 /**
  * The four column headers that rest on a convention — and only four. `Cours`

--- a/src/web/src/lib/gain.test.ts
+++ b/src/web/src/lib/gain.test.ts
@@ -19,8 +19,10 @@ import {
   termCarriesSign,
   termIsRendered,
   termRendering,
+  termTone,
   type Sum,
 } from '@/lib/gain'
+import { signClass } from '@/lib/sign'
 import { aPosition, defaultPositions } from '@/test/factories'
 
 /** A known sum, spelled once so the arithmetic below stays readable. */
@@ -244,5 +246,12 @@ describe('what the terms are allowed to do on screen', () => {
     expect(termRendering(sold, 'unrealised')).toBe(DASH)
     expect(termRendering(sold, 'realised')).toBe(FIGURE)
     expect((gainTotal(sold) as { value: number }).value).toBeCloseTo(80, 2)
+
+    // And the tone follows the **rendering** and not the amount (#860). The
+    // amount here is a known `0` — the state the two predicates diverged on —
+    // so a caller asking `amount === null ?` painted this dash in the colour of
+    // a figure, above rows painting theirs in the grey of absence.
+    expect(termAmount(sold, 'unrealised')).toBe(0)
+    expect(termTone(sold, 'unrealised')).toBe(signClass(null))
   })
 })

--- a/src/web/src/lib/gain.ts
+++ b/src/web/src/lib/gain.ts
@@ -24,6 +24,7 @@
  */
 import { AWAITING_RATE, DASH, FIGURE, REBUILDING, absenceCase, type Rendering } from '@/lib/absence'
 import type { Position } from '@/lib/api'
+import { toneOf } from '@/lib/sign'
 
 export const GAIN_TERMS = ['unrealised', 'realised', 'dividends', 'transferFees'] as const
 
@@ -278,4 +279,13 @@ export function termRendering(terms: GainTerms, term: GainTermName): Rendering {
 export function termAmount(terms: GainTerms, term: GainTermName): number | null {
   if (term !== 'unrealised') return terms[term]
   return terms.unrealised.known ? terms.unrealised.value : null
+}
+
+/**
+ * The tone of one term: the **rendering** decides, never the amount — a known
+ * `0` still renders a dash (#860). The rationing of colour rides here so it
+ * stops being copied at the three call sites.
+ */
+export function termTone(terms: GainTerms, term: GainTermName): string {
+  return toneOf(termRendering(terms, term), termCarriesSign(term) ? termAmount(terms, term) : 0)
 }

--- a/src/web/src/lib/sign.ts
+++ b/src/web/src/lib/sign.ts
@@ -19,6 +19,8 @@
  * colouring them is decoration that steals the signal from the two terms that
  * do carry it.
  */
+import type { Rendering } from '@/lib/absence'
+
 export type Sign = 'gain' | 'loss' | 'zero' | 'absent'
 
 export function signOf(value: number | null | undefined): Sign {
@@ -39,4 +41,9 @@ const CLASSES: Record<Sign, string> = {
 
 export function signClass(value: number | null | undefined): string {
   return CLASSES[signOf(value)]
+}
+
+/** The colour of a cell whose content is not a number at all — the one predicate (#860). */
+export function toneOf(rendering: Rendering, value: number | null): string {
+  return rendering.kind === 'figure' ? signClass(value) : signClass(null)
 }

--- a/src/web/src/shareSheet.test.tsx
+++ b/src/web/src/shareSheet.test.tsx
@@ -22,6 +22,7 @@ import { describe, expect, it } from 'vitest'
 import { ROUTES } from '@/lib/api'
 import { PROBLEM_TYPES } from '@/lib/problem'
 import {
+  aClosedPosition,
   aPosition,
   aPositionsPayload,
   fundamentalsOf,
@@ -161,6 +162,40 @@ describe('the per-account breakdown', () => {
     expect(rows[0]).toHaveTextContent(/alpha/)
     expect(rows[0]).toHaveTextContent(/220,00/)
     expect(rows[1]).toHaveTextContent(/330,00/)
+  })
+})
+
+describe('the same dash is the same grey (#860)', () => {
+  it('paints the tile and the rows of a sold-out share alike', async () => {
+    // The state the two predicates diverged on: every line of the share is
+    // closed, so `holdsPosition` is false while `unrealised` is a **known**
+    // zero. The tile branched on the amount — `0`, the ordinary text colour —
+    // and the rows on the rendering — the em dash, the grey of absence. One
+    // dash, one column, two greys.
+    const { user } = renderShares([
+      ...sharesPortfolio(),
+      aClosedPosition({ account: 'alpha', symbol: 'ZZF', name: 'Zeta Phi', realised: 70, closed_at: '2025-06-01' }),
+      aClosedPosition({ account: 'beta', symbol: 'ZZF', name: 'Zeta Phi', realised: 30, closed_at: '2025-07-01' }),
+    ])
+    await waitFor(() =>
+      expect(screen.getByRole('group', { name: 'Valorisation' })).toHaveTextContent(/2\D?300,00/),
+    )
+    // A sold-out share is reached through the fold, which is where it lives.
+    await user.click(screen.getByRole('button', { name: /position(s)? soldée(s)?/ }))
+    await user.click(screen.getByRole('button', { name: 'Zeta Phi' }))
+    const sheet = await screen.findByRole('dialog', { name: 'Zeta Phi' })
+
+    const tile = within(sheetHead(sheet)).getByRole('group', { name: 'Latente' })
+    const cells = within(within(sheet).getByRole('table', { name: 'Ce titre, compte par compte' }))
+      .getAllByRole('row')
+      .slice(1)
+      .map((row) => within(row).getAllByRole('cell')[4] as HTMLElement)
+
+    // Both read the em dash, and both wear the grey of absence — the class the
+    // rows already had, which is the one a dash takes.
+    const tones = [within(tile).getByText('—'), ...cells].map((node) => node.className)
+    for (const tone of tones) expect(tone).toContain('text-muted-foreground')
+    for (const cell of cells) expect(cell).toHaveTextContent('—')
   })
 })
 


### PR DESCRIPTION
Closes #860.

## The divergence

The unrealised term's tone was decided by two predicates that are not the same
one, and they diverge on a reachable state.

`positionTerms` sets `unrealised = {known: true, value: 0}` the moment every
position in scope has `quantity === 0`, and `holdsPosition` is then `false` — so
`termRendering` returns the em dash while `termAmount` returns `0`, not `null`.

The three heads branched on the **amount**: `signClass(0)` = `text-foreground`.
`SharesTable` branches on the **rendering**: `signClass(null)` =
`text-muted-foreground`. Same dash, same column, two greys — and `sign.ts`
exists precisely to say that in one place:

> there are **four** answers and not three: gain, loss, a zero that is a figure
> (the ordinary text colour), and an absence that is not (the muted one).

A dash is an absence. It was being painted in the colour of a figure.

## The repair

One predicate, and it is the rendering.

- `toneOf(rendering, value)` moves out of `SharesTable.tsx` into `lib/sign.ts`.
- `lib/gain.ts` grows `termTone(terms, term)`, which layers ADR-0018's rationing
  of colour on top of it — that rationing was copied three times too, which is
  three chances for one copy to answer differently.
- `Head.tsx`, `SharesHead.tsx` and `ShareSheet.tsx` call `termTone`;
  `ShareSheet.tsx`'s per-account rows held a fourth inline copy of `toneOf` and
  now call it.

Four copies of the predicate deleted, one function added: **+74 / −38**, and the
components lose more than they gain.

## The test

The sheet of a sold-out share is the one surface where the two dashes are on
screen together — the `Latente` tile above, the breakdown's cells below — so
that is where the acceptance criterion goes, in `shareSheet.test.tsx`. Putting
the old predicate back in `ShareSheet.tsx` alone fails it on
`text-foreground`.

`lib/gain.test.ts` pins the same state one floor down: `termAmount` is `0` where
`termTone` is the grey of absence.

## Acceptance criteria

- [x] A term's tone is decided in the same place on all four surfaces.
- [x] A test asserts the class on an entirely closed portfolio: the band's dash
      and the row's dash carry the same tone.
- [x] `pnpm lint` and `pnpm test` pass — 42 files, 793 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PpRztkcSVharzTk1fRTct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized color treatment for gain figures across dashboard and share views.
  - Ensured non-numeric or unavailable gain values use neutral styling instead of sign-based colors.
  - Corrected sold-out and closed-position displays so latent amounts shown as dashes consistently use the same muted grey in summary tiles and account breakdowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->