### PR TITLE
fix: the eleven findings of the preview/v5 review (#861)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -118,6 +118,12 @@ reached the start of the holding window, or the symbol can never be converted. A
 terminal backfill is what makes a missing price *permanent* rather than *not yet
 arrived*, and the two are never confused.
 
+**Holding window**:
+The days, first to last, on which an account's end-of-day position in a security
+carries a quantity. A buy and a full sale on one day leave no window: a day traded
+through is not a day held.
+_Avoid_: holding period, position span
+
 **Carrying price**:
 What a position is valued at on a day where no price exists and none ever will: its
 own unit cost basis. Deliberately invoked, never a silent fallback — it is a
@@ -139,8 +145,8 @@ _Avoid_: account metrics, portfolio metrics (as domain terms)
 
 **Horizon**:
 The earliest day an account's performance can honestly be stated — the day from
-which every security it held has a price. It recedes as the backfill advances, so
-the series fills in leftward; nothing is written before it.
+which every security it held has a price **or is carried at cost**. It recedes as
+the backfill advances, so the series fills in leftward; nothing is written before it.
 _Avoid_: cutoff, start date, window
 
 **Latent gain**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -119,9 +119,11 @@ terminal backfill is what makes a missing price *permanent* rather than *not yet
 arrived*, and the two are never confused.
 
 **Holding window**:
-The days, first to last, on which an account's end-of-day position in a security
-carries a quantity. A buy and a full sale on one day leave no window: a day traded
-through is not a day held.
+The two bounds of an account's position in a security: the first day it carried a
+quantity, and the day that quantity went to zero — or today, while it still stands.
+The closing day is *in* the window, being the day the sale happened. A buy and a
+full sale on one day leave no window at all, for want of an opening day: no day
+ever ends holding anything, and a day traded through is not a day held.
 _Avoid_: holding period, position span
 
 **Carrying price**:

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -195,8 +195,8 @@ def get_portfolio_totals_history():
         return bad_request(str(exc))
 
     return jsonify({
-        'from': start.isoformat(),
-        'to': stop.isoformat(),
+        'from': instants.iso(start),
+        'to': instants.iso(stop),
         'points': [
             {
                 't': instants.iso(row.get('day')),
@@ -222,8 +222,8 @@ def get_positions_history():
     reader = _reader()
     timeline = EventAggregator().replay(_snapshot().events)
     return jsonify({
-        'from': start.isoformat(),
-        'to': stop.isoformat(),
+        'from': instants.iso(start),
+        'to': instants.iso(stop),
         'points': portfolio_view.valuation_series(
             reader.daily_closes(start, stop), timeline.at,
             carried_in={row['symbol']: row['price']
@@ -297,8 +297,8 @@ def get_account_history(account_id: str):
 
     return jsonify({
         'account': account_id,
-        'from': start.isoformat(),
-        'to': stop.isoformat(),
+        'from': instants.iso(start),
+        'to': instants.iso(stop),
         'points': [
             {
                 't': instants.iso(row.get('day')),
@@ -1097,14 +1097,21 @@ def _parse_window(default: timedelta = DEFAULT_WINDOW) -> Tuple[datetime, dateti
 
 
 def _parse_instant(value: Optional[str]) -> Optional[datetime]:
-    """Parse an ISO-8601 date or datetime, always returning UTC-aware."""
+    """Parse an ISO-8601 date or datetime, always returning UTC-aware.
+
+    *Always*, including the value that arrives carrying an offset of its own:
+    ``?from=2024-01-15T00:00:00+02:00`` used to come back in ``+02:00`` and be
+    echoed as such beside points whose ``t`` is in ``+00:00`` (issue #861).
+    :func:`instants.utc` is the one repair, and it holds both halves — a naive
+    instant means UTC, an aware one is converted to it.
+    """
     if not value:
         return None
     try:
         parsed = datetime.fromisoformat(value.strip())
     except ValueError:
         raise ValueError(f"Not an ISO-8601 instant: {value!r}")
-    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    return instants.utc(parsed)
 
 
 __all__ = ['api_bp']

--- a/src/application/accounts.py
+++ b/src/application/accounts.py
@@ -22,7 +22,8 @@ CSV_ENCODING = 'utf-8-sig'
 
 
 class AccountSourceError(Exception):
-    """What is being declared cannot stand: no id, or no type."""
+    """What is being declared cannot stand: no id, no type, or an id no route
+    can carry."""
 
 
 class AccountInUse(Exception):
@@ -159,6 +160,15 @@ def create_account(store, account_id: str, account_type: str,
     account_type = _text(account_type)
     if not account_id:
         raise AccountSourceError("id is required")
+    if '/' in account_id:
+        # The id is the account's **address**: it is what the four
+        # ``<account_id>`` routes match on, and Flask's default converter stops
+        # at a slash. An id holding one inserts and is then unreachable — no
+        # history, no reassignment, no rename and no delete — and ADR-0013
+        # refuses the cascade that would clean it up (issue #861).
+        raise AccountSourceError(
+            "id cannot contain '/': it is the account's address in the app's "
+            "own URLs, and a slash there names a route that does not exist")
     if not account_type:
         raise AccountSourceError("type is required")
     if account_id in account_ids(store):

--- a/src/application/accounts.py
+++ b/src/application/accounts.py
@@ -153,6 +153,35 @@ def is_named_by_events(store, account_id: str) -> bool:
     return bool(rows and rows[0][0])
 
 
+#: The dot segments a URL resolves away before a request is even sent: `.` is
+#: removed and `..` climbs a level, so an account wearing either is reached at
+#: an address that names some other route (issue #861).
+DOT_SEGMENTS = ('.', '..')
+
+
+def refuse_unaddressable_id(account_id: str) -> None:
+    """Refuse an id the app's own ``<account_id>`` routes cannot carry (#861).
+
+    The id is the account's **address**: it is what four routes match on —
+    ``GET …/history``, ``POST …/reassignment``, ``PATCH`` and ``DELETE`` — and
+    Flask's default converter stops at a slash, while a URL resolves ``.`` and
+    ``..`` away before the request leaves the browser. An id holding one of the
+    three inserts and is then unreachable, unrenameable and **undeletable**,
+    with ADR-0013 refusing the cascade that would clean it up.
+
+    It is a function of its own, and not a line inside :func:`create_account`,
+    because the dry run has to refuse what the write would refuse: the preview
+    judges a file's declarations (:func:`entries.judge`) without going anywhere
+    near the writer.
+    """
+    account_id = _text(account_id)
+    if '/' in account_id or account_id in DOT_SEGMENTS:
+        raise AccountSourceError(
+            f"{account_id!r} cannot be an account id: it is the address the "
+            f"account is reached at in the app's own URLs, and '/', '.' and "
+            f"'..' there name a route that does not exist")
+
+
 def create_account(store, account_id: str, account_type: str,
                    label: Optional[str] = None) -> Account:
     """Declare an account. The app is where one is born, and the only place."""
@@ -160,15 +189,7 @@ def create_account(store, account_id: str, account_type: str,
     account_type = _text(account_type)
     if not account_id:
         raise AccountSourceError("id is required")
-    if '/' in account_id:
-        # The id is the account's **address**: it is what the four
-        # ``<account_id>`` routes match on, and Flask's default converter stops
-        # at a slash. An id holding one inserts and is then unreachable — no
-        # history, no reassignment, no rename and no delete — and ADR-0013
-        # refuses the cascade that would clean it up (issue #861).
-        raise AccountSourceError(
-            "id cannot contain '/': it is the account's address in the app's "
-            "own URLs, and a slash there names a route that does not exist")
+    refuse_unaddressable_id(account_id)
     if not account_type:
         raise AccountSourceError("type is required")
     if account_id in account_ids(store):
@@ -224,5 +245,6 @@ __all__ = [
     'read_accounts', 'account_ids', 'accounts_are_declared',
     'default_is_declared', 'declared_portfolio',
     'is_named_by_events',
+    'refuse_unaddressable_id', 'DOT_SEGMENTS',
     'create_account', 'update_account', 'delete_account',
 ]

--- a/src/application/accounts.py
+++ b/src/application/accounts.py
@@ -153,12 +153,6 @@ def is_named_by_events(store, account_id: str) -> bool:
     return bool(rows and rows[0][0])
 
 
-#: The dot segments a URL resolves away before a request is even sent: `.` is
-#: removed and `..` climbs a level, so an account wearing either is reached at
-#: an address that names some other route (issue #861).
-DOT_SEGMENTS = ('.', '..')
-
-
 def refuse_unaddressable_id(account_id: str) -> None:
     """Refuse an id the app's own ``<account_id>`` routes cannot carry (#861).
 
@@ -175,7 +169,7 @@ def refuse_unaddressable_id(account_id: str) -> None:
     near the writer.
     """
     account_id = _text(account_id)
-    if '/' in account_id or account_id in DOT_SEGMENTS:
+    if '/' in account_id or account_id in ('.', '..'):
         raise AccountSourceError(
             f"{account_id!r} cannot be an account id: it is the address the "
             f"account is reached at in the app's own URLs, and '/', '.' and "
@@ -245,6 +239,6 @@ __all__ = [
     'read_accounts', 'account_ids', 'accounts_are_declared',
     'default_is_declared', 'declared_portfolio',
     'is_named_by_events',
-    'refuse_unaddressable_id', 'DOT_SEGMENTS',
+    'refuse_unaddressable_id',
     'create_account', 'update_account', 'delete_account',
 ]

--- a/src/application/entries.py
+++ b/src/application/entries.py
@@ -216,7 +216,15 @@ def split_duplicates(store, drafts: Sequence[Event]) -> Tuple[List[Event],
 def judge(store, drafts: Sequence[Event], *,
           declaring: Sequence[str] = (),
           accounts_pending: bool = False) -> None:
-    """Refuse what :func:`create_many` would refuse, **without writing a row**."""
+    """Refuse what :func:`create_many` would refuse, **without writing a row**.
+
+    Including the ids the file would declare: the writer refuses one no route
+    can carry (:func:`accounts.refuse_unaddressable_id`), and a preview that let
+    it through would answer a green receipt for a file the confirmed import then
+    refuses — which is the one thing a dry run exists not to do (issue #861).
+    """
+    for account_id in declaring:
+        accounts_module.refuse_unaddressable_id(account_id)
     settled = _settled_all(store, drafts)
     _refuse_all(store, settled, declaring=declaring,
                 accounts_pending=accounts_pending)

--- a/src/application/events/schemas.py
+++ b/src/application/events/schemas.py
@@ -197,10 +197,15 @@ class Timeline:
         it: *this account carried no end-of-day quantity of this security on any
         day up to* ``today``. The events that were never recorded, the
         acquisition dated after today, and the buy sold in full on its own day
-        are three ways of arriving at that one absence, not three answers — a
-        window is made of end-of-day states, and a position whose quantity is
-        zero has fallen out of the model (``CONTEXT.md``, *Holding window*). A
-        day traded through is not a day held (issue #861).
+        are three ways of arriving at that one absence, not three answers.
+
+        The **bounds** are not read that way, and the asymmetry is deliberate:
+        the closing one is the day the quantity went to zero and it is *in* the
+        window — the day of the sale is a day of the position's life, which is
+        the reading :func:`carrying.holding_bounds` makes of an exit on the
+        backfill's side. What a same-day round trip lacks is therefore not a
+        closing day but an **opening** one (``CONTEXT.md``, *Holding window*,
+        issue #861).
         """
         snaps = self.snapshots.get((account, symbol))
         if not snaps:

--- a/src/application/events/schemas.py
+++ b/src/application/events/schemas.py
@@ -191,7 +191,17 @@ class Timeline:
 
     def holding_window(self, account: str, symbol: str,
                        today: date) -> Optional[Tuple[date, date]]:
-        """``(first day held, last day held)`` for one ``(account, symbol)``."""
+        """``(first day held, last day held)`` for one ``(account, symbol)``.
+
+        ``None`` says **one** thing, and it says it of every case that reaches
+        it: *this account carried no end-of-day quantity of this security on any
+        day up to* ``today``. The events that were never recorded, the
+        acquisition dated after today, and the buy sold in full on its own day
+        are three ways of arriving at that one absence, not three answers — a
+        window is made of end-of-day states, and a position whose quantity is
+        zero has fallen out of the model (``CONTEXT.md``, *Holding window*). A
+        day traded through is not a day held (issue #861).
+        """
         snaps = self.snapshots.get((account, symbol))
         if not snaps:
             return None

--- a/src/application/fx.py
+++ b/src/application/fx.py
@@ -1,10 +1,12 @@
 """The exchange rate — one pure module with a TTL cache (issue #702, ADR-0002)."""
 import bisect
 import re
-from datetime import date, datetime, timezone
+from datetime import date, datetime
 from typing import Callable, Dict, List, Optional, Tuple
 
 from logfmt_logger import getLogger
+
+from application import instants
 
 logger = getLogger("fx")
 
@@ -195,10 +197,15 @@ def _shift(day: date, days: int) -> date:
 
 
 def _as_date(value) -> date:
-    """A ``date`` out of whatever the injected fetch handed back."""
-    if isinstance(value, datetime):
-        return value.astimezone(timezone.utc).date()
-    return value
+    """A ``date`` out of whatever the injected fetch handed back.
+
+    Through :func:`instants.utc` and not ``astimezone``, which is the whole
+    point: a naive instant means **UTC** here (#843), where ``astimezone``
+    reads it as the machine's local time and shifts the day by its offset.
+    """
+    normalised = instants.utc(value)
+    return (normalised.date() if isinstance(normalised, datetime)
+            else normalised)
 
 
 __all__ = [

--- a/src/application/fx.py
+++ b/src/application/fx.py
@@ -203,9 +203,8 @@ def _as_date(value) -> date:
     point: a naive instant means **UTC** here (#843), where ``astimezone``
     reads it as the machine's local time and shifts the day by its offset.
     """
-    normalised = instants.utc(value)
-    return (normalised.date() if isinstance(normalised, datetime)
-            else normalised)
+    value = instants.utc(value)
+    return value.date() if isinstance(value, datetime) else value
 
 
 __all__ = [

--- a/src/application/perf_job.py
+++ b/src/application/perf_job.py
@@ -96,21 +96,11 @@ class PerfJob:
             return {}
 
         store_handle = self.facade.config_manager.store
-        # **The published snapshot, not a second read of the ledger** (#861).
-        # A write reaches here through `main.replay_after_write`, which has just
-        # ingested — read, aggregated and validated the whole ledger — and
-        # published it; reading `event` again produced the same rows at the cost
-        # of a second full pass on every write. The **replay** below stays: a
-        # `position` row is a current state and performance needs every day's,
-        # which is what `Timeline` is for.
-        #
-        # `reload` and not `current`: it compares the ledger's fingerprint and
-        # hands the published snapshot straight back when it matches, which on
-        # the write path it always does — so the read is still paid once. What
-        # it refuses to do is compute a whole series from a snapshot the
-        # ingestion *kept* because its own read failed: `ingest` swallows that
-        # failure by design, and this pass ends in a prune that empties a table
-        # a stale set of events leaves nothing to write to.
+        # **The rows the ingestion just published**, not a second read of them
+        # (#861): a write reaches here through `main.replay_after_write`, which
+        # has already read, validated and published the whole ledger. `reload`
+        # and not `current` because `ingest` keeps the previous snapshot when
+        # its own read fails, and this pass ends in a prune.
         events = self.facade.config_manager.reload().events or []
         declared = accounts_module.read_accounts(store_handle)
 

--- a/src/application/perf_job.py
+++ b/src/application/perf_job.py
@@ -33,11 +33,20 @@ def value_kwargs(dp, last: bool, perf) -> dict:
             for name, value in values.items()}
 
 
-def account_holding_windows(timeline, account_id: str, symbols,
+def account_holding_windows(timeline, account_id: str,
                             today: date) -> Dict[str, Tuple[date, date]]:
-    """``{symbol: (first, last) day this account held it}`` — the horizon's bound (issue #708)."""
+    """``{symbol: (first, last) day this account held it}`` — the horizon's bound (issue #708).
+
+    Over **this account's** symbols, which the timeline already knows: it was
+    handed the whole ledger's set, so a portfolio of a dozen accounts paid a
+    ``holding_window`` per (account × symbol) every cycle to be told ``None``
+    for the ones it had never touched (issue #861). Same windows, and the
+    absence a symbol is genuinely missing from is the same absence.
+    """
     windows = {}
-    for symbol in symbols:
+    for account, symbol in timeline.snapshots:
+        if account != account_id:
+            continue
         window = timeline.holding_window(account_id, symbol, today)
         if window is not None:
             windows[symbol] = window
@@ -134,7 +143,7 @@ class PerfJob:
                        if symbol not in first_quoted}
             writable = {
                 account.id: performance.account_horizon(
-                    account_holding_windows(timeline, account.id, symbols, today),
+                    account_holding_windows(timeline, account.id, today),
                     oldest_priced, settled, start=start, ceiling=today)
                 for account in declared
             }

--- a/src/application/perf_job.py
+++ b/src/application/perf_job.py
@@ -103,7 +103,15 @@ class PerfJob:
         # of a second full pass on every write. The **replay** below stays: a
         # `position` row is a current state and performance needs every day's,
         # which is what `Timeline` is for.
-        events = self.facade.config_manager.current().events or []
+        #
+        # `reload` and not `current`: it compares the ledger's fingerprint and
+        # hands the published snapshot straight back when it matches, which on
+        # the write path it always does — so the read is still paid once. What
+        # it refuses to do is compute a whole series from a snapshot the
+        # ingestion *kept* because its own read failed: `ingest` swallows that
+        # failure by design, and this pass ends in a prune that empties a table
+        # a stale set of events leaves nothing to write to.
+        events = self.facade.config_manager.reload().events or []
         declared = accounts_module.read_accounts(store_handle)
 
         now = datetime.now(timezone.utc)

--- a/src/application/perf_job.py
+++ b/src/application/perf_job.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from application import accounts as accounts_module
 from application import carrying
-from application import ledger
 from application import perf_series
 from application import performance
 from application import quotes
@@ -88,7 +87,14 @@ class PerfJob:
             return {}
 
         store_handle = self.facade.config_manager.store
-        events = ledger.read_events(store_handle)
+        # **The published snapshot, not a second read of the ledger** (#861).
+        # A write reaches here through `main.replay_after_write`, which has just
+        # ingested — read, aggregated and validated the whole ledger — and
+        # published it; reading `event` again produced the same rows at the cost
+        # of a second full pass on every write. The **replay** below stays: a
+        # `position` row is a current state and performance needs every day's,
+        # which is what `Timeline` is for.
+        events = self.facade.config_manager.current().events or []
         declared = accounts_module.read_accounts(store_handle)
 
         now = datetime.now(timezone.utc)

--- a/src/application/perf_job.py
+++ b/src/application/perf_job.py
@@ -139,12 +139,20 @@ class PerfJob:
 
             oldest_priced = {symbol: pairs[0][0]
                              for symbol, pairs in price_pairs.items() if pairs}
+            # The two halves of ADR-0004's domain, on a **terminal** symbol:
+            # one never quoted at all, which blocks nothing; one quoted from a
+            # day later than its acquisition, which blocks nothing before that
+            # day (issue #861). `compute_account` already values both at the
+            # carrying price — the horizon is what refused them.
             settled = {symbol for symbol in carried
                        if symbol not in first_quoted}
+            carried_from = {symbol: first_quoted[symbol] for symbol in carried
+                            if symbol in first_quoted}
             writable = {
                 account.id: performance.account_horizon(
                     account_holding_windows(timeline, account.id, today),
-                    oldest_priced, settled, start=start, ceiling=today)
+                    oldest_priced, settled, carried_from=carried_from,
+                    start=start, ceiling=today)
                 for account in declared
             }
             named = {event.account for event in events if event.account}

--- a/src/application/performance.py
+++ b/src/application/performance.py
@@ -45,19 +45,37 @@ class Horizon(NamedTuple):
 def account_horizon(windows: Mapping[str, Tuple[date, date]],
                     oldest_priced: Mapping[str, date],
                     settled: Collection[str] = (), *,
+                    carried_from: Optional[Mapping[str, date]] = None,
                     start: date, ceiling: date) -> Horizon:
-    """The days this account's figures may be written on."""
+    """The days this account's figures may be written on.
+
+    ``settled`` names the symbols that block nothing at all: their backfill is
+    terminal and no quote of them was ever observed, so every day they were held
+    is carried at cost (ADR-0004) and none of them is a hole.
+
+    ``carried_from`` is the same rule applied to the **other half** of that set
+    — a terminal symbol whose first quote is *later* than its acquisition
+    (issue #861). Those first days will never have a price either, and
+    :func:`compute_account` already values them at the carrying price; only the
+    horizon refused them, blocking from the acquisition. It now blocks from the
+    symbol's first quoted day, which leaves the *waiting* case untouched: a
+    symbol quoted from one day and converted only from a later one still blocks
+    the range between the two, because a quote was observed there and its
+    conversion is coming.
+    """
     day = timedelta(days=1)
+    quoted_from = carried_from or {}
     blocked: List[Tuple[date, date]] = []
     for symbol, (acquired, last_held) in windows.items():
         if symbol in settled:
             continue
+        first = max(acquired, quoted_from.get(symbol, acquired))
         oldest = oldest_priced.get(symbol)
         unpriced = (last_held if oldest is None
                     else min(oldest - day, last_held))
-        if unpriced < acquired:
+        if unpriced < first:
             continue
-        blocked.append((acquired, unpriced))
+        blocked.append((first, unpriced))
 
     if not blocked:
         return Horizon(None, None)

--- a/src/application/quotes.py
+++ b/src/application/quotes.py
@@ -242,12 +242,6 @@ def oldest_window_tried(store, symbol: str) -> Optional[date]:
     return rows[0][0] if rows and rows[0][0] is not None else None
 
 
-#: How many times a writer has moved a symbol's oldest point. It is part of the
-#: memo's key rather than a signal to clear it, and that is the whole of the
-#: thread safety: the web workers and the scheduler's pool share one connection,
-#: so a scan started before a write and returning after it would otherwise be
-#: stored as the current answer — ``lru_cache`` inserts when the call *returns*,
-#: and a ``cache_clear`` landing mid-scan clears nothing (issue #861).
 _generation = 0
 
 
@@ -261,10 +255,10 @@ def oldest_stored(store) -> Dict[str, datetime]:
     rhythm and not the reader's.
 
     Keyed on ``(store, generation)``: the handle because a suite opens one store
-    per test, and the generation because a scan is slow **by construction** —
-    being slow is why the memo exists — so the window in which a writer commits
-    under a reader is the widest in the app. A scan that started a generation ago
-    is stored under that generation and never read again.
+    per test, and the generation because ``lru_cache`` inserts when the call
+    *returns* — so a ``cache_clear`` landing mid-scan would clear nothing and
+    the reader would then store its pre-write answer. A scan that started a
+    generation ago is stored under that generation and never read again.
     """
     return _scanned(store, _generation)
 
@@ -412,7 +406,7 @@ __all__ = [
     'collapse_to_ladder',
     'unconverted_span', 'unconverted_days', 'repair_conversions',
     'record_window_tried', 'oldest_window_tried', 'terminal_symbols',
-    'oldest_stored', 'forget_oldest_stored',
+    'forget_oldest_stored',
     'first_quoted_days',
     'quote_currency',
     'oldest_ts', 'newest_ts', 'last_price', 'price_series', 'read_quote',

--- a/src/application/quotes.py
+++ b/src/application/quotes.py
@@ -1,4 +1,5 @@
 """The market's own two tables: ``symbol_quote`` and ``price_point`` (issue #700)."""
+from functools import lru_cache
 from datetime import date, datetime, timezone
 from typing import (Dict, Iterable, List, Mapping, Optional, Sequence, Set,
                     Tuple)
@@ -73,6 +74,7 @@ def record_quote(store, symbol: str, moment: datetime,
             'VALUES (?, ?, ?, ?, ?)',
             [symbol, ts, native, converted, rate])
         _advance_latest(store, symbol, ts, native, converted, rate)
+    forget_oldest_stored()
 
 
 def record_attributes(store, symbol: str, moment: datetime,
@@ -119,6 +121,7 @@ def record_history(store, symbol: str, points: Sequence[Mapping]) -> int:
             rows)
         latest = [row for row in rows if row[1] == newest][-1]
         _advance_latest(store, symbol, newest, latest[2], latest[3], latest[4])
+    forget_oldest_stored()
 
     logger.debug(f"Wrote {len(rows)} historical price(s) for {symbol}")
     return len(rows)
@@ -151,6 +154,7 @@ def collapse_to_ladder(store, now: datetime) -> int:
             removed += int(result.fetchone()[0])
 
     if removed:
+        forget_oldest_stored()
         logger.debug(f"Aged {removed} price point(s) onto the retention ladder")
     return removed
 
@@ -238,18 +242,40 @@ def oldest_window_tried(store, symbol: str) -> Optional[date]:
     return rows[0][0] if rows and rows[0][0] is not None else None
 
 
+@lru_cache(maxsize=1)
+def oldest_stored(store) -> Dict[str, datetime]:
+    """``{symbol: oldest instant stored}`` — one full scan, memoized (issue #861).
+
+    ``price_point`` carries no index (ADR-0007), so this ``GROUP BY`` is a scan
+    of the store's largest table — and it sat on the product's **hottest** read:
+    every ``/api/positions`` and every dashboard load ran it whole. Its answer
+    only moves when a price point is written or removed, which is the backfill's
+    rhythm and not the reader's, so it is memoized on the store handle and
+    dropped by :func:`forget_oldest_stored` from every writer below.
+
+    Keyed on the handle rather than global: a suite opens one store per test,
+    and one entry is all a process with one connection ever needs.
+    """
+    return {
+        symbol: instants.utc(value)
+        for symbol, value in store.query(
+            'SELECT symbol, min(ts) FROM price_point GROUP BY symbol')
+        if value is not None
+    }
+
+
+def forget_oldest_stored() -> None:
+    """Drop the memo — called by every gesture that can move a symbol's oldest point."""
+    oldest_stored.cache_clear()
+
+
 def terminal_symbols(store, windows: Mapping[str, Tuple[date, Optional[date]]],
                      now: datetime) -> Set[str]:
     """Which symbols the backward pass has **finished** with — issue #706."""
     if not windows:
         return set()
 
-    oldest_stored = {
-        symbol: instants.utc(value)
-        for symbol, value in store.query(
-            'SELECT symbol, min(ts) FROM price_point GROUP BY symbol')
-        if value is not None
-    }
+    oldest = oldest_stored(store)
     oldest_tried = {
         symbol: value
         for symbol, value in store.query(
@@ -261,7 +287,7 @@ def terminal_symbols(store, windows: Mapping[str, Tuple[date, Optional[date]]],
     for symbol, (acquired, exited) in windows.items():
         target, ceiling = carrying.holding_bounds(acquired, exited, now)
         anchor = carrying.backward_anchor(
-            ceiling, oldest_stored.get(symbol), oldest_tried.get(symbol))
+            ceiling, oldest.get(symbol), oldest_tried.get(symbol))
         if carrying.is_terminal(anchor, target):
             finished.add(symbol)
     return finished
@@ -359,6 +385,7 @@ def forget_symbol(store, symbol: str) -> int:
         'SELECT count(*) FROM price_point WHERE symbol = ?', [symbol])[0]
     store.execute('DELETE FROM price_point WHERE symbol = ?', [symbol])
     store.execute('DELETE FROM symbol_quote WHERE symbol = ?', [symbol])
+    forget_oldest_stored()
     return int(points)
 
 
@@ -368,6 +395,7 @@ __all__ = [
     'collapse_to_ladder',
     'unconverted_span', 'unconverted_days', 'repair_conversions',
     'record_window_tried', 'oldest_window_tried', 'terminal_symbols',
+    'oldest_stored', 'forget_oldest_stored',
     'first_quoted_days',
     'quote_currency',
     'oldest_ts', 'newest_ts', 'last_price', 'price_series', 'read_quote',

--- a/src/application/quotes.py
+++ b/src/application/quotes.py
@@ -242,7 +242,15 @@ def oldest_window_tried(store, symbol: str) -> Optional[date]:
     return rows[0][0] if rows and rows[0][0] is not None else None
 
 
-@lru_cache(maxsize=1)
+#: How many times a writer has moved a symbol's oldest point. It is part of the
+#: memo's key rather than a signal to clear it, and that is the whole of the
+#: thread safety: the web workers and the scheduler's pool share one connection,
+#: so a scan started before a write and returning after it would otherwise be
+#: stored as the current answer — ``lru_cache`` inserts when the call *returns*,
+#: and a ``cache_clear`` landing mid-scan clears nothing (issue #861).
+_generation = 0
+
+
 def oldest_stored(store) -> Dict[str, datetime]:
     """``{symbol: oldest instant stored}`` — one full scan, memoized (issue #861).
 
@@ -250,12 +258,20 @@ def oldest_stored(store) -> Dict[str, datetime]:
     of the store's largest table — and it sat on the product's **hottest** read:
     every ``/api/positions`` and every dashboard load ran it whole. Its answer
     only moves when a price point is written or removed, which is the backfill's
-    rhythm and not the reader's, so it is memoized on the store handle and
-    dropped by :func:`forget_oldest_stored` from every writer below.
+    rhythm and not the reader's.
 
-    Keyed on the handle rather than global: a suite opens one store per test,
-    and one entry is all a process with one connection ever needs.
+    Keyed on ``(store, generation)``: the handle because a suite opens one store
+    per test, and the generation because a scan is slow **by construction** —
+    being slow is why the memo exists — so the window in which a writer commits
+    under a reader is the widest in the app. A scan that started a generation ago
+    is stored under that generation and never read again.
     """
+    return _scanned(store, _generation)
+
+
+@lru_cache(maxsize=2)
+def _scanned(store, generation: int) -> Dict[str, datetime]:
+    """The scan itself, held under the generation it was started in."""
     return {
         symbol: instants.utc(value)
         for symbol, value in store.query(
@@ -265,8 +281,9 @@ def oldest_stored(store) -> Dict[str, datetime]:
 
 
 def forget_oldest_stored() -> None:
-    """Drop the memo — called by every gesture that can move a symbol's oldest point."""
-    oldest_stored.cache_clear()
+    """Move the memo on — every gesture that can move a symbol's oldest point."""
+    global _generation
+    _generation += 1
 
 
 def terminal_symbols(store, windows: Mapping[str, Tuple[date, Optional[date]]],

--- a/src/web/src/components/settings/RebuildBlock.tsx
+++ b/src/web/src/components/settings/RebuildBlock.tsx
@@ -61,6 +61,11 @@ interface RebuildBlockProps {
   accounts: AccountsResponse | null
 }
 
+//: The heading this card is named by, like the six other settings cards: a
+//: region navigated to by name, rather than a hole where the page's heaviest
+//: gesture lives (#861).
+const REBUILD_HEADING = 'settings-rebuild'
+
 export function RebuildBlock({ runtime, firstEvent, accounts }: RebuildBlockProps) {
   const { t } = useI18n()
 
@@ -73,9 +78,11 @@ export function RebuildBlock({ runtime, firstEvent, accounts }: RebuildBlockProp
   const percent = ratio === null ? null : Math.round(ratio * 100)
 
   return (
-    <Card>
+    <Card role="region" aria-labelledby={REBUILD_HEADING}>
       <CardHeader>
-        <h2 className="eyebrow">{t('installation.rebuild.title')}</h2>
+        <h2 id={REBUILD_HEADING} className="eyebrow">
+          {t('installation.rebuild.title')}
+        </h2>
       </CardHeader>
       <CardContent className="space-y-3">
         {/* Named or not, it is not the same sentence: *which* account is late is

--- a/src/web/src/i18n/en.json
+++ b/src/web/src/i18n/en.json
@@ -580,6 +580,7 @@
   "problem.unreplayableLedger.remove.inAccount": "The app refused and removed nothing: a later sale of {symbol} in the {account} account rests on this — it sells {wanted, plural, one {{wanted, number, ::.####} share} other {{wanted, number, ::.####} shares}}, and {owned, number, ::.####} would be left.",
   "problem.invalidFile": "The app refused this file and wrote nothing. Check that it is an event ledger, that the accounts it names are declared, and that its columns are the ones the export writes.",
   "problem.tooLarge": "This file is larger than the app takes in one go. Export a narrower range, or split it.",
+  "problem.invalidSetting": "The app refused this value: it is not one this setting takes.",
   "problem.internal": "The app hit an error it did not expect.",
   "problem.unreachable": "The app is not answering. Nothing on screen comes from it."
 }

--- a/src/web/src/i18n/en.json
+++ b/src/web/src/i18n/en.json
@@ -580,7 +580,7 @@
   "problem.unreplayableLedger.remove.inAccount": "The app refused and removed nothing: a later sale of {symbol} in the {account} account rests on this — it sells {wanted, plural, one {{wanted, number, ::.####} share} other {{wanted, number, ::.####} shares}}, and {owned, number, ::.####} would be left.",
   "problem.invalidFile": "The app refused this file and wrote nothing. Check that it is an event ledger, that the accounts it names are declared, and that its columns are the ones the export writes.",
   "problem.tooLarge": "This file is larger than the app takes in one go. Export a narrower range, or split it.",
-  "problem.invalidSetting": "The app refused this value: it is not one this setting takes.",
+  "problem.invalidSetting": "The app refused this value: this setting does not accept it.",
   "problem.internal": "The app hit an error it did not expect.",
   "problem.unreachable": "The app is not answering. Nothing on screen comes from it."
 }

--- a/src/web/src/i18n/fr.json
+++ b/src/web/src/i18n/fr.json
@@ -580,6 +580,7 @@
   "problem.unreplayableLedger.remove.inAccount": "L’application a refusé et n’a rien retiré : une vente postérieure de {symbol} sur le compte {account} repose dessus — elle vend {wanted, plural, one {{wanted, number, ::.####} part} other {{wanted, number, ::.####} parts}}, et il n’en resterait que {owned, number, ::.####}.",
   "problem.invalidFile": "L’application a refusé ce fichier et n’a rien écrit. Vérifiez qu’il s’agit bien d’un grand livre d’événements, que les comptes qu’il nomme sont déclarés, et que ses colonnes sont celles qu’écrit l’export.",
   "problem.tooLarge": "Ce fichier dépasse ce que l’application accepte en une fois. Exportez une plage plus étroite, ou coupez-le en deux.",
+  "problem.invalidSetting": "L’application a refusé cette valeur : ce réglage ne l’accepte pas.",
   "problem.internal": "L’application a rencontré une erreur qu’elle n’attendait pas.",
   "problem.unreachable": "L’application ne répond pas. Rien de ce qui est affiché ne vient d’elle."
 }

--- a/src/web/src/lib/problem.ts
+++ b/src/web/src/lib/problem.ts
@@ -64,6 +64,16 @@ export const PROBLEM_TYPES = {
   invalidFile: '/problems/invalid-file',
   /** The upload is past the bound the server states (#811). */
   tooLarge: '/problems/payload-too-large',
+  /**
+   * A value `PUT /api/settings` will not take (`problem.unprocessable`): the
+   * body parsed, and the registry refuses what is in it. A refusal **by
+   * design**, and without its own row here it fell back to *an unexpected
+   * error* — the one sentence that is certainly untrue of it (#861).
+   *
+   * `/problems/foreign-origin` deliberately stays out: its own docstring says
+   * no page this app serves can ever read it.
+   */
+  invalidSetting: '/problems/invalid-setting',
   internal: '/problems/internal-error',
 } as const
 
@@ -81,6 +91,7 @@ const MESSAGES: Record<string, MessageKey> = {
   [PROBLEM_TYPES.unreplayableLedger]: 'problem.unreplayableLedger',
   [PROBLEM_TYPES.invalidFile]: 'problem.invalidFile',
   [PROBLEM_TYPES.tooLarge]: 'problem.tooLarge',
+  [PROBLEM_TYPES.invalidSetting]: 'problem.invalidSetting',
   [PROBLEM_TYPES.internal]: 'problem.internal',
 }
 

--- a/src/web/src/lib/status.test.ts
+++ b/src/web/src/lib/status.test.ts
@@ -210,6 +210,20 @@ describe('the front branches on problem.type, never on status', () => {
       .toBe('problem.badRequest')
   })
 
+  it('has a sentence for a setting the registry refuses, which is not "unexpected"', () => {
+    // `PUT /api/settings` answers `/problems/invalid-setting`, and the table
+    // did not know it: a refusal **by design** fell through to *an error it did
+    // not expect*, which is the one thing that is certainly untrue of it (#861).
+    expect(problemMessageKey(new ApiProblem({ status: 422, type: PROBLEM_TYPES.invalidSetting })))
+      .toBe('problem.invalidSetting')
+  })
+
+  it('does not know foreign-origin, and that is the answer', () => {
+    // `problem.foreign_origin`'s own docstring: no page this app serves can
+    // read it. A sentence for it would be a sentence nobody meets.
+    expect(Object.values(PROBLEM_TYPES)).not.toContain('/problems/foreign-origin')
+  })
+
   it('does not read a 503 as a store failure when the type says otherwise', () => {
     // Branching on `status` is what made two unrelated failures the same
     // screen. The same status, two types, two sentences.

--- a/src/web/src/settings.test.tsx
+++ b/src/web/src/settings.test.tsx
@@ -91,6 +91,19 @@ describe('the page, and the cards it is made of', () => {
     )
   })
 
+  it('names the rebuild card too, so no region on the page is anonymous', async () => {
+    // Six cards set `role="region"` and `aria-labelledby`, and this one did
+    // not: navigating by region skipped the card carrying the page's heaviest
+    // gesture, which is the one a reader arrives at from the bell (#861).
+    server.use(
+      http.get(ROUTES.runtime, () => HttpResponse.json(aRuntime({ rebuilding: true }))),
+    )
+    await openSettings()
+
+    expect(await screen.findByRole('region', { name: 'Reconstruction en cours' }))
+      .toBeInTheDocument()
+  })
+
   it('says nothing about the notices, which live behind the bell', async () => {
     await openSettings([anEnvironmentFact()])
     await screen.findByRole('heading', { name: 'Ce que vous pouvez changer' })

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,13 @@ class PerfConfigManager:
     ledger the store holds, because the production pass only ever runs after an
     ingestion has read and published it.
 
+    It reads on every call **on purpose**: every module that uses it seeds the
+    store and then drives a pass, so a snapshot frozen at construction would
+    describe a ledger the test has not written yet. The *no second read* this
+    fake would seem the place to hold is held where it is true — over the real
+    :class:`main.ConfigurationManager`, in
+    ``tests/test_replay_perf.py::test_the_replay_that_follows_a_write_reads_the_ledger_once``.
+
     One class rather than the four byte-identical ones the perf modules each
     kept: they had drifted into the same shape, and a fifth copy is how a fake
     stops standing for the thing it fakes.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,11 +15,14 @@ All fixtures below are project-wide (auto-discovered by any ``test_*.py`` under
 ``tests/``). Keep them generic; put test-specific data in the test module.
 """
 
+from contextlib import contextmanager
 from datetime import date, timezone
 
 import pandas as pd
 import pytest
 
+from application import ledger
+from application import main
 from application import positions
 from application import store as store_module
 from application.events.schemas import Event, EventType
@@ -39,6 +42,39 @@ _EXAMPLE_CSV = (
     "2024-09-15,SELL,AAPL,Apple Inc,3,190.00,2.00,,Partial sale\n"
     "2025-01-30,DIVIDEND,MSFT,Microsoft,,,,5.00,New dividend\n"
 )
+
+
+class PerfConfigManager:
+    """The manager surface the perf pass uses, over a real store (issue #861).
+
+    Three members and no more: the read handle, the writers' mutex, and the
+    published snapshot the pass takes its events from — which here *is* the
+    ledger the store holds, because the production pass only ever runs after an
+    ingestion has read and published it.
+
+    One class rather than the four byte-identical ones the perf modules each
+    kept: they had drifted into the same shape, and a fifth copy is how a fake
+    stops standing for the thing it fakes.
+    """
+
+    def __init__(self, opened_store):
+        self._store = opened_store
+
+    @property
+    def store(self):
+        return self._store
+
+    @contextmanager
+    def writing(self):
+        yield self._store
+
+    def current(self):
+        return main.ConfigSnapshot(
+            shares=[], events=ledger.read_events(self._store),
+            accounts=None, cache_key=None)
+
+    def reload(self, force: bool = False):
+        return self.current()
 
 
 @pytest.fixture

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -301,6 +301,22 @@ def test_two_accounts_cannot_share_an_id(store):
         accounts_module.create_account(store, 'pea', 'CTO')
 
 
+def test_an_id_holding_a_slash_is_refused_before_it_is_written(store):
+    """An id is an address, and one no route matches is a row nobody can reach.
+
+    ``/api/accounts/<account_id>/…`` stops at a slash, so ``pea/2024`` inserted
+    and was then unreachable by all four of its routes — no history, no
+    reassignment, no rename, **no delete** — and ADR-0013 refuses the cascade
+    that would have cleaned it up. The refusal is the one the id rules already
+    speak (issue #861).
+    """
+    with pytest.raises(accounts_module.AccountSourceError) as refused:
+        accounts_module.create_account(store, 'pea/2024', 'PEA')
+
+    assert '/' in str(refused.value)
+    assert accounts_module.account_ids(store) == {DEFAULT_ACCOUNT}
+
+
 def test_creating_an_account_makes_a_blank_column_an_error(store, tmp_path):
     """An account created in the app declares as much as a file does.
 

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -301,19 +301,20 @@ def test_two_accounts_cannot_share_an_id(store):
         accounts_module.create_account(store, 'pea', 'CTO')
 
 
-def test_an_id_holding_a_slash_is_refused_before_it_is_written(store):
+def test_an_id_no_route_can_carry_is_refused_before_it_is_written(store):
     """An id is an address, and one no route matches is a row nobody can reach.
 
     ``/api/accounts/<account_id>/…`` stops at a slash, so ``pea/2024`` inserted
     and was then unreachable by all four of its routes — no history, no
     reassignment, no rename, **no delete** — and ADR-0013 refuses the cascade
-    that would have cleaned it up. The refusal is the one the id rules already
-    speak (issue #861).
+    that would have cleaned it up. ``.`` and ``..`` arrive at the same place by
+    another road: a URL resolves its dot segments away before the request is
+    sent, so ``/api/accounts/../history`` asks for ``/api/history`` (#861).
     """
-    with pytest.raises(accounts_module.AccountSourceError) as refused:
-        accounts_module.create_account(store, 'pea/2024', 'PEA')
+    for unaddressable in ('pea/2024', '.', '..'):
+        with pytest.raises(accounts_module.AccountSourceError):
+            accounts_module.create_account(store, unaddressable, 'PEA')
 
-    assert '/' in str(refused.value)
     assert accounts_module.account_ids(store) == {DEFAULT_ACCOUNT}
 
 

--- a/tests/test_carrying.py
+++ b/tests/test_carrying.py
@@ -66,6 +66,10 @@ class _FakeConfigManager:
             shares=[], events=ledger.read_events(self._store),
             accounts=None, cache_key=None)
 
+    def reload(self, force: bool = False):
+        """What the perf pass reads through: the snapshot, rebuilt on demand."""
+        return self.current()
+
 
 def _metrics(store):
     m = workloads.Workloads(_FakeConfigManager(store))

--- a/tests/test_carrying.py
+++ b/tests/test_carrying.py
@@ -16,14 +16,13 @@ The store is real, as everywhere in the v5 suite: terminality is derived from
 rows, so a fake would be asserting the derivation against itself.
 """
 
-from contextlib import contextmanager
 from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
+from conftest import PerfConfigManager
+
 from application import carrying
-from application import ledger
-from application import main
 from application import performance
 from application import portfolio_view
 from application import quotes
@@ -41,38 +40,9 @@ PEA = Account("PEA", "PEA", "Mon PEA")
 # Helpers
 # --------------------------------------------------------------------------- #
 
-class _FakeConfigManager:
-    """The surface ``Workloads`` needs from the manager, over a real store."""
-
-    def __init__(self, opened_store):
-        self._store = opened_store
-
-    @property
-    def store(self):
-        return self._store
-
-    @contextmanager
-    def writing(self):
-        yield self._store
-
-    def current(self):
-        """The published snapshot, which is the ledger the store holds (#861).
-
-        The perf pass reads its events here rather than from ``event`` a second
-        time, so a snapshot that answered an empty list would starve a pass this
-        file drives on a seeded store.
-        """
-        return main.ConfigSnapshot(
-            shares=[], events=ledger.read_events(self._store),
-            accounts=None, cache_key=None)
-
-    def reload(self, force: bool = False):
-        """What the perf pass reads through: the snapshot, rebuilt on demand."""
-        return self.current()
-
 
 def _metrics(store):
-    m = workloads.Workloads(_FakeConfigManager(store))
+    m = workloads.Workloads(PerfConfigManager(store))
     m.backfill_delay = 0
     m.backfill_chunk_days = 365
     return m

--- a/tests/test_carrying.py
+++ b/tests/test_carrying.py
@@ -22,6 +22,7 @@ from datetime import date, datetime, timedelta, timezone
 import pytest
 
 from application import carrying
+from application import ledger
 from application import main
 from application import performance
 from application import portfolio_view
@@ -55,8 +56,15 @@ class _FakeConfigManager:
         yield self._store
 
     def current(self):
-        return main.ConfigSnapshot(shares=[], events=[], accounts=None,
-                                   cache_key=None)
+        """The published snapshot, which is the ledger the store holds (#861).
+
+        The perf pass reads its events here rather than from ``event`` a second
+        time, so a snapshot that answered an empty list would starve a pass this
+        file drives on a seeded store.
+        """
+        return main.ConfigSnapshot(
+            shares=[], events=ledger.read_events(self._store),
+            accounts=None, cache_key=None)
 
 
 def _metrics(store):

--- a/tests/test_cash.py
+++ b/tests/test_cash.py
@@ -316,6 +316,10 @@ class _CashConfigManager:
             shares=[], events=ledger.read_events(self._store),
             accounts=None, cache_key=None)
 
+    def reload(self, force: bool = False):
+        """What the perf pass reads through: the snapshot, rebuilt on demand."""
+        return self.current()
+
 
 def _metrics(store, declare_ledger, events, accounts):
     declare_ledger(store, events, accounts.accounts if accounts else None)

--- a/tests/test_cash.py
+++ b/tests/test_cash.py
@@ -13,14 +13,13 @@ Covers:
 No network, no real InfluxDB.
 """
 
-from contextlib import contextmanager
 from dataclasses import replace
 from datetime import date, datetime, time, timedelta, timezone
 
 import pytest
 
-from application import ledger
-from application import main
+from conftest import PerfConfigManager
+
 from application import perf_series
 from application import quotes
 from application import workloads
@@ -291,39 +290,10 @@ def test_portfolio_totals_is_keyed_by_the_day_alone(store):
 # The configuration manager is down to what the job actually asks it for: the
 # open store, and the writers' mutex.
 # --------------------------------------------------------------------------- #
-class _CashConfigManager:
-    """The three members the perf job uses: the read handle, the published
-    snapshot and the write mutex."""
-
-    def __init__(self, opened_store):
-        self._store = opened_store
-
-    @property
-    def store(self):
-        return self._store
-
-    @contextmanager
-    def writing(self):
-        yield self._store
-
-    def current(self):
-        """The published snapshot the perf pass reads its events from (#861).
-
-        It is the ledger: the pass no longer reads ``event`` itself, because a
-        write has just been ingested and published when it runs.
-        """
-        return main.ConfigSnapshot(
-            shares=[], events=ledger.read_events(self._store),
-            accounts=None, cache_key=None)
-
-    def reload(self, force: bool = False):
-        """What the perf pass reads through: the snapshot, rebuilt on demand."""
-        return self.current()
-
 
 def _metrics(store, declare_ledger, events, accounts):
     declare_ledger(store, events, accounts.accounts if accounts else None)
-    metrics = workloads.Workloads(_CashConfigManager(store))
+    metrics = workloads.Workloads(PerfConfigManager(store))
     # The one question the app asks (#702, ADR-0021). Without an answer the perf
     # job writes **nothing at all** — not zeros, not NULLs — because every figure
     # it computes is money and an amount with no settled unit is not a figure.

--- a/tests/test_cash.py
+++ b/tests/test_cash.py
@@ -19,6 +19,8 @@ from datetime import date, datetime, time, timedelta, timezone
 
 import pytest
 
+from application import ledger
+from application import main
 from application import perf_series
 from application import quotes
 from application import workloads
@@ -290,7 +292,8 @@ def test_portfolio_totals_is_keyed_by_the_day_alone(store):
 # open store, and the writers' mutex.
 # --------------------------------------------------------------------------- #
 class _CashConfigManager:
-    """The two members the perf job uses: the read handle and the write mutex."""
+    """The three members the perf job uses: the read handle, the published
+    snapshot and the write mutex."""
 
     def __init__(self, opened_store):
         self._store = opened_store
@@ -302,6 +305,16 @@ class _CashConfigManager:
     @contextmanager
     def writing(self):
         yield self._store
+
+    def current(self):
+        """The published snapshot the perf pass reads its events from (#861).
+
+        It is the ledger: the pass no longer reads ``event`` itself, because a
+        write has just been ingested and published when it runs.
+        """
+        return main.ConfigSnapshot(
+            shares=[], events=ledger.read_events(self._store),
+            accounts=None, cache_key=None)
 
 
 def _metrics(store, declare_ledger, events, accounts):

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -14,6 +14,7 @@ that a method was called. The three cases the ticket names are here — a positi
 quoted in ``GBp``, a position whose rate cannot be had, and the passage from
 *"no reporting currency"* to *"one is answered"*.
 """
+import time
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta, timezone
 
@@ -208,6 +209,29 @@ def test_a_day_with_no_close_of_its_own_takes_the_last_one_before_it():
     assert len(fetched) == 1
     # A day before the window is a hole, not Friday's rate reaching backwards.
     assert rates.rate('USD', 'EUR', date(2024, 5, 1)) is None
+
+
+def test_a_naive_instant_from_the_fetch_is_read_as_utc(monkeypatch):
+    """One rule for a naive instant, and it is ``instants.utc``'s (#843, #861).
+
+    The machine is put five hours west of UTC — the shape of any laptop in New
+    York — and the fetch answers a point stamped late in the day with no zone.
+    Read as **local** time, as ``astimezone`` reads it, that point lands on the
+    *next* day: the rate for the 10th is then keyed on the 11th, and the day
+    that asked for it gets nothing rather than a rate. Read as UTC, which is
+    what a naive instant means everywhere else in this tree, it stays on the
+    10th.
+    """
+    monkeypatch.setenv('TZ', 'America/New_York')
+    time.tzset()
+
+    def history(pair, start, end):
+        return {datetime(2024, 6, 10, 23, 30): 0.92}
+
+    rates = fx.Rates(_Fetch(), history, clock=_Clock())
+    rates.series('USD', 'EUR', date(2024, 6, 5), date(2024, 6, 12))
+
+    assert rates.rate('USD', 'EUR', date(2024, 6, 10)) == 0.92
 
 
 def test_the_forward_fill_stops_at_the_lookback_and_never_borrows_another_year():

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -224,14 +224,20 @@ def test_a_naive_instant_from_the_fetch_is_read_as_utc(monkeypatch):
     """
     monkeypatch.setenv('TZ', 'America/New_York')
     time.tzset()
+    try:
+        def history(pair, start, end):
+            return {datetime(2024, 6, 10, 23, 30): 0.92}
 
-    def history(pair, start, end):
-        return {datetime(2024, 6, 10, 23, 30): 0.92}
+        rates = fx.Rates(_Fetch(), history, clock=_Clock())
+        rates.series('USD', 'EUR', date(2024, 6, 5), date(2024, 6, 12))
 
-    rates = fx.Rates(_Fetch(), history, clock=_Clock())
-    rates.series('USD', 'EUR', date(2024, 6, 5), date(2024, 6, 12))
-
-    assert rates.rate('USD', 'EUR', date(2024, 6, 10)) == 0.92
+        assert rates.rate('USD', 'EUR', date(2024, 6, 10)) == 0.92
+    finally:
+        # ``monkeypatch`` puts the variable back; only ``tzset`` puts the C
+        # library back, and CI runs in UTC (``tests/test_store.py`` holds the
+        # same pattern for the same reason).
+        monkeypatch.undo()
+        time.tzset()
 
 
 def test_the_forward_fill_stops_at_the_lookback_and_never_borrows_another_year():

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1271,6 +1271,33 @@ def test_a_correspondence_for_an_account_the_file_does_not_name_is_refused(
     assert _declared(opened) == ['default', 'pea']
 
 
+def test_a_preview_refuses_the_id_the_import_would_refuse(tmp_path):
+    """**No refusal arrives after the button** — including the id rule (#861).
+
+    A bank export's account column is free text, and ``PEA / Bourso`` is an
+    ordinary cell. The writer refuses an id no ``<account_id>`` route can carry,
+    and the preview never reached the writer: it answered a green receipt for a
+    file the confirmed import then refused, which is the one thing a dry run
+    exists not to do.
+    """
+    client, opened = build_client_and_store(tmp_path)
+    slashed = (
+        "date,event_type,symbol,name,quantity,unit_price,fee,amount,account\n"
+        "2024-01-15,BUY,AAPL,Apple Inc,10,150.00,2.50,,PEA/Bourso\n"
+    ).encode('utf-8')
+
+    preview = _upload(client, slashed,
+                      query=_query(dry_run=1, map='{}', declare='PEA/Bourso'))
+    written = _upload(client, slashed,
+                      query=_query(map='{}', declare='PEA/Bourso'))
+
+    assert preview.status_code == 422
+    assert written.status_code == 422
+    assert "PEA/Bourso" in preview.get_json()['detail']
+    assert _declared(opened) == ['default']
+    assert opened.query('SELECT count(*) FROM event') == [(0,)]
+
+
 def test_a_label_declared_between_the_forecast_and_the_button_is_not_refused(
         tmp_path):
     """**No refusal arrives after the button** — including this one.

--- a/tests/test_perf_job.py
+++ b/tests/test_perf_job.py
@@ -23,13 +23,12 @@ readable.
 Prior art: ``tests/test_perf_price_source.py``, ``tests/test_replay_perf.py``,
 ``tests/test_performance.py``.
 """
-from contextlib import contextmanager
 from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
-from application import ledger
-from application import main
+from conftest import PerfConfigManager
+
 from application import perf_job
 from application import quotes
 from application import workloads
@@ -56,36 +55,6 @@ _LISTED = date(2024, 1, 16)
 _RATED = date(2024, 1, 22)
 
 
-class _ConfigManager:
-    """The surface the perf pass needs: the open store, the published snapshot
-    and the writers' mutex."""
-
-    def __init__(self, opened):
-        self._store = opened
-
-    @property
-    def store(self):
-        return self._store
-
-    @contextmanager
-    def writing(self):
-        yield self._store
-
-    def current(self):
-        """The published snapshot the perf pass reads its events from (#861).
-
-        It is the ledger: the pass no longer reads ``event`` itself, because a
-        write has just been ingested and published when it runs.
-        """
-        return main.ConfigSnapshot(
-            shares=[], events=ledger.read_events(self._store),
-            accounts=None, cache_key=None)
-
-    def reload(self, force: bool = False):
-        """What the perf pass reads through: the snapshot, rebuilt on demand."""
-        return self.current()
-
-
 def _fixed_today(mocker):
     """The perf pass's clock, pinned — UTC-qualified, like every read of it."""
     class _FixedDatetime(datetime):
@@ -98,7 +67,7 @@ def _fixed_today(mocker):
 def _metrics(opened, mocker):
     """A real metrics object over a real store, its reporting currency answered."""
     _fixed_today(mocker)
-    metrics = workloads.Workloads(_ConfigManager(opened))
+    metrics = workloads.Workloads(PerfConfigManager(opened))
     metrics.base_currency = 'EUR'
     return metrics
 

--- a/tests/test_perf_job.py
+++ b/tests/test_perf_job.py
@@ -30,7 +30,9 @@ import pytest
 
 from application import ledger
 from application import main
+from application import perf_job
 from application import workloads
+from application.events.aggregator import EventAggregator
 from application.events.schemas import Event, EventType
 
 UTC = timezone.utc
@@ -122,6 +124,47 @@ def _totals(opened):
     return opened.query(
         'SELECT day, holdings_value, total_value FROM portfolio_totals '
         ' ORDER BY day')
+
+
+def test_an_account_is_asked_only_about_the_symbols_it_has_touched():
+    """The windows are the same; the questions are not (issue #861).
+
+    ``account_holding_windows`` was handed ``{e.symbol for e in events}`` — the
+    **whole ledger's** set — for each declared account, and filtered correctly
+    afterwards: a symbol the account never touched answers ``None`` and drops
+    out. So the answer was right and the cost was one ``holding_window`` per
+    (account × symbol) per cycle, on a set the timeline already keys by
+    ``(account, symbol)``.
+
+    Two accounts holding disjoint securities is the shape that makes the two
+    readings differ, and the assertion is on both: the windows produced, and —
+    since a question that was not asked leaves no row — the calls made.
+    """
+    events = [
+        Event(_OPENED, EventType.DEPOSIT, amount=10000.0, account='pea'),
+        Event(_OPENED, EventType.DEPOSIT, amount=10000.0, account='cto'),
+        Event(_ACQUIRED, EventType.BUY, 'AAPL', 'Apple', quantity=10,
+              unit_price=100.0, account='pea'),
+        Event(_ACQUIRED, EventType.BUY, 'MSFT', 'Microsoft', quantity=5,
+              unit_price=300.0, account='cto'),
+    ]
+    timeline = EventAggregator().replay(events)
+
+    asked = []
+    original = timeline.holding_window
+
+    def counting(account, symbol, today):
+        asked.append((account, symbol))
+        return original(account, symbol, today)
+
+    timeline.holding_window = counting
+
+    assert perf_job.account_holding_windows(timeline, 'pea', _TODAY) == {
+        'AAPL': (_ACQUIRED, _TODAY)}
+    assert perf_job.account_holding_windows(timeline, 'cto', _TODAY) == {
+        'MSFT': (_ACQUIRED, _TODAY)}
+
+    assert asked == [('pea', 'AAPL'), ('cto', 'MSFT')]
 
 
 def test_a_line_converted_late_blocks_the_years_before_the_conversion(

--- a/tests/test_perf_job.py
+++ b/tests/test_perf_job.py
@@ -81,6 +81,10 @@ class _ConfigManager:
             shares=[], events=ledger.read_events(self._store),
             accounts=None, cache_key=None)
 
+    def reload(self, force: bool = False):
+        """What the perf pass reads through: the snapshot, rebuilt on demand."""
+        return self.current()
+
 
 def _fixed_today(mocker):
     """The perf pass's clock, pinned — UTC-qualified, like every read of it."""
@@ -114,6 +118,8 @@ def _price(opened, symbol, day, native, converted=None):
         '                         fx_rate) VALUES (?, ?, ?, ?, ?)',
         [symbol, datetime(day.year, day.month, day.day, 17, 0, tzinfo=UTC),
          native, converted, 1.0 if converted is not None else None])
+    # By hand, so the memo the market writers move on does not move (#861).
+    quotes.forget_oldest_stored()
 
 
 #: One deposit and one purchase held to this day: ten shares at 100, paid for
@@ -258,8 +264,13 @@ def test_a_terminal_line_quoted_before_it_is_converted_still_blocks_the_gap(
     days a quote **was** observed, so its absence of a converted price is
     transitory — the lateral pass is coming for it — and
     :func:`carrying.carrying_price` refuses to carry a day it knows a number
-    for. Those six days are blocked, as they were, and the clip added by #861
-    starts the blocked range at the first quote rather than at the acquisition.
+    for. Those six days go on being blocked, which is what ``settled`` was
+    protecting and what the clip of #861 must not take away.
+
+    It is the *guard* on that clip and not a demonstration of it: the clip
+    itself is only observable where ``oldest_priced`` is empty, and it is pinned
+    there — ``test_a_carried_symbol_blocks_from_its_first_quote_and_not_its_acquisition``
+    in ``tests/test_performance.py``.
     """
     declare_ledger(store, _LEDGER)
     _quote(store, 'AAPL')

--- a/tests/test_perf_job.py
+++ b/tests/test_perf_job.py
@@ -28,6 +28,8 @@ from datetime import date, datetime, timezone
 
 import pytest
 
+from application import ledger
+from application import main
 from application import workloads
 from application.events.schemas import Event, EventType
 
@@ -46,7 +48,8 @@ _CONVERTED = date(2024, 6, 10)
 
 
 class _ConfigManager:
-    """The surface the perf pass needs: the open store and the writers' mutex."""
+    """The surface the perf pass needs: the open store, the published snapshot
+    and the writers' mutex."""
 
     def __init__(self, opened):
         self._store = opened
@@ -58,6 +61,16 @@ class _ConfigManager:
     @contextmanager
     def writing(self):
         yield self._store
+
+    def current(self):
+        """The published snapshot the perf pass reads its events from (#861).
+
+        It is the ledger: the pass no longer reads ``event`` itself, because a
+        write has just been ingested and published when it runs.
+        """
+        return main.ConfigSnapshot(
+            shares=[], events=ledger.read_events(self._store),
+            accounts=None, cache_key=None)
 
 
 def _fixed_today(mocker):

--- a/tests/test_perf_job.py
+++ b/tests/test_perf_job.py
@@ -24,13 +24,14 @@ Prior art: ``tests/test_perf_price_source.py``, ``tests/test_replay_perf.py``,
 ``tests/test_performance.py``.
 """
 from contextlib import contextmanager
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
 from application import ledger
 from application import main
 from application import perf_job
+from application import quotes
 from application import workloads
 from application.events.aggregator import EventAggregator
 from application.events.schemas import Event, EventType
@@ -47,6 +48,12 @@ _TODAY = date(2024, 6, 20)
 _OPENED = date(2024, 1, 1)
 _ACQUIRED = date(2024, 1, 2)
 _CONVERTED = date(2024, 6, 10)
+
+#: A security whose market has no session before the 16th — fourteen days after
+#: the acquisition — and whose conversion lands six days after that. The two
+#: halves of a terminal line quoted late (issue #861).
+_LISTED = date(2024, 1, 16)
+_RATED = date(2024, 1, 22)
 
 
 class _ConfigManager:
@@ -208,6 +215,66 @@ def test_a_line_converted_late_blocks_the_years_before_the_conversion(
     assert [row for row in written if row[1] == 0.0] == []
     assert dict((day, holdings) for day, holdings, _ in written)[_TODAY] \
         == pytest.approx(10 * 120.0)
+
+
+def test_a_terminal_line_quoted_late_carries_the_days_before_its_first_quote(
+        store, mocker, declare_ledger):
+    """ADR-0004 applied to its own domain: no price, and none is coming (#861).
+
+    A security bought on the 2nd whose market has no session before the 16th —
+    the backward pass has been *tried* back to the acquisition and came back
+    empty, which is what makes it terminal. Those fourteen days will **never**
+    have a price, so they are carried at the unit cost, which is exactly what
+    :func:`performance.compute_account` already does with them. Only the horizon
+    refused: ``settled`` excluded any carried symbol carrying a first quote, so
+    the days between the acquisition and that quote were written nowhere at all.
+
+    The series therefore opens on the ledger's own first day, and the days
+    before the first quote value the ten shares at what they cost.
+    """
+    declare_ledger(store, _LEDGER)
+    _quote(store, 'AAPL')
+    # The backward pass reached the acquisition and found nothing: terminal.
+    quotes.record_window_tried(store, 'AAPL', _ACQUIRED)
+    _price(store, 'AAPL', _LISTED, 120.0, 120.0)
+
+    horizons = _metrics(store, mocker).update_account_metrics()
+
+    written = dict((day, holdings) for day, holdings, _ in _totals(store))
+    assert horizons == {'default': None}, 'nothing blocks this account'
+    assert min(written) == _OPENED
+    # The fourteen days no price will ever answer for, at the carrying price.
+    assert written[_ACQUIRED] == pytest.approx(10 * 100.0)
+    assert written[_LISTED - timedelta(days=1)] == pytest.approx(10 * 100.0)
+    # And the market's own price from the day it exists.
+    assert written[_LISTED] == pytest.approx(10 * 120.0)
+
+
+def test_a_terminal_line_quoted_before_it_is_converted_still_blocks_the_gap(
+        store, mocker, declare_ledger):
+    """The half ``settled`` was protecting, and it goes on being protected.
+
+    Quoted from the 16th and converted only from the 22nd: between those two
+    days a quote **was** observed, so its absence of a converted price is
+    transitory — the lateral pass is coming for it — and
+    :func:`carrying.carrying_price` refuses to carry a day it knows a number
+    for. Those six days are blocked, as they were, and the clip added by #861
+    starts the blocked range at the first quote rather than at the acquisition.
+    """
+    declare_ledger(store, _LEDGER)
+    _quote(store, 'AAPL')
+    quotes.record_window_tried(store, 'AAPL', _ACQUIRED)
+    # A native price with no conversion beside it — the *waiting* state.
+    _price(store, 'AAPL', _LISTED, 120.0, None)
+    _price(store, 'AAPL', _RATED, 130.0, 130.0)
+
+    horizons = _metrics(store, mocker).update_account_metrics()
+
+    written = _totals(store)
+    assert horizons == {'default': _RATED}
+    assert min(day for day, _, _ in written) == _RATED
+    # Not one of the six days is written at nothing.
+    assert [row for row in written if row[1] == 0.0] == []
 
 
 def test_a_line_nobody_ever_quoted_in_a_nameable_unit_is_still_carried(

--- a/tests/test_perf_price_source.py
+++ b/tests/test_perf_price_source.py
@@ -28,8 +28,8 @@ from datetime import date, datetime, timezone
 
 import pytest
 
-from application import ledger
-from application import main
+from conftest import PerfConfigManager
+
 from application import quotes
 from application import store_reads
 from application import workloads
@@ -40,40 +40,6 @@ UTC = timezone.utc
 #: The day every recompute below is pinned to. The series runs to *today*, so a
 #: floating one would change the shape of the assertions tomorrow.
 _TODAY = date(2024, 6, 20)
-
-
-class _ConfigManager:
-    """The surface :meth:`workloads.Workloads._rebuild_series` needs.
-
-    It reads the **store** and the clock and nothing else since #707, so the
-    manager is down to two gestures here: handing the open store out, and the
-    writers' mutex the final upsert takes.
-    """
-
-    def __init__(self, opened):
-        self._store = opened
-
-    @property
-    def store(self):
-        return self._store
-
-    @contextmanager
-    def writing(self):
-        yield self._store
-
-    def current(self):
-        """The published snapshot the perf pass reads its events from (#861).
-
-        It is the ledger: the pass no longer reads ``event`` itself, because a
-        write has just been ingested and published when it runs.
-        """
-        return main.ConfigSnapshot(
-            shares=[], events=ledger.read_events(self._store),
-            accounts=None, cache_key=None)
-
-    def reload(self, force: bool = False):
-        """What the perf pass reads through: the snapshot, rebuilt on demand."""
-        return self.current()
 
 
 class _Recorder:
@@ -127,7 +93,7 @@ def _fixed_today(mocker):
 def _metrics(opened, mocker):
     """A real metrics object over a real store, its reporting currency answered."""
     _fixed_today(mocker)
-    metrics = workloads.Workloads(_ConfigManager(opened))
+    metrics = workloads.Workloads(PerfConfigManager(opened))
     metrics.base_currency = 'EUR'
     return metrics
 

--- a/tests/test_perf_price_source.py
+++ b/tests/test_perf_price_source.py
@@ -28,6 +28,8 @@ from datetime import date, datetime, timezone
 
 import pytest
 
+from application import ledger
+from application import main
 from application import quotes
 from application import store_reads
 from application import workloads
@@ -58,6 +60,16 @@ class _ConfigManager:
     @contextmanager
     def writing(self):
         yield self._store
+
+    def current(self):
+        """The published snapshot the perf pass reads its events from (#861).
+
+        It is the ledger: the pass no longer reads ``event`` itself, because a
+        write has just been ingested and published when it runs.
+        """
+        return main.ConfigSnapshot(
+            shares=[], events=ledger.read_events(self._store),
+            accounts=None, cache_key=None)
 
 
 class _Recorder:

--- a/tests/test_perf_price_source.py
+++ b/tests/test_perf_price_source.py
@@ -131,6 +131,10 @@ def _price(opened, symbol, day, native, converted=None):
         '                         fx_rate) VALUES (?, ?, ?, ?, ?)',
         [symbol, datetime(day.year, day.month, day.day, 17, 0, tzinfo=UTC),
          native, converted, 1.0 if converted is not None else None])
+    # The row goes in by hand, so the gesture that drops the oldest-per-symbol
+    # memo (issue #861) does not run: this fixture is the one place in the tree
+    # that writes ``price_point`` without going through :mod:`quotes`.
+    quotes.forget_oldest_stored()
 
 
 def _ledger(symbols):

--- a/tests/test_perf_price_source.py
+++ b/tests/test_perf_price_source.py
@@ -71,6 +71,10 @@ class _ConfigManager:
             shares=[], events=ledger.read_events(self._store),
             accounts=None, cache_key=None)
 
+    def reload(self, force: bool = False):
+        """What the perf pass reads through: the snapshot, rebuilt on demand."""
+        return self.current()
+
 
 class _Recorder:
     """Every statement the store is handed during a pass, in order.
@@ -143,9 +147,11 @@ def _price(opened, symbol, day, native, converted=None):
         '                         fx_rate) VALUES (?, ?, ?, ?, ?)',
         [symbol, datetime(day.year, day.month, day.day, 17, 0, tzinfo=UTC),
          native, converted, 1.0 if converted is not None else None])
-    # The row goes in by hand, so the gesture that drops the oldest-per-symbol
-    # memo (issue #861) does not run: this fixture is the one place in the tree
-    # that writes ``price_point`` without going through :mod:`quotes`.
+    # The row goes in by hand, so the gesture that moves the oldest-per-symbol
+    # memo on (issue #861) does not run. Several fixtures write ``price_point``
+    # this way and are green only because each inserts before its first read on
+    # that handle; the two in this module and in ``test_perf_job`` run a pass
+    # either side of a write, so they say it themselves.
     quotes.forget_oldest_stored()
 
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -541,10 +541,39 @@ LONG_HELD = (LEDGER_START, TODAY)
 BOUGHT = date(2026, 8, 10)
 
 
-def _horizon(windows, oldest_priced, settled=(), start=LEDGER_START):
+def _horizon(windows, oldest_priced, settled=(), start=LEDGER_START,
+             carried_from=None):
     """The rule, on the ordinary caller's two days: the ledger's first, today."""
     return performance.account_horizon(windows, oldest_priced, settled,
+                                       carried_from=carried_from,
                                        start=start, ceiling=TODAY)
+
+
+def test_a_carried_symbol_blocks_from_its_first_quote_and_not_its_acquisition():
+    """ADR-0004's predicate, clipped to the days it is true of (issue #861).
+
+    A terminal symbol held since 2019 and first quoted in June of that year, in
+    a unit nobody has ever converted: from the first quote on, a number *is*
+    known and its conversion is what is missing, so those days are blocked — the
+    *waiting* state :func:`carrying.carrying_price` refuses to carry. Before it
+    there is no number and none is coming, which is exactly the domain ADR-0004
+    names, and :func:`compute_account` already values those days at the unit
+    cost.
+
+    Blocking from the acquisition threw them away with the rest: the account had
+    **no writable day at all**, where the truth is that it has every day up to
+    the first quote.
+    """
+    quoted = date(2019, 6, 1)
+
+    without = _horizon({"AAPL": LONG_HELD}, {})
+    clipped = _horizon({"AAPL": LONG_HELD}, {}, carried_from={"AAPL": quoted})
+
+    # Nothing writable: the block covers the whole ledger and pushes the first
+    # day past today.
+    assert without == (TODAY + timedelta(days=1), None)
+    # And with the clip, the months before the first quote are the account's.
+    assert clipped == (None, quoted - timedelta(days=1))
 
 
 def test_the_horizon_is_the_day_after_the_last_unpriced_held_day():

--- a/tests/test_replay_perf.py
+++ b/tests/test_replay_perf.py
@@ -427,17 +427,11 @@ def test_the_replay_that_follows_a_write_reads_the_ledger_once(tmp_path, mocker)
     client, opened = _build(tmp_path, mocker)
     runtime = api_module.current_runtime()
 
-    reads = []
-    original = opened.query
-
-    def counting(sql, parameters=None):
-        if sql.startswith('SELECT id, date, event_type'):
-            reads.append(sql)
-        return original(sql, parameters)
-
-    mocker.patch.object(opened, 'query', counting)
+    queried = mocker.spy(opened, 'query')
     main.replay_after_write(runtime)
 
+    reads = [call for call in queried.call_args_list
+             if call.args[0].startswith('SELECT id, date, event_type')]
     assert len(reads) == 1
     # And the series is the one the published events describe, not a stale one.
     assert _days(opened)[0] == date(2024, 1, 10)

--- a/tests/test_replay_perf.py
+++ b/tests/test_replay_perf.py
@@ -410,6 +410,39 @@ def test_the_record_of_a_pass_is_published_under_the_pass_lock(
     assert seen == [False]
 
 
+def test_the_replay_that_follows_a_write_reads_the_ledger_once(tmp_path, mocker):
+    """``replay_after_write`` reads ``event`` **once** (issue #861).
+
+    Its two halves used to read the whole ledger each: ``ingest(force=True)``
+    reads, aggregates, validates and publishes it, and then the perf recompute
+    read it all over again for the same rows. The second **replay** is justified
+    and stays — a ``position`` row is a current state, performance needs every
+    day's — and it now replays the events the ingestion has just published.
+
+    Asserted **on the call**, which is the suite's rule for what the app decided
+    not to do: a query that was not run leaves no row to look at. The counter is
+    put around the replay alone, because the write itself legitimately reads the
+    ledger once more, to prove the ledger it would leave still replays.
+    """
+    client, opened = _build(tmp_path, mocker)
+    runtime = api_module.current_runtime()
+
+    reads = []
+    original = opened.query
+
+    def counting(sql, parameters=None):
+        if sql.startswith('SELECT id, date, event_type'):
+            reads.append(sql)
+        return original(sql, parameters)
+
+    mocker.patch.object(opened, 'query', counting)
+    main.replay_after_write(runtime)
+
+    assert len(reads) == 1
+    # And the series is the one the published events describe, not a stale one.
+    assert _days(opened)[0] == date(2024, 1, 10)
+
+
 def _free_from_another_thread(lock) -> bool:
     """Could a *different* thread take this lock right now?
 

--- a/tests/test_replay_perf.py
+++ b/tests/test_replay_perf.py
@@ -424,7 +424,7 @@ def test_the_replay_that_follows_a_write_reads_the_ledger_once(tmp_path, mocker)
     put around the replay alone, because the write itself legitimately reads the
     ledger once more, to prove the ledger it would leave still replays.
     """
-    client, opened = _build(tmp_path, mocker)
+    _, opened = _build(tmp_path, mocker)
     runtime = api_module.current_runtime()
 
     queried = mocker.spy(opened, 'query')

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -233,6 +233,31 @@ def test_beyond_two_years_only_the_last_point_of_each_day_survives(store):
     assert _series(store) == [_at(1000, 16, 30), _at(999, 17, 0)]
 
 
+def test_a_writer_that_moves_the_oldest_point_moves_the_memo_with_it(store):
+    """The memo answers the store, not the store as it was (issue #861).
+
+    ``quotes.oldest_stored`` is a full scan of the largest table, memoized
+    because its answer moves at the backfill's rhythm — and it feeds
+    ``carrying.backward_anchor``, so a stale answer makes a symbol *terminal* on
+    a series it no longer has. The two writers that genuinely move a symbol's
+    oldest point are here, each in the direction it moves it: the backward pass
+    writing older history, and the ladder dropping every point of an old day but
+    the last. Frozen at either, the app carries a line at cost while real prices
+    are still landing under it, and only another write ever repairs it.
+    """
+    _seed(store, 'AAPL', [_at(400)])
+    assert quotes.oldest_stored(store)['AAPL'] == _at(400)
+
+    # Backward: the pass reaches further into the past.
+    _seed(store, 'AAPL', [_at(900, 9, 0), _at(900, 17, 0)])
+    assert quotes.oldest_stored(store)['AAPL'] == _at(900, 9, 0)
+
+    # And the ladder, forward: past two years the day keeps its last point
+    # alone, so the oldest instant the store holds is the later of the two.
+    quotes.collapse_to_ladder(store, NOW)
+    assert quotes.oldest_stored(store)['AAPL'] == _at(900, 17, 0)
+
+
 def test_the_three_bands_are_aged_in_one_pass_and_never_confused(store):
     """One call, one series, three ages — and each band gets its own rung."""
     _seed(store, 'AAPL', [

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -309,6 +309,33 @@ def test_an_acquisition_dated_in_the_future_has_held_nothing_yet():
     assert tl.holding_window("PEA", "AAPL", TODAY) is None
 
 
+def test_a_line_bought_and_sold_in_full_on_one_day_was_never_held():
+    """A day traded through is not a day held — the answer, and its name (#861).
+
+    ``_snapshot`` keeps **one snapshot per change date**, so a buy and a full
+    sale on the same day leave only the final state, ``quantity = 0``. The loop
+    below therefore never sets ``acquired`` and answers ``None`` — and that is
+    the **right** answer rather than a case that slipped through: a window is
+    made of end-of-day states, and a position at zero has fallen out of the
+    model. What was missing was the docstring naming it, which is the third road
+    to the one absence the method reports.
+
+    The consequence is deliberate: ``account_holding_windows`` drops the symbol,
+    and the horizon never sees it. There is no day to price and none to block.
+    """
+    tl = _replayed([
+        Event(date(2024, 1, 15), EventType.BUY, "AAPL", "Apple", quantity=10,
+              unit_price=100.0, account="PEA"),
+        Event(date(2024, 1, 15), EventType.SELL, "AAPL", "Apple", quantity=10,
+              unit_price=110.0, account="PEA"),
+    ])
+
+    assert tl.holding_window("PEA", "AAPL", TODAY) is None
+    # The events are not lost: the realized gain is on the position, which is
+    # what a round trip leaves behind.
+    assert tl.position_at("PEA", "AAPL", TODAY)['quantity'] == 0
+
+
 def test_a_future_acquisition_after_a_real_one_does_not_move_the_window():
     """The clamp is on the window's **end**, never on the days already held.
 

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -1947,6 +1947,30 @@ def test_a_bare_date_bounds_the_window_in_utc_and_keeps_its_first_day(tmp_path):
     assert [point['t'] for point in inside['points']] == ['2024-06-01', '2024-06-02']
 
 
+def test_a_window_carrying_an_offset_comes_back_in_utc(tmp_path):
+    """The three window routes echo their bounds beside points in `+00:00`.
+
+    `_parse_instant` promised *always returning UTC-aware* and handed an
+    already-aware instant straight back, so `?from=…+02:00` was echoed in
+    `+02:00` next to a `t` in `+00:00` — two clocks in one payload, and the
+    docstring's word not kept. One repair, `instants`, on both halves (#861).
+    """
+    def seed(opened):
+        seed_account_metrics(opened, day=date(2024, 6, 1), total_value=100.0)
+
+    client = build_client(tmp_path, accounts=ACCOUNTS_FILE,
+                          events=ACCOUNTS_EVENTS, seed=seed)
+    window = 'from=2024-06-01T00:00:00%2B02:00&to=2024-06-03T00:00:00%2B02:00'
+
+    for route in ('/api/accounts/pea/history',
+                  '/api/positions/history',
+                  '/api/portfolio-totals/history'):
+        payload = client.get(f'{route}?{window}').get_json()
+
+        assert payload['from'] == '2024-05-31T22:00:00+00:00', route
+        assert payload['to'] == '2024-06-02T22:00:00+00:00', route
+
+
 def test_account_history_rejects_an_inverted_window(tmp_path):
     client = build_client(tmp_path, accounts=ACCOUNTS_FILE,
                           events=ACCOUNTS_EVENTS)

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -2693,6 +2693,26 @@ def test_a_declaration_conflict_keeps_the_conflict_type(tmp_path):
         assert response.get_json()['type'] == problem.TYPE_CONFLICT
 
 
+def test_an_account_id_holding_a_slash_is_refused_by_the_route(tmp_path):
+    """The id is the address, and the four ``<account_id>`` routes stop at a slash.
+
+    Inserted, ``pea/2024`` was unreachable and undeletable: its history, its
+    reassignment, its rename and its removal all name a route Flask's default
+    converter never matches (issue #861).
+    """
+    client = build_client(tmp_path, events=ACCOUNTS_EVENTS,
+                          accounts=ACCOUNTS_FILE)
+
+    refused = client.post('/api/accounts', json={'id': 'pea/2024', 'type': 'PEA'})
+
+    assert refused.status_code == 400
+    body = refused.get_json()
+    assert body['type'] == problem.TYPE_BAD_REQUEST
+    assert '/' in body['detail']
+    listed = client.get('/api/accounts').get_json()['accounts']
+    assert not any(account['id'] == 'pea/2024' for account in listed)
+
+
 def test_a_typed_event_is_exported_like_any_other_row(tmp_path):
     """Provenance is deliberately not exported (issue #710).
 

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -968,7 +968,7 @@ def test_positions_publishes_the_terminality_of_each_symbol(tmp_path):
     assert rows['MSFT']['terminal'] is False
 
 
-def test_two_dashboard_reads_scan_the_price_table_once(tmp_path, monkeypatch):
+def test_two_dashboard_reads_scan_the_price_table_once(tmp_path, mocker):
     """The hottest read stops re-scanning the largest table (issue #861).
 
     `_carried()` asks `quotes.terminal_symbols` which symbols the backward pass
@@ -987,20 +987,16 @@ def test_two_dashboard_reads_scan_the_price_table_once(tmp_path, monkeypatch):
     )
     client, opened = build_client_and_store(tmp_path, events=events)
 
-    scans = []
-    original = opened.query
+    queried = mocker.spy(opened, 'query')
 
-    def counting(sql, parameters=None):
-        if 'min(ts)' in sql and 'price_point' in sql:
-            scans.append(sql)
-        return original(sql, parameters)
-
-    monkeypatch.setattr(opened, 'query', counting)
+    def scans():
+        return [call for call in queried.call_args_list
+                if 'min(ts)' in call.args[0] and 'price_point' in call.args[0]]
 
     assert client.get('/api/positions').status_code == 200
     assert client.get('/api/positions').status_code == 200
 
-    assert len(scans) == 1
+    assert len(scans()) == 1
 
     # And a written point puts it back: the memo is dropped by the writer, so
     # the next read answers on the series that now exists rather than on the
@@ -1008,7 +1004,7 @@ def test_two_dashboard_reads_scan_the_price_table_once(tmp_path, monkeypatch):
     quotes.record_quote(opened, 'AAPL', datetime(2024, 2, 1, tzinfo=timezone.utc), 160.0)
     assert client.get('/api/positions').status_code == 200
 
-    assert len(scans) == 2
+    assert len(scans()) == 2
 
 
 def test_the_table_and_the_curve_agree_on_a_line_being_rebuilt(tmp_path):

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -968,6 +968,49 @@ def test_positions_publishes_the_terminality_of_each_symbol(tmp_path):
     assert rows['MSFT']['terminal'] is False
 
 
+def test_two_dashboard_reads_scan_the_price_table_once(tmp_path, monkeypatch):
+    """The hottest read stops re-scanning the largest table (issue #861).
+
+    `_carried()` asks `quotes.terminal_symbols` which symbols the backward pass
+    has finished with, and that used to run
+    `SELECT symbol, min(ts) FROM price_point GROUP BY symbol` on **every**
+    `/api/positions` — a full scan, `price_point` carrying no index by design
+    (ADR-0007). Its answer moves at the backfill's rhythm, never at the
+    reader's.
+
+    Asserted **on the call**, which is the suite's rule for what the app decided
+    *not* to do: a query that did not run leaves no row to look at.
+    """
+    events = (
+        "date,event_type,symbol,name,quantity,unit_price,fee\n"
+        "2024-01-15,BUY,AAPL,Apple Inc,10,150.00,0\n"
+    )
+    client, opened = build_client_and_store(tmp_path, events=events)
+
+    scans = []
+    original = opened.query
+
+    def counting(sql, parameters=None):
+        if 'min(ts)' in sql and 'price_point' in sql:
+            scans.append(sql)
+        return original(sql, parameters)
+
+    monkeypatch.setattr(opened, 'query', counting)
+
+    assert client.get('/api/positions').status_code == 200
+    assert client.get('/api/positions').status_code == 200
+
+    assert len(scans) == 1
+
+    # And a written point puts it back: the memo is dropped by the writer, so
+    # the next read answers on the series that now exists rather than on the
+    # one that did.
+    quotes.record_quote(opened, 'AAPL', datetime(2024, 2, 1, tzinfo=timezone.utc), 160.0)
+    assert client.get('/api/positions').status_code == 200
+
+    assert len(scans) == 2
+
+
 def test_the_table_and_the_curve_agree_on_a_line_being_rebuilt(tmp_path):
     """The two ends, on one line of one install — the ticket's own criterion.
 


### PR DESCRIPTION
## What this is

The eleven findings of #861 — ten, as the body counts them — landed on one
branch, one commit per finding, with the two domain questions decided as the
agent brief settled them with the owner.

Closes #861

## The ten

**Correctness**

- **An account id no route can carry is refused before it is written.**
  `pea/2024` inserted and was then unreachable by all four `<account_id>`
  routes — Flask's default converter stops at a slash — and ADR-0013 refuses
  the cascade that would have cleaned it up. The rule names `/`, `.` and `..`
  (a URL resolves its dot segments away before the request is sent), lives in
  `accounts.refuse_unaddressable_id`, and is called from the writer **and**
  from `entries.judge`, so the import preview refuses what the confirmed
  import refuses.
- **`fx._as_date` reads a naive instant as UTC**, through `instants.utc` rather
  than `astimezone`, which read it as the machine's local time. Pinned by a
  test that runs five hours west of UTC.
- **A window's bounds come back in `+00:00`.** `_parse_instant` promised
  *always returning UTC-aware* and handed an already-aware instant straight
  back; the three window routes now serialize through `instants.iso`.
- **The front knows `/problems/invalid-setting`**, which fell back to *an
  unexpected error* — the one sentence certainly untrue of a refusal by design.
  `/problems/foreign-origin` stays out, and a test says so.

**Accessibility**

- **`RebuildBlock` is a named region** like the six other settings cards. Seven
  regions, no hole where the page's heaviest gesture lives.

**Cost**

- **The oldest point per symbol is scanned at the backfill's rhythm**, not on
  every dashboard load. A memo keyed on `(store, generation)` — the generation
  because `lru_cache` inserts when the call *returns*, so a clear landing
  mid-scan would clear nothing. Dropped by the four gestures in `quotes.py`
  that can move the answer. No index on `price_point` (ADR-0007).
- **The replay that follows a write reads the ledger once.** `rebuild_series`
  replays the events the ingestion has just published. The second *replay*
  stays — a `position` row is a current state, performance needs every day's —
  and it reads through `reload`, which refuses a snapshot the ingestion only
  *kept* because its own read failed.
- **An account is asked only about the symbols it has touched.** The timeline
  keys its snapshots by `(account, symbol)` and already knew.

**Decided**

- **A day traded through is not a day held.** `holding_window` returning `None`
  for a same-day round trip is the right answer; the docstring now folds the
  three roads into the one absence it reports, and a test pins it. No behaviour
  change.
- **A terminal line quoted late carries the days before its first quote.**
  ADR-0004's predicate applied to its own domain: `compute_account` already
  valued those days at the carrying price, and only `account_horizon` refused
  them. It now blocks from the symbol's first quoted day. The *waiting* case —
  quoted from one day, converted only from a later one — **stays blocked**, and
  a test guards that.

`CONTEXT.md` carries the new *Holding window* entry and the reworded *Horizon*.
No ADR: the second decision applies ADR-0004 to its stated domain.

## Beyond the ticket

An adversarial review of the branch found nine further defects in the work
itself, repaired in four commits: the memo's lost-invalidation race, a clip
that survived being reverted (now pinned where it is observable), the dot
segments, the dry-run/import parity, the stale-snapshot path, the untested
invalidation of `record_history` and `collapse_to_ladder`, an uninstrumented
fixture twin, a `tzset` leak into the rest of the suite, and three commit types
this repository does not declare.

A complexity pass then took 194 lines out for 72 in: one `PerfConfigManager` in
`conftest` where four byte-identical fakes stood, `mocker.spy` where two
hand-rolled counting closures stood, and three comment blocks that outweighed
the statement they explained.

## Checks

`uv run pytest tests/` (1604), `uv run flake8 src/application src/api
--ignore=E501`, `.github/scripts/conventions.sh`, `pnpm lint`, `pnpm test`
(796) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - History date ranges are now consistently returned in UTC.
  - Invalid account IDs are rejected before imports or account creation, including previews.
  - Same-day buy-and-sell activity is no longer treated as a holding period.
  - Performance horizons correctly handle securities first priced after acquisition.
  - Repeated dashboard reads are more efficient while updates refresh results promptly.

- **Accessibility**
  - The rebuilding settings section is now a named, navigable region.

- **Documentation**
  - Updated glossary definitions for holding windows and horizons.

- **Error Handling**
  - Added localized messages for settings values that are not accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->