### PR TITLE
fix(api): a refusal by design is neither fault (#856)

### DIFF
--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -38,8 +38,13 @@ def create_app(runtime: main.Runtime) -> Flask:
         Everywhere else werkzeug's own page stands: returning ``exc`` is Flask's
         way of saying *the default was right* — the ``404`` on ``/metrics`` is a
         door closed to a scraper (ADR-0033), not a problem+json for a reader.
+
+        ``/api`` is read as a **path segment**, which is the whole of the test
+        below it: a prefix match claims ``/apiary`` too, and the SPA serves
+        every path this app does not know, so that is a page of the front being
+        answered in the API's vocabulary.
         """
-        if not request.path.startswith('/api'):
+        if request.path != '/api' and not request.path.startswith('/api/'):
             return exc
         return refused(exc)
 

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -2,12 +2,13 @@
 from pathlib import Path
 from typing import Optional
 
-from flask import Flask, abort, send_from_directory
+from flask import Flask, abort, request, send_from_directory
+from werkzeug.exceptions import HTTPException
 
 from application import main
 from application import uploads
 from api import problem
-from api.api import api_bp
+from api.api import api_bp, refused
 from api.health import health_bp
 
 _runtime: Optional[main.Runtime] = None
@@ -22,6 +23,25 @@ def create_app(runtime: main.Runtime) -> Flask:
     flask_app.config['MAX_CONTENT_LENGTH'] = uploads.MAX_BODY_BYTES
     flask_app.register_blueprint(health_bp)
     flask_app.register_blueprint(api_bp)
+
+    @flask_app.errorhandler(HTTPException)
+    def _on_routing_refusal(exc: HTTPException):
+        """What werkzeug decides **before** a blueprint exists (#856).
+
+        A routing failure has no endpoint and therefore no blueprint, so
+        ``api_bp``'s own handler cannot see one: ``POST /api/anything`` matches
+        the catch-all's path and not its method, and came back as werkzeug's
+        HTML ``405`` — which the front reads as *not even the app answered*,
+        about a routing mistake the app answered perfectly well. Under ``/api``
+        it goes through the same translation as a refusal raised inside a view.
+
+        Everywhere else werkzeug's own page stands: returning ``exc`` is Flask's
+        way of saying *the default was right* — the ``404`` on ``/metrics`` is a
+        door closed to a scraper (ADR-0033), not a problem+json for a reader.
+        """
+        if not request.path.startswith('/api'):
+            return exc
+        return refused(exc)
 
     @flask_app.get('/')
     @flask_app.get('/<path:path>')

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -35,12 +35,13 @@ from application.store_reads import PortfolioReader, chart_window
 from api.problem import (
     GESTURE_REMOVE,
     GESTURE_WRITE,
+    TYPE_INTERNAL,
     bad_request,
     conflict,
     entry_gone,
     foreign_origin,
-    http_refusal,
     internal_error,
+    problem,
     not_found,
     storage_unavailable,
     too_large,
@@ -162,11 +163,6 @@ def _on_error(exc: Exception):
     return internal_error(str(exc))
 
 
-#: The one route a ``413`` is *about a file* on — ``MAX_CONTENT_LENGTH`` is
-#: app-wide and every other route it stops is carrying JSON.
-UPLOAD_ENDPOINT = 'api.import_events'
-
-
 def refused(exc: HTTPException):
     """An ``HTTPException`` as the status it already is (#856).
 
@@ -178,14 +174,19 @@ def refused(exc: HTTPException):
     an oversized JSON body would name a limit that body never crossed, so
     anywhere but the upload the generic translation answers.
 
-    Any other code keeps its status rather than being flattened to ``500``: the
-    reader gets the *unexpected error* sentence, which is true of it, over a
-    status that is not.
+    That one keeps the status rather than flattening it to ``500``, under
+    :data:`TYPE_INTERNAL`: the front branches on ``type`` alone (ADR-0024) and
+    has no sentence for a refusal nothing here arranged, so it says *an
+    unexpected error* — which is true of it — over a status that is not.
+
+    ``exc.code`` and ``exc.description`` are read straight: Flask returns an
+    ``HTTPException`` whose code is ``None`` before any handler is consulted,
+    and werkzeug carries a description on the class.
     """
     logger.warning(f"API refusal on {request.path}: {exc}")
-    if exc.code == 413 and request.endpoint == UPLOAD_ENDPOINT:
+    if exc.code == 413 and request.endpoint == 'api.import_events':
         return too_large(uploads.too_large_detail(), uploads.MAX_UPLOAD_BYTES)
-    return http_refusal(exc.code or 500, exc.name, exc.description or str(exc))
+    return problem(exc.code, exc.name, exc.description, TYPE_INTERNAL)
 
 
 @api_bp.get('/portfolio/movers')

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -7,6 +7,7 @@ from urllib.parse import urlsplit
 
 import duckdb
 from flask import Blueprint, Response, jsonify, request
+from werkzeug.exceptions import HTTPException
 from logfmt_logger import getLogger
 
 from application import accounts as accounts_module
@@ -38,6 +39,7 @@ from api.problem import (
     conflict,
     entry_gone,
     foreign_origin,
+    http_refusal,
     internal_error,
     not_found,
     storage_unavailable,
@@ -127,11 +129,63 @@ def _refuse_a_foreign_origin():
 
 @api_bp.errorhandler(Exception)
 def _on_error(exc: Exception):
-    """Turn anything a route raises into problem+json."""
+    """Turn anything a route raises into problem+json.
+
+    **Three answers, not two** (#856). *A fault of the store* and *a fault of
+    ours* were the whole of it, and a third thing reaches here: a refusal
+    werkzeug itself decided, which is neither. Flask looks an ``HTTPException``
+    up by code and then by MRO, so with nothing registered for ``413`` the walk
+    landed on the ``Exception`` below and answered *an unexpected error* — the
+    invitation to file a bug report — about the one bound that can stop a
+    chunked upload, whose sentence was already written
+    (:func:`uploads.too_large_detail`).
+
+    The ``HTTPException`` branch therefore comes first, and it does not log a
+    traceback: a refusal by design is not an incident.
+
+    **What werkzeug raises while *routing* cannot arrive here at all**, and that
+    is why :func:`refused` is a function rather than a branch: a routing failure
+    has no endpoint, so it has no blueprint, so a blueprint handler is
+    structurally unable to see it. ``GET /api/nothing`` is answered by the SPA
+    catch-all in :mod:`api` — ``problem.not_found``, the ``/problems/not-found``
+    the front knows — because that rule matches the path; ``POST`` on the same
+    path matches no method and is werkzeug's ``405``, which :mod:`api` hands to
+    :func:`refused` from an **app-level** handler. Every ``/api`` answer is
+    problem+json, and the two halves of that sentence are held in two places
+    because Flask's dispatch puts them there.
+    """
+    if isinstance(exc, HTTPException):
+        return refused(exc)
     logger.error(f"API error on {request.path}: {exc}", exc_info=True)
     if isinstance(exc, (store_module.StoreUnavailable, duckdb.Error)):
         return storage_unavailable(str(exc))
     return internal_error(str(exc))
+
+
+#: The one route a ``413`` is *about a file* on — ``MAX_CONTENT_LENGTH`` is
+#: app-wide and every other route it stops is carrying JSON.
+UPLOAD_ENDPOINT = 'api.import_events'
+
+
+def refused(exc: HTTPException):
+    """An ``HTTPException`` as the status it already is (#856).
+
+    ``413`` on the upload is the one this app *arranged* — ``MAX_CONTENT_LENGTH``
+    is the third of the three bounds ``uploads`` names, the only one that sees a
+    body making no length declaration — so it is answered with the same problem
+    the route's own check answers, ``limit`` member included. The bound is
+    app-wide and the *sentence* is not: **a file may carry at most 8 MiB** about
+    an oversized JSON body would name a limit that body never crossed, so
+    anywhere but the upload the generic translation answers.
+
+    Any other code keeps its status rather than being flattened to ``500``: the
+    reader gets the *unexpected error* sentence, which is true of it, over a
+    status that is not.
+    """
+    logger.warning(f"API refusal on {request.path}: {exc}")
+    if exc.code == 413 and request.endpoint == UPLOAD_ENDPOINT:
+        return too_large(uploads.too_large_detail(), uploads.MAX_UPLOAD_BYTES)
+    return http_refusal(exc.code or 500, exc.name, exc.description or str(exc))
 
 
 @api_bp.get('/portfolio/movers')

--- a/src/api/problem.py
+++ b/src/api/problem.py
@@ -114,6 +114,18 @@ def foreign_origin(detail: str):
     return problem(403, 'Foreign origin', detail, TYPE_FOREIGN_ORIGIN)
 
 
+def http_refusal(status: int, title: str, detail: str):
+    """Any ``HTTPException`` but the ``413``, kept at the status it already has.
+
+    The type is :data:`TYPE_INTERNAL` because it is the honest one: the front
+    branches on ``type`` alone (ADR-0024) and has no sentence for a refusal
+    nothing here arranged, so it says *an unexpected error* — which is what a
+    ``406`` out of a route that never meant to raise one is. The status is not
+    flattened with it: a client reading the code learns more than *500* (#856).
+    """
+    return problem(status, title, detail, TYPE_INTERNAL)
+
+
 def internal_error(detail: str):
     """500 — the last resort, for what no route anticipated."""
     return problem(500, 'Internal error', detail, TYPE_INTERNAL)
@@ -123,6 +135,6 @@ __all__ = [
     'problem', 'storage_unavailable', 'not_found', 'bad_request', 'conflict',
     'unreplayable', 'unprocessable', 'unprocessable_parameter',
     'unprocessable_entry', 'unprocessable_file', 'too_large', 'foreign_origin',
-    'internal_error',
+    'http_refusal', 'internal_error',
     'CONTENT_TYPE', 'GESTURE_WRITE', 'GESTURE_REMOVE',
 ]

--- a/src/api/problem.py
+++ b/src/api/problem.py
@@ -114,18 +114,6 @@ def foreign_origin(detail: str):
     return problem(403, 'Foreign origin', detail, TYPE_FOREIGN_ORIGIN)
 
 
-def http_refusal(status: int, title: str, detail: str):
-    """Any ``HTTPException`` but the ``413``, kept at the status it already has.
-
-    The type is :data:`TYPE_INTERNAL` because it is the honest one: the front
-    branches on ``type`` alone (ADR-0024) and has no sentence for a refusal
-    nothing here arranged, so it says *an unexpected error* — which is what a
-    ``406`` out of a route that never meant to raise one is. The status is not
-    flattened with it: a client reading the code learns more than *500* (#856).
-    """
-    return problem(status, title, detail, TYPE_INTERNAL)
-
-
 def internal_error(detail: str):
     """500 — the last resort, for what no route anticipated."""
     return problem(500, 'Internal error', detail, TYPE_INTERNAL)
@@ -135,6 +123,6 @@ __all__ = [
     'problem', 'storage_unavailable', 'not_found', 'bad_request', 'conflict',
     'unreplayable', 'unprocessable', 'unprocessable_parameter',
     'unprocessable_entry', 'unprocessable_file', 'too_large', 'foreign_origin',
-    'http_refusal', 'internal_error',
+    'internal_error',
     'CONTENT_TYPE', 'GESTURE_WRITE', 'GESTURE_REMOVE',
 ]

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -909,17 +909,87 @@ def test_a_security_named_once_in_a_file_is_named_on_every_row_of_it(tmp_path):
         ("Apple Inc",), ("Apple Inc",)]
 
 
+def _upload_undeclared(client, body, filename="2024.csv"):
+    """The upload a browser does not make: a body with **no ``Content-Length``**.
+
+    ``wsgi.input_terminated`` is what a WSGI server sets when it, and not a
+    header, terminates the stream — the shape a chunked request has by the time
+    werkzeug sees it, and the only shape in which ``MAX_CONTENT_LENGTH`` is the
+    bound that speaks: ``oversize`` reads a declaration this request does not
+    make, and ``uploads.read``'s own bound is past the parser that never
+    finishes.
+    """
+    boundary = b"----suivibourse"
+    envelope = (b"--" + boundary + b"\r\n"
+                b'Content-Disposition: form-data; name="file"; filename="'
+                + filename.encode('utf-8') + b'"\r\n'
+                b"Content-Type: text/csv\r\n\r\n"
+                + body + b"\r\n--" + boundary + b"--\r\n")
+    return client.post(
+        '/api/events/import',
+        data=io.BytesIO(envelope),
+        content_type='multipart/form-data; boundary=' + boundary.decode('ascii'),
+        headers={'Transfer-Encoding': 'chunked'},
+        environ_overrides={'CONTENT_LENGTH': '', 'wsgi.input_terminated': True})
+
+
 def test_a_body_that_declares_no_length_is_still_bounded(tmp_path):
     """The bound that stops bytes already in flight, and it is werkzeug's.
 
     ``oversize`` reads a *declaration*, which a chunked upload does not make;
     without ``MAX_CONTENT_LENGTH`` the whole body is spooled to disk before
     anything here can refuse it.
+
+    And the request is **issued** (#856). What stood here was an assert on the
+    config value, which is why nobody saw that the ``413`` werkzeug raises for
+    it — lazily, inside the view, while the parser reads ``request.files`` —
+    walked the MRO to ``errorhandler(Exception)`` and came back a ``500``
+    ``/problems/internal-error``: the bug-report invitation, on a refusal this
+    app arranged and had already written the sentence for.
     """
-    client = build_client(tmp_path)
+    client, opened = build_client_and_store(tmp_path)
 
     assert client.application.config['MAX_CONTENT_LENGTH'] == uploads.MAX_BODY_BYTES
     assert uploads.MAX_BODY_BYTES > uploads.MAX_UPLOAD_BYTES
+
+    response = _upload_undeclared(client, b"x" * (uploads.MAX_BODY_BYTES + 4096))
+
+    assert response.status_code == 413
+    assert response.mimetype == problem.CONTENT_TYPE
+    payload = response.get_json()
+    assert payload['type'] == problem.TYPE_TOO_LARGE
+    assert payload['limit'] == uploads.MAX_UPLOAD_BYTES
+    assert '8 MiB' in payload['detail']
+    assert opened.query('SELECT count(*) FROM event') == [(0,)]
+
+    # The same road with a legal file, so the refusal above is the bound
+    # speaking and not a body nothing ever read.
+    assert _upload_undeclared(client, ONE_BUY.encode('utf-8')).status_code == 201
+    assert opened.query('SELECT count(*) FROM event') == [(1,)]
+
+
+def test_the_bound_is_app_wide_and_its_file_sentence_is_not(tmp_path):
+    """``MAX_CONTENT_LENGTH`` stops every route; only one of them is a file.
+
+    A ``413`` raised on ``POST /api/events`` is the same werkzeug bound, and
+    answering it with *a file may carry at most 8 MiB* — plus a ``limit`` naming
+    a file's bound the body never met — would describe a gesture the reader did
+    not make. The status is the true part and it is kept; the sentence falls
+    back to the generic one.
+    """
+    client = build_client(tmp_path)
+
+    response = client.post(
+        '/api/events',
+        data=b'{"notes": "' + b'x' * (uploads.MAX_BODY_BYTES + 1024) + b'"}',
+        content_type='application/json')
+
+    assert response.status_code == 413
+    assert response.mimetype == problem.CONTENT_TYPE
+    payload = response.get_json()
+    assert payload['type'] == problem.TYPE_INTERNAL
+    assert 'limit' not in payload
+    assert 'MiB' not in payload['detail']
 
 
 def test_a_file_of_exactly_the_bound_is_not_refused_by_its_envelope(tmp_path):

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -2000,9 +2000,13 @@ def test_every_api_answer_is_problem_json_whatever_the_verb(tmp_path):
         assert response.get_json()['type'] == '/problems/internal-error'
 
     # And the door closed to a scraper stays closed the way it was (ADR-0033):
-    # outside `/api`, werkzeug's own page is the right answer.
-    assert client.get('/metrics').status_code == 404
-    assert client.get('/metrics').mimetype == 'text/html'
+    # outside `/api`, werkzeug's own page is the right answer. `/apiary` is
+    # there because `/api` is a **segment**: a prefix match would answer a page
+    # of the front in the API's vocabulary.
+    closed = client.get('/metrics')
+    assert closed.status_code == 404
+    assert closed.mimetype == 'text/html'
+    assert client.post('/apiary').mimetype == 'text/html'
 
 
 def test_a_bare_date_bounds_the_window_in_utc_and_keeps_its_first_day(tmp_path):

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -21,6 +21,7 @@ import json
 import openpyxl
 import pytest
 from apscheduler.schedulers.background import BackgroundScheduler
+from werkzeug.exceptions import NotAcceptable
 
 from application import accounts as accounts_module
 from application import advisories
@@ -1945,6 +1946,63 @@ def test_a_fault_of_ours_is_a_500_and_not_a_storage_failure(tmp_path, mocker):
     assert response.status_code == 500
     assert response.mimetype == 'application/problem+json'
     assert response.get_json()['type'] == '/problems/internal-error'
+
+
+def test_a_refusal_werkzeug_decided_keeps_its_status(tmp_path, mocker):
+    """The third answer the handler owed (#856).
+
+    Flask looks an `HTTPException` up by code and *then* by MRO, so with nothing
+    registered for it the walk reached `errorhandler(Exception)` and every one
+    of them came out `500` — the status the front reads as *file a bug report*,
+    said about a refusal that was deliberate. The status is what a client
+    outside the browser has to go on, and flattening it threw away the only fact
+    the exception carried.
+
+    `406` here because nothing in this app raises one: what is asserted is the
+    generic translation, not the `413` the next test owns.
+    """
+    client = build_client(tmp_path, accounts=ACCOUNTS_FILE,
+                          events=ACCOUNTS_EVENTS)
+    mocker.patch.object(portfolio_view, 'build_positions',
+                        side_effect=NotAcceptable())
+
+    response = client.get('/api/positions')
+
+    assert response.status_code == 406
+    assert response.mimetype == 'application/problem+json'
+    assert response.get_json()['type'] == '/problems/internal-error'
+
+
+def test_every_api_answer_is_problem_json_whatever_the_verb(tmp_path):
+    """The decision #856 asked to be written down, and both halves of it.
+
+    A `GET` on an unknown `/api` path matches the SPA catch-all and gets
+    `problem.not_found` — the `/problems/not-found` the front already knows.
+    Any other verb matches that rule's **path and not its method**, so werkzeug
+    raises `405` *while routing*: no endpoint, therefore no blueprint, therefore
+    `api_bp`'s handler is structurally unable to see it, and what came back was
+    werkzeug's HTML page. The front reads a body that is not problem+json as
+    *not even the app answered* (`api.ts`), which is a false thing to say about
+    a routing mistake — hence the app-level handler, and hence the two verbs
+    below in one test: they are one decision.
+    """
+    client = build_client(tmp_path)
+
+    unknown = client.get('/api/no-such-thing')
+    assert unknown.status_code == 404
+    assert unknown.mimetype == 'application/problem+json'
+    assert unknown.get_json()['type'] == '/problems/not-found'
+
+    for response in (client.post('/api/no-such-thing'),
+                     client.post('/api/positions')):
+        assert response.status_code == 405
+        assert response.mimetype == 'application/problem+json'
+        assert response.get_json()['type'] == '/problems/internal-error'
+
+    # And the door closed to a scraper stays closed the way it was (ADR-0033):
+    # outside `/api`, werkzeug's own page is the right answer.
+    assert client.get('/metrics').status_code == 404
+    assert client.get('/metrics').mimetype == 'text/html'
 
 
 def test_a_bare_date_bounds_the_window_in_utc_and_keeps_its_first_day(tmp_path):


### PR DESCRIPTION
Closes #856.

## Ce qui n'allait pas

`api_bp.errorhandler(Exception)` connaissait deux réponses — *une panne du store*, *une faute à nous*. Flask cherche un handler d'`HTTPException` par code **puis par MRO** : rien n'étant enregistré pour `413`, la marche atterrissait sur `Exception` et le `MAX_CONTENT_LENGTH` qui existe précisément pour arrêter un upload chunké ressortait en `500` `/problems/internal-error` — l'invitation à ouvrir un rapport de bug, sur un refus délibéré dont la phrase était déjà écrite (`uploads.too_large_detail()`). La réponse perdait aussi le membre `limit` que le front lit pour refuser le fichier dans le navigateur.

Le test qui couvrait la borne assertait la **valeur de configuration** sans jamais émettre la requête ; c'est pour ça que personne ne l'a vu.

## Le correctif

- **`_on_error`** : branche `HTTPException` en tête, et sans `exc_info` — un refus voulu n'est pas un incident.
- **`refused()`** : `413` sur la route d'import → `too_large(...)` avec son `limit`. La borne est *app-wide* et la phrase ne l'est pas : « a file may carry at most 8 MiB » sur un corps JSON nommerait une limite que ce corps n'a jamais franchie, donc partout ailleurs c'est la traduction générique, qui **conserve le statut** au lieu de l'aplatir en `500`.
- **Handler au niveau app** (`src/api/__init__.py`) : ce que werkzeug lève *pendant le routage* n'atteint aucun blueprint. Le catch-all SPA est `@flask_app.get`, donc `POST /api/n-importe-quoi` matche son chemin et pas sa méthode → `405` en page HTML, que le front lit comme *même pas l'application n'a répondu*. Hors `/api`, `return exc` : le `404` de `/metrics` reste la porte fermée d'ADR-0033.

## Les critères, tenus par des requêtes émises

- `test_a_body_that_declares_no_length_is_still_bounded` — réécrit : corps chunké (`wsgi.input_terminated`, aucun `Content-Length`), `413` `/problems/payload-too-large` avec `limit` ; puis **le même chemin avec un fichier légal en `201`**, pour que le refus soit la borne qui parle et non un corps que personne ne lit.
- `test_every_api_answer_is_problem_json_whatever_the_verb` — le `404` du catch-all *et* le `405` du routage, plus `/metrics` inchangé.
- `test_a_refusal_werkzeug_decided_keeps_its_status` — la traduction générique garde son code.
- `test_the_bound_is_app_wide_and_its_file_sentence_is_not` — pas de `limit`, pas de phrase de fichier sur `POST /api/events`.

`flake8`, `.github/scripts/conventions.sh` et `uv run pytest tests/` (1607) sont verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API errors now consistently return structured `application/problem+json` responses while preserving the correct HTTP status.
  * Oversized uploads, including requests without a declared content length, are correctly rejected with a `413` response and relevant size details.
  * Invalid API routes and unsupported methods now return consistent problem responses.
  * Non-API error pages retain their existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->