### PR TITLE
fix(scrape): the re-arm is the last thing that puts a symbol back (#855)

### DIFF
--- a/src/application/scrape.py
+++ b/src/application/scrape.py
@@ -307,7 +307,24 @@ class ScrapeWorkload:
                 error=f"{type(exc).__name__}: {exc}",
             ))
         finally:
-            if self.facade.scheduler is not None and \
-                    symbol in self.facade._held_symbols():
-                arm_now = now if injected_now else datetime.now(timezone.utc)
-                self.facade._arm_symbol(symbol, next_delay, arm_now)
+            # The only thing that puts the symbol back, so neither the read nor
+            # the arming may escape into APScheduler (issue #855). A read that
+            # fails re-arms all the same: an arming too many writes nothing, a
+            # missing arming costs the symbol.
+            if self.facade.scheduler is not None:
+                try:
+                    still_held = symbol in self.facade._held_symbols()
+                except Exception as e:
+                    app_logger.error(
+                        f"Failed to read the held symbols after the pass for "
+                        f"{symbol}: {e} — re-arming anyway")
+                    still_held = True
+                if still_held:
+                    try:
+                        self.facade._arm_symbol(
+                            symbol, next_delay,
+                            now if injected_now else datetime.now(timezone.utc))
+                    except Exception as e:
+                        app_logger.error(
+                            f"Failed to re-arm the scrape job for {symbol}: {e} "
+                            f"— it leaves the rotation until the next reconcile")

--- a/tests/test_scheduling_wiring.py
+++ b/tests/test_scheduling_wiring.py
@@ -333,6 +333,40 @@ def test_inflight_scrape_racing_with_cleanup_does_not_resurrect_counter(
 
 
 # ---------------------------------------------------------------------------
+# The re-arm is the last thing that puts a symbol back (#855)
+# ---------------------------------------------------------------------------
+
+def test_scrape_symbol_rearms_although_the_held_read_raised(store, mocker):
+    """*I could not find out* is not *no longer held*, and it re-arms.
+
+    Nothing else puts the symbol back: the job is a one-shot ``date`` trigger.
+    """
+    m = _metrics([_share("AAPL")], store, mocker)
+    mocker.patch.object(m, "_fetch_ticker_data", return_value=(None, None))
+    mocker.patch.object(m, "_held_symbols",
+                        side_effect=RuntimeError("the configuration is unreadable"))
+
+    m._scrape_symbol("AAPL", now=NOW)
+
+    assert m.scheduler.add_job.call_args.kwargs["id"] == _scrape_job_id("AAPL")
+    assert m.scheduler.add_job.call_args.kwargs["run_date"] == NOW + timedelta(seconds=120)
+
+
+def test_scrape_symbol_failed_rearm_does_not_escape_into_apscheduler(
+        store, fake_ticker, mocker, monkeypatch):
+    """A jobstore refusal is logged, not raised: the pass itself still stands."""
+    m = _metrics([_share()], store, mocker)
+    monkeypatch.setattr(market.yf, "Ticker", lambda s: fake_ticker(market_state="REGULAR"))
+    mocker.patch.object(m, "_arm_symbol",
+                        side_effect=RuntimeError("the jobstore refused the job"))
+
+    m._scrape_symbol("AAPL", now=NOW)   # must not raise
+
+    assert _prices(store) == [185.0]
+    assert m.recorder.scrape_of("AAPL").verdict == runtime_state.SCRAPE_WROTE
+
+
+# ---------------------------------------------------------------------------
 # Perf recompute — its own interval job, ungated (#618, #707)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #855.

## What was wrong

`scrape_symbol`'s `finally` was the only scheduler contact in the tree with no
guard, and the module's own docstring states what that costs: the job is a
one-shot `date` trigger, APScheduler drops it from the store as it dispatches,
so the re-arm is the **only** thing that puts the symbol back.

Both halves could raise:

- `_held_symbols()` reaches `config_manager.current()`, which falls back to a
  full `reload()` when nothing is published — `EventValidationError`,
  `AggregationError` or `duckdb.Error`;
- `_arm_symbol` raises on a jobstore refusal or a scheduler shutting down.

Either escaped into APScheduler, which logs and has nothing left to fire for
that symbol. And v5 has no timer calling `reconcile_jobs` since the drop folder
left (#697), so recovery needed a restart or an unrelated write to the ledger.
What the reader saw: a line whose price freezes, with nothing saying so.

## The fix

The three neighbours' shape — `reconcile_jobs`, `rearm_regular_scrapes`,
`_reschedule_interval_job` — applied here: the read and the arming each under
their own `try/except` that logs. *No longer held* and *I could not find out*
are not the same case, and the second re-arms: an arming too many writes
nothing (`holdings` is empty) and `reconcile_jobs` prunes it at the next write,
whereas a missing arming is picked up by nothing at all.

## Held on

Two tests on `test_scheduling_wiring.py`'s APScheduler spy:

- the job is re-armed although `_held_symbols` raised;
- a refused `add_job` is logged rather than raised, and the pass itself stands
  (the point is written, the verdict is `SCRAPE_WROTE`).

`uv run flake8 src/application src/api --ignore=E501` clean,
`.github/scripts/conventions.sh` exit 0, `uv run pytest tests/` 1609 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of scheduled symbol scraping when configuration data cannot be read.
  - Scraping jobs now continue to be scheduled at the standard interval when held-symbol status is unavailable.
  - Scheduling errors are handled without interrupting completed scrape results, ensuring collected price data remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->