### PR TITLE
feat(accounts): the account type stops being a question (#916)

### DIFF
--- a/.github/workflows/renovate-approve.yml
+++ b/.github/workflows/renovate-approve.yml
@@ -1,0 +1,27 @@
+name: "Renovate auto-approve"
+
+# `autoApprove` de Renovate ne vaut que sur Azure, Gerrit et GitLab — c'est
+# l'ancien `azureAutoApprove`. Sur GitHub l'approbation que `master` exige doit
+# venir d'un acteur du dépôt : c'est ce job, et l'approbation de
+# github-actions[bot] compte pour la règle de branche.
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [master]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  approve:
+    name: Renovate approval
+    if: github.event.pull_request.user.login == 'renovate[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      # `dismiss_stale_reviews` est armé sur master : chaque rebase de Renovate
+      # efface l'approbation, d'où le `synchronize` au-dessus.
+      - run: gh pr review "$PR" --approve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}

--- a/docs/adr/0043-the-account-type-stops-being-a-question.md
+++ b/docs/adr/0043-the-account-type-stops-being-a-question.md
@@ -122,11 +122,14 @@ that matters is handed to it.
 
 ## Consequences
 
-- **The account id returns to the accounts page as the subtitle, reversing
+- **The account id returns to the accounts page, in the slot the type held, reversing
   [#838](https://github.com/pbrissaud/suivi-bourse/issues/838).** That ticket removed it
   saying the page heads an account with *what the owner called it and what kind it is*; only
   one of the two is left, and the id is the half that does concrete work — it is what the
-  owner writes in the `account` column of an import file.
+  owner writes in the `account` column of an import file. **Beside the name, never beneath
+  it**: the drawing puts this value on the heading's own line — inline after a `·` on the
+  detail, at the far end of a `justify-between` row on the rail — so what changes is which
+  value sits there and nothing about where.
 - **`wrapper` enters `CONTEXT.md`, and it is the only word this adds.** ADR-0042 already
   uses it three times as though it were defined. The shortcut gets no term of its own: it is
   not stored, does not survive the form, and naming it would promise a concept where there

--- a/renovate.json
+++ b/renovate.json
@@ -8,8 +8,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true,
-      "autoApprove": true
+      "automerge": true
     },
     {
       "matchFileNames": ["pyproject.toml", "Dockerfile"],

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -380,7 +380,7 @@ def create_account():
         with runtime.config_manager.writing() as opened:
             with opened.transaction():
                 account = accounts_module.create_account(
-                    opened, body.get('id'), body.get('type'), body.get('label'))
+                    opened, body.get('id'), body.get('label'))
                 if _flag(body.get('reassign')):
                     reassignment.reassign_unassigned(opened, account.id)
     except accounts_module.DuplicateAccount as exc:
@@ -423,9 +423,12 @@ def update_account(account_id: str):
     runtime = current_runtime()
     try:
         with runtime.config_manager.writing() as opened:
+            # A `type` member is **read by nothing** rather than refused (#916,
+            # ADR-0043): `/api` is the front's interface and not a contract held
+            # for anybody else (ADR-0033), so a refusal written for a client that
+            # does not exist is code for nobody.
             account = accounts_module.update_account(
-                opened, account_id,
-                account_type=body.get('type'), label=body.get('label'))
+                opened, account_id, label=body.get('label'))
     except accounts_module.UnknownAccount as exc:
         return not_found(str(exc))
 
@@ -453,7 +456,6 @@ def _account_to_dict(account) -> dict:
     """One :class:`events.schemas.Account`, on the wire."""
     return {
         'id': account.id,
-        'type': account.type,
         'label': account.label,
     }
 

--- a/src/application/CLAUDE.md
+++ b/src/application/CLAUDE.md
@@ -86,6 +86,12 @@ name: `/healthz` was examined and declined.
 - **Two kinds of time, never mixed**: `TIMESTAMPTZ` in UTC for an observed
   instant, `DATE` for a calendar day. A bound on a `DATE` column is **cast**, or
   DuckDB widens it to midnight and the first day of every window is dropped.
+- **An account has an id and a name, and no type** (#916, ADR-0043). The `type`
+  column is still in the DDL — it is `NOT NULL` and nothing can drop it until
+  #926 brings migration machinery — so `create_account` writes the seed's own
+  word into it and **nothing reads it**: not the API, not the view, not the
+  export. `default_is_declared` therefore answers on the label alone, where it
+  used to read both seeded columns.
 - **The seed has two halves**: the `default` account row is written at creation
   only and never removed; the `setting` defaults are inserted at every start with
   `ON CONFLICT DO NOTHING`. `base_currency` has no default and is therefore never

--- a/src/application/accounts.py
+++ b/src/application/accounts.py
@@ -95,9 +95,8 @@ def _normalised(names: Iterable) -> Set[str]:
 
 def read_accounts(store) -> List[Account]:
     """Every row of ``account``, id-sorted. ``default`` is always among them."""
-    rows = store.query(
-        'SELECT id, type, label FROM account ORDER BY id')
-    return [Account(id=r[0], type=r[1], label=r[2]) for r in rows]
+    rows = store.query('SELECT id, label FROM account ORDER BY id')
+    return [Account(id=r[0], label=r[1]) for r in rows]
 
 
 def account_ids(store) -> Set[str]:
@@ -113,12 +112,15 @@ def accounts_are_declared(store) -> bool:
 
 
 def default_is_declared(store) -> bool:
-    """Has anybody declared the row every install is given? (issue #725)"""
+    """Has anybody declared the row every install is given? (issue #725)
+
+    **On the label alone** since #916: the type used to be the other half of this
+    answer, and there is no longer a type to answer with.
+    """
     row = next((a for a in read_accounts(store) if a.id == DEFAULT_ACCOUNT), None)
     if row is None:
         return False
-    declared = as_declared(row)
-    return declared.label is not None or declared.type is not None
+    return as_declared(row).label is not None
 
 
 def declared_portfolio(store) -> Optional[Portfolio]:
@@ -138,11 +140,10 @@ def as_declared(account: Account) -> Account:
     """The row as a **reader** must see it: what nobody declared reads ``None``."""
     if account.id != DEFAULT_ACCOUNT:
         return account
-    _, seeded_type, seeded_label = store_module.DEFAULT_ACCOUNT_ROW
+    _, _, seeded_label = store_module.DEFAULT_ACCOUNT_ROW
     return replace(
         account,
         label=None if account.label == seeded_label else account.label,
-        type=None if account.type == seeded_type else account.type,
     )
 
 
@@ -176,36 +177,41 @@ def refuse_unaddressable_id(account_id: str) -> None:
             f"'..' there name a route that does not exist")
 
 
-def create_account(store, account_id: str, account_type: str,
+def create_account(store, account_id: str,
                    label: Optional[str] = None) -> Account:
-    """Declare an account. The app is where one is born, and the only place."""
+    """Declare an account. The app is where one is born, and the only place.
+
+    **Two fields** since #916: an identifier and a name. The ``type`` column is
+    still written, because it is ``NOT NULL`` and no migration machinery exists
+    to drop it (#926) — it takes the seed's own word, and nothing reads it.
+    """
     account_id = _text(account_id)
-    account_type = _text(account_type)
     if not account_id:
         raise AccountSourceError("id is required")
     refuse_unaddressable_id(account_id)
-    if not account_type:
-        raise AccountSourceError("type is required")
     if account_id in account_ids(store):
         raise DuplicateAccount(f"Account {account_id!r} already exists")
 
+    _, seeded_type, _ = store_module.DEFAULT_ACCOUNT_ROW
     store.execute(
         'INSERT INTO account (id, type, label) VALUES (?, ?, ?)',
-        [account_id, account_type, _text(label) or account_id])
+        [account_id, seeded_type, _text(label) or account_id])
     logger.info(f"Declared account {account_id}")
-    return Account(id=account_id, type=account_type,
-                   label=_text(label) or account_id)
+    return Account(id=account_id, label=_text(label) or account_id)
 
 
-def update_account(store, account_id: str, *, account_type: Optional[str] = None,
+def update_account(store, account_id: str, *,
                    label: Optional[str] = None) -> Account:
-    """Relabel or retype an account created in the app."""
+    """Rename an account created in the app.
+
+    Renaming is the whole of it since #916: there is no second column left to
+    change, and a blank keeps the name that is there.
+    """
     current = _require(store, account_id)
-    new_type = _text(account_type) or current.type
     new_label = _text(label) or current.label
-    store.execute('UPDATE account SET type = ?, label = ? WHERE id = ?',
-                  [new_type, new_label, account_id])
-    return Account(id=account_id, type=new_type, label=new_label)
+    store.execute('UPDATE account SET label = ? WHERE id = ?',
+                  [new_label, account_id])
+    return Account(id=account_id, label=new_label)
 
 
 def delete_account(store, account_id: str) -> None:

--- a/src/application/accounts.py
+++ b/src/application/accounts.py
@@ -117,10 +117,8 @@ def default_is_declared(store) -> bool:
     **On the label alone** since #916: the type used to be the other half of this
     answer, and there is no longer a type to answer with.
     """
-    row = next((a for a in read_accounts(store) if a.id == DEFAULT_ACCOUNT), None)
-    if row is None:
-        return False
-    return as_declared(row).label is not None
+    return any(as_declared(a).label is not None
+               for a in read_accounts(store) if a.id == DEFAULT_ACCOUNT)
 
 
 def declared_portfolio(store) -> Optional[Portfolio]:
@@ -140,11 +138,9 @@ def as_declared(account: Account) -> Account:
     """The row as a **reader** must see it: what nobody declared reads ``None``."""
     if account.id != DEFAULT_ACCOUNT:
         return account
-    _, _, seeded_label = store_module.DEFAULT_ACCOUNT_ROW
-    return replace(
-        account,
-        label=None if account.label == seeded_label else account.label,
-    )
+    seeded_label = store_module.DEFAULT_ACCOUNT_ROW[2]
+    return replace(account,
+                   label=None if account.label == seeded_label else account.label)
 
 
 def is_named_by_events(store, account_id: str) -> bool:
@@ -192,10 +188,10 @@ def create_account(store, account_id: str,
     if account_id in account_ids(store):
         raise DuplicateAccount(f"Account {account_id!r} already exists")
 
-    _, seeded_type, _ = store_module.DEFAULT_ACCOUNT_ROW
     store.execute(
         'INSERT INTO account (id, type, label) VALUES (?, ?, ?)',
-        [account_id, seeded_type, _text(label) or account_id])
+        [account_id, store_module.DEFAULT_ACCOUNT_ROW[1],
+         _text(label) or account_id])
     logger.info(f"Declared account {account_id}")
     return Account(id=account_id, label=_text(label) or account_id)
 

--- a/src/application/entries.py
+++ b/src/application/entries.py
@@ -8,7 +8,6 @@ from logfmt_logger import getLogger
 from application import accounts as accounts_module
 from application import ledger
 from application import settings_registry
-from application import store as store_module
 from application.events.aggregator import EventAggregator
 from application.events.validator import EventValidator
 from application.events import export as events_export
@@ -84,8 +83,11 @@ def create_many(store, drafts: Sequence[Event], *,
 
     with store.transaction():
         for account_id in declare_accounts:
-            accounts_module.create_account(
-                store, account_id, store_module.DEFAULT_ACCOUNT_ROW[1])
+            # **The id and nothing else.** `create_account` falls the label back
+            # to the id, which is what a row nobody named must carry; passing a
+            # second argument here would put that word in the *label*, the type
+            # having stopped being a parameter with #916.
+            accounts_module.create_account(store, account_id)
             logger.info(f"The file names {account_id} and nobody had declared "
                         f"it; declaring it with the import")
 

--- a/src/application/events/export.py
+++ b/src/application/events/export.py
@@ -179,8 +179,11 @@ def _haystack(event: Event) -> str:
                          (event.symbol, event.notes, account_of(event)) if part))
 
 
+# **No `account_type`** since #916 (ADR-0043): the column it rendered is written
+# by the app and read by nobody, so exporting it would ship a field whose every
+# row carries the same seeded word.
 PORTFOLIO_COLUMNS = (
-    'account', 'account_label', 'account_type',
+    'account', 'account_label',
     'cash_balance', 'net_contributed',
     'symbol', 'name', 'quantity', 'unit_cost', 'cost_basis',
     'price', 'market_value', 'realized_gain', 'received_dividend',
@@ -216,7 +219,6 @@ def _account_row(account: str, declaration: Optional[Any],
     return {
         'account': account,
         'account_label': None if declaration is None else declaration.label,
-        'account_type': None if declaration is None else declaration.type,
         'cash_balance': None if state is None else state.cash_balance,
         'net_contributed': None if state is None else state.net_contributed,
         BASE_CURRENCY_COLUMN: base_currency,
@@ -232,7 +234,6 @@ def _position_row(account: str, declaration: Optional[Any],
     return {
         'account': account,
         'account_label': None if declaration is None else declaration.label,
-        'account_type': None if declaration is None else declaration.type,
         'symbol': position.get('symbol'),
         'name': position.get('name'),
         'quantity': quantity,

--- a/src/application/events/schemas.py
+++ b/src/application/events/schemas.py
@@ -249,9 +249,15 @@ class Timeline:
 
 @dataclass
 class Account:
-    """A declared account — a row of the store's ``account`` table (issue #698)."""
+    """A declared account — a row of the store's ``account`` table (issue #698).
+
+    **No ``type``** (#916, ADR-0043). The column is still in the store — the DDL
+    runs with ``IF NOT EXISTS``, it is ``NOT NULL``, and there is no migration
+    machinery to drop it until #926 — but nothing asks for it, nothing serves it
+    and nothing renders it, so a reader that carried it would be carrying a value
+    no reader has.
+    """
     id: str
-    type: str
     label: str = ''
 
 

--- a/src/application/portfolio_view.py
+++ b/src/application/portfolio_view.py
@@ -281,7 +281,6 @@ class AccountSummary:
 
     id: str
     label: Optional[str]
-    type: Optional[str]
     as_of: Optional[date]
     cash_balance: Optional[float]
     holdings_value: Optional[float]
@@ -296,7 +295,6 @@ class AccountSummary:
         return {
             'id': self.id,
             'label': self.label,
-            'type': self.type,
             'as_of': instants.iso(self.as_of),
             'cash_balance': self.cash_balance,
             'holdings_value': self.holdings_value,
@@ -326,7 +324,6 @@ def build_accounts(
         summaries.append(AccountSummary(
             id=account.id,
             label=getattr(account, 'label', None),
-            type=getattr(account, 'type', None),
             as_of=row.get('day'),
             cash_balance=row.get('cash_balance'),
             holdings_value=row.get('holdings_value'),

--- a/src/web/CLAUDE.md
+++ b/src/web/CLAUDE.md
@@ -611,6 +611,14 @@ Five nets hold a rule nothing made true by construction:
   run yet* and never *something is wrong*. `STATE_TONE` is declared **once**, in
   `Notifications.tsx`, and it has exactly one consumer since #829: the sidebar
   card that used to be its second reader is gone.
+- **An account is a name and an id, and the id is the subtitle** (#916,
+  ADR-0043). The type is gone from the forms, from `Account` and from the wire,
+  so declaring an account is two fields. What sits under the name on the rail
+  and on the detail is the **id** — which reverses #838 deliberately: that
+  ticket took the id off the page saying the line heads an account with *what
+  the owner called it and what kind it is*, and only one of the two is left. The
+  id is the half that does concrete work, being what the owner writes in the
+  `account` column of an import file.
 - **The theme, the language and the table density are the reader's three
   preferences, one mechanism** (ADR-0024 decided the first two): three states each
   for theme and language (`light|dark|auto`, `fr|en|auto`), **two** for density

--- a/src/web/CLAUDE.md
+++ b/src/web/CLAUDE.md
@@ -611,10 +611,13 @@ Five nets hold a rule nothing made true by construction:
   run yet* and never *something is wrong*. `STATE_TONE` is declared **once**, in
   `Notifications.tsx`, and it has exactly one consumer since #829: the sidebar
   card that used to be its second reader is gone.
-- **An account is a name and an id, and the id is the subtitle** (#916,
+- **An account is a name and an id, and the id sits where the type sat** (#916,
   ADR-0043). The type is gone from the forms, from `Account` and from the wire,
-  so declaring an account is two fields. What sits under the name on the rail
-  and on the detail is the **id** — which reverses #838 deliberately: that
+  so declaring an account is two fields. What that slot now holds is the **id** —
+  beside the name and never beneath it, which is where the drawing put the kind:
+  inline after a `·` on the detail, at the far end of a `justify-between` row on
+  the rail, in the right-hand column of the first-run list. It reverses #838
+  deliberately: that
   ticket took the id off the page saying the line heads an account with *what
   the owner called it and what kind it is*, and only one of the two is left. The
   id is the half that does concrete work, being what the owner writes in the

--- a/src/web/src/components/FirstRun.tsx
+++ b/src/web/src/components/FirstRun.tsx
@@ -113,9 +113,7 @@ import { Input } from '@/components/ui/input'
 import { api, type AccountDraft, type ConfigResponse } from '@/lib/api'
 import {
   DEFAULT_ACCOUNT_LABEL,
-  DEFAULT_ACCOUNT_TYPE,
   declaredLabel,
-  declaredType,
 } from '@/lib/accounts'
 import { suggestedCurrency } from '@/lib/currencies'
 import {
@@ -368,7 +366,10 @@ export function FirstRun() {
                             {declaredLabel(account) ?? t(DEFAULT_ACCOUNT_LABEL)}
                           </span>
                           <span className="ml-auto shrink-0 font-mono text-2xs">
-                            {account.id} · {declaredType(account) ?? t(DEFAULT_ACCOUNT_TYPE)}
+                            {/* The id alone since #916: it is what the
+                                owner's own files name, and the type it used to
+                                sit beside is gone (ADR-0043). */}
+                            {account.id}
                           </span>
                         </li>
                       ))}
@@ -568,8 +569,8 @@ function DeclareAccount() {
   const { t } = useI18n()
   const client = useQueryClient()
   const [open, setOpen] = useState(false)
-  const [draft, setDraft] = useState({ id: '', type: '', label: '' })
-  const [errors, setErrors] = useState<Partial<Record<'id' | 'type', MessageKey>>>({})
+  const [draft, setDraft] = useState({ id: '', label: '' })
+  const [errors, setErrors] = useState<Partial<Record<'id', MessageKey>>>({})
 
   const write = useMutation({
     mutationFn: (body: AccountDraft) => api.createAccount(body),
@@ -585,28 +586,26 @@ function DeclareAccount() {
 
   function close() {
     setOpen(false)
-    setDraft({ id: '', type: '', label: '' })
+    setDraft({ id: '', label: '' })
     setErrors({})
     write.reset()
   }
 
-  function set(field: 'id' | 'type' | 'label', value: string) {
+  function set(field: 'id' | 'label', value: string) {
     setDraft((previous) => ({ ...previous, [field]: value }))
     setErrors((previous) => ({ ...previous, [field]: undefined }))
   }
 
   function submit() {
     const id = draft.id.trim()
-    const type = draft.type.trim()
-    const found: Partial<Record<'id' | 'type', MessageKey>> = {}
+    const found: Partial<Record<'id', MessageKey>> = {}
     if (id === '') found.id = 'accounts.form.required'
-    if (type === '') found.type = 'accounts.form.required'
 
     setErrors(found)
     if (Object.values(found).some(Boolean)) return
 
     const label = draft.label.trim()
-    write.mutate({ id, type, label: label || id })
+    write.mutate({ id, label: label || id })
   }
 
   if (!open) {
@@ -649,37 +648,21 @@ function DeclareAccount() {
             />
           )}
         </Field>
-        <Field
-          name="type"
-          label="accounts.form.type"
-          hint="accounts.form.type.hint"
-          error={errors.type}
-        >
+        {/* The name takes the column the type used to hold (#916): two fields
+            declare an account now, and they sit side by side rather than
+            leaving a half-empty row above a full-width one. */}
+        <Field name="label" label="accounts.form.label" optional>
           {(id, described) => (
             <Input
               id={id}
-              value={draft.type}
+              value={draft.label}
               autoComplete="off"
-              placeholder="PEA"
-              aria-invalid={errors.type !== undefined}
               aria-describedby={described}
-              onChange={(changed) => set('type', changed.target.value)}
+              onChange={(changed) => set('label', changed.target.value)}
             />
           )}
         </Field>
       </div>
-
-      <Field name="label" label="accounts.form.label" optional>
-        {(id, described) => (
-          <Input
-            id={id}
-            value={draft.label}
-            autoComplete="off"
-            aria-describedby={described}
-            onChange={(changed) => set('label', changed.target.value)}
-          />
-        )}
-      </Field>
 
       {write.error ? <Refusal>{problemSentence(t, write.error)}</Refusal> : null}
 
@@ -711,7 +694,7 @@ function Field({
   optional,
   children,
 }: {
-  name: 'id' | 'type' | 'label'
+  name: 'id' | 'label'
   label: MessageKey
   /** What the value is for, under the control — never a second label. */
   hint?: MessageKey

--- a/src/web/src/components/FirstRun.tsx
+++ b/src/web/src/components/FirstRun.tsx
@@ -366,8 +366,9 @@ export function FirstRun() {
                             {declaredLabel(account) ?? t(DEFAULT_ACCOUNT_LABEL)}
                           </span>
                           <span className="ml-auto shrink-0 font-mono text-2xs">
-                            {/* The id alone since #916: it is what the
-                                owner's own files name, and the type it used to
+                            {/* The id alone since #916, in the column it
+                                already shared with the type: it is what the
+                                owner's own files name, and the word it used to
                                 sit beside is gone (ADR-0043). */}
                             {account.id}
                           </span>

--- a/src/web/src/components/accounts/AccountDetail.tsx
+++ b/src/web/src/components/accounts/AccountDetail.tsx
@@ -177,10 +177,6 @@ export function AccountDetail({
   const heading = useId()
 
   const name = declaredLabel(row) ?? t(DEFAULT_ACCOUNT_LABEL)
-  // The id, **where the type used to be** — beside the name, not under it: the
-  // drawing puts this value on the heading's own line and #916 changes which
-  // value it is, never where it sits (ADR-0043, reversing #838).
-  const identifier = row.id
   const reason = degradedReason(row, rebuilding)
 
   // **Every derivation below is memoised, and against the reads themselves.**
@@ -288,7 +284,9 @@ export function AccountDetail({
                 <h2 id={heading} className="eyebrow">
                   {name}
                 </h2>
-                <span className="eyebrow">· {identifier}</span>
+                {/* The id, where the type used to be — beside the name and
+                    never under it (#916, ADR-0043, reversing #838). */}
+                <span className="eyebrow">· {row.id}</span>
                 {/* **The gesture is a pencil beside the name**, where it was
                     the name itself. One control for one gesture: a heading that
                     is also a button reads as a link to somewhere, and the

--- a/src/web/src/components/accounts/AccountDetail.tsx
+++ b/src/web/src/components/accounts/AccountDetail.tsx
@@ -177,9 +177,10 @@ export function AccountDetail({
   const heading = useId()
 
   const name = declaredLabel(row) ?? t(DEFAULT_ACCOUNT_LABEL)
-  // The id, under the name, where the type used to be — see `AccountsRail`
-  // (#916, ADR-0043, reversing #838).
-  const type = row.id
+  // The id, **where the type used to be** — beside the name, not under it: the
+  // drawing puts this value on the heading's own line and #916 changes which
+  // value it is, never where it sits (ADR-0043, reversing #838).
+  const identifier = row.id
   const reason = degradedReason(row, rebuilding)
 
   // **Every derivation below is memoised, and against the reads themselves.**
@@ -281,13 +282,13 @@ export function AccountDetail({
                 {/* The heading is the **name alone**: it is the accessible name
                     of the whole detail (`aria-labelledby`), and a region called
                     *Alpha · CTO* names a thing nobody calls that. The kind
-                    rides beside it as ordinary text, which is where the drawing
-                    puts it and where a screen reader reads it after the heading
-                    rather than inside it. */}
+                    identifier rides beside it as ordinary text, which is where
+                    the drawing puts it and where a screen reader reads it after
+                    the heading rather than inside it. */}
                 <h2 id={heading} className="eyebrow">
                   {name}
                 </h2>
-                {type === null ? null : <span className="eyebrow">· {type}</span>}
+                <span className="eyebrow">· {identifier}</span>
                 {/* **The gesture is a pencil beside the name**, where it was
                     the name itself. One control for one gesture: a heading that
                     is also a button reads as a link to somewhere, and the

--- a/src/web/src/components/accounts/AccountDetail.tsx
+++ b/src/web/src/components/accounts/AccountDetail.tsx
@@ -59,15 +59,12 @@ import {
   accountEvents,
   accountPositions,
   declaredLabel,
-  declaredType,
   degradedReason,
   distinctSymbols,
   dividendPayers,
-  isDefaultAccount,
   onContributed,
   valueSeries,
   DEFAULT_ACCOUNT_LABEL,
-  DEFAULT_ACCOUNT_TYPE,
   type AccountRow,
   type DegradedReason,
   type Reassignment as ReassignmentOffer,
@@ -180,7 +177,9 @@ export function AccountDetail({
   const heading = useId()
 
   const name = declaredLabel(row) ?? t(DEFAULT_ACCOUNT_LABEL)
-  const type = declaredType(row) ?? (isDefaultAccount(row.id) ? t(DEFAULT_ACCOUNT_TYPE) : row.id)
+  // The id, under the name, where the type used to be — see `AccountsRail`
+  // (#916, ADR-0043, reversing #838).
+  const type = row.id
   const reason = degradedReason(row, rebuilding)
 
   // **Every derivation below is memoised, and against the reads themselves.**

--- a/src/web/src/components/accounts/AccountForm.tsx
+++ b/src/web/src/components/accounts/AccountForm.tsx
@@ -51,7 +51,6 @@ import {
 } from '@/components/ui/sheet'
 import {
   declaredLabel,
-  declaredType,
   DEFAULT_ACCOUNT_LABEL,
   type Reassignment,
   type Removal,
@@ -75,13 +74,12 @@ const REFUSALS: Record<Exclude<Removal['kind'], 'offered'>, MessageKey> = {
 
 interface Draft {
   id: string
-  type: string
   label: string
 }
 
 type FieldName = keyof Draft
 
-const EMPTY: Draft = { id: '', type: '', label: '' }
+const EMPTY: Draft = { id: '', label: '' }
 
 interface AccountFormProps {
   open: boolean
@@ -173,12 +171,11 @@ export function AccountForm({
         ? EMPTY
         : {
             id: account.id,
-            // **Both seeded columns open empty.** `Default account` and `OTHER`
-            // are what the *server* wrote about a row nobody declared, so
-            // neither is a value the reader typed — and handing one back had
-            // them typing `PEA` into `OTHER` and saving `OTHERPEA`, the form
-            // giving them a value they never gave.
-            type: declaredType(account) ?? '',
+            // **The seeded name opens empty.** `Default account` is what the
+            // *server* wrote about a row nobody declared, so it is not a value
+            // the reader typed — and handing it back had them typing over it and
+            // saving a name the form had given them. There was a second column
+            // under this rule until #916 took the type away (ADR-0043).
             label: declaredLabel(account) ?? '',
           },
     )
@@ -199,15 +196,8 @@ export function AccountForm({
   function submit() {
     const found: Partial<Record<FieldName, MessageKey>> = {}
     const id = draft.id.trim()
-    const type = draft.type.trim()
 
     if (account === null && id === '') found.id = 'accounts.form.required'
-    // Required on a **declaration** only, which is where the store requires it
-    // (`create_account` raises without one). On an edit a blank type is the
-    // label's own case: `update_account` keeps what is there, so refusing here
-    // would make *renaming* the seeded row — the one gesture this panel exists
-    // for at N = 1 — conditional on answering a second question.
-    if (account === null && type === '') found.type = 'accounts.form.required'
 
     setErrors(found)
     if (Object.values(found).some(Boolean)) return
@@ -222,13 +212,12 @@ export function AccountForm({
       account === null
         ? {
             id,
-            type,
             label: label || id,
             // Sent only where the box was shown **and** left ticked: `reassign`
             // is a request, and a client that never asks must never perform one.
             ...(offered && reassign ? { reassign: true } : {}),
           }
-        : { type, label },
+        : { label },
     )
   }
 
@@ -277,18 +266,6 @@ export function AccountForm({
               </p>
             </div>
           )}
-
-          <Field name="type" label="accounts.form.type" error={errors.type}>
-            {(id, described) => (
-              <Input
-                id={id}
-                value={draft.type}
-                aria-invalid={errors.type !== undefined}
-                aria-describedby={described}
-                onChange={(changed) => set('type', changed.target.value)}
-              />
-            )}
-          </Field>
 
           <Field name="label" label="accounts.form.label" error={errors.label} optional>
             {(id, described) => (

--- a/src/web/src/components/accounts/AccountsRail.tsx
+++ b/src/web/src/components/accounts/AccountsRail.tsx
@@ -245,15 +245,6 @@ export function AccountsRail({
           const reason = degradedReason(row, rebuilding)
           const cash = cashShare(advisories, row.id)
           const name = declaredLabel(row) ?? t(DEFAULT_ACCOUNT_LABEL)
-          // **The id, at the end of the row**, in the slot the type held since
-          // #838 — the row is `justify-between`, so this value sits opposite the
-          // name rather than beneath it, and #916 changes which value it is and
-          // nothing about where (ADR-0043). It reverses #838 deliberately: that
-          // ticket took the id off this page saying the line heads an account
-          // with *what the owner called it and what kind it is*, and only one of
-          // the two is left. The id is the half that does concrete work — it is
-          // what the owner writes in the `account` column of an import file.
-          const identifier = row.id
           // `null` where there is no ratio to state — nothing written about this
           // account yet, nothing ever paid in, or more taken out than put in.
           const performance = onContributed(row.gain_absolu, row.net_contributed)
@@ -288,7 +279,9 @@ export function AccountsRail({
                       </span>
                     )}
                   </span>
-                  <span className="shrink-0 font-mono text-2xs text-muted-foreground">{identifier}</span>
+                  {/* The id, in the slot the type held since #838 — opposite
+                      the name, never beneath it (#916, ADR-0043). */}
+                  <span className="shrink-0 font-mono text-2xs text-muted-foreground">{row.id}</span>
                 </span>
 
                 {/* **What the account is worth, and what it has done with it.**

--- a/src/web/src/components/accounts/AccountsRail.tsx
+++ b/src/web/src/components/accounts/AccountsRail.tsx
@@ -245,13 +245,15 @@ export function AccountsRail({
           const reason = degradedReason(row, rebuilding)
           const cash = cashShare(advisories, row.id)
           const name = declaredLabel(row) ?? t(DEFAULT_ACCOUNT_LABEL)
-          // **The id under the name** since #916 (ADR-0043), where the type used
-          // to sit. It reverses #838 deliberately: that ticket took the id off
-          // this page saying the line heads an account with *what the owner
-          // called it and what kind it is*, and only one of the two is left. The
-          // id is the half that does concrete work — it is what the owner writes
-          // in the `account` column of an import file.
-          const type = row.id
+          // **The id, at the end of the row**, in the slot the type held since
+          // #838 — the row is `justify-between`, so this value sits opposite the
+          // name rather than beneath it, and #916 changes which value it is and
+          // nothing about where (ADR-0043). It reverses #838 deliberately: that
+          // ticket took the id off this page saying the line heads an account
+          // with *what the owner called it and what kind it is*, and only one of
+          // the two is left. The id is the half that does concrete work — it is
+          // what the owner writes in the `account` column of an import file.
+          const identifier = row.id
           // `null` where there is no ratio to state — nothing written about this
           // account yet, nothing ever paid in, or more taken out than put in.
           const performance = onContributed(row.gain_absolu, row.net_contributed)
@@ -286,7 +288,7 @@ export function AccountsRail({
                       </span>
                     )}
                   </span>
-                  <span className="shrink-0 font-mono text-2xs text-muted-foreground">{type}</span>
+                  <span className="shrink-0 font-mono text-2xs text-muted-foreground">{identifier}</span>
                 </span>
 
                 {/* **What the account is worth, and what it has done with it.**

--- a/src/web/src/components/accounts/AccountsRail.tsx
+++ b/src/web/src/components/accounts/AccountsRail.tsx
@@ -67,13 +67,10 @@ import {
   accountWeights,
   accountWorth,
   declaredLabel,
-  declaredType,
   degradedReason,
-  isDefaultAccount,
   onContributed,
   DEFAULT_ACCOUNT_ID,
   DEFAULT_ACCOUNT_LABEL,
-  DEFAULT_ACCOUNT_TYPE,
   type AccountRow,
   type DegradedReason,
   type Reassignment as ReassignmentOffer,
@@ -248,8 +245,13 @@ export function AccountsRail({
           const reason = degradedReason(row, rebuilding)
           const cash = cashShare(advisories, row.id)
           const name = declaredLabel(row) ?? t(DEFAULT_ACCOUNT_LABEL)
-          const type =
-            declaredType(row) ?? (isDefaultAccount(row.id) ? t(DEFAULT_ACCOUNT_TYPE) : row.id)
+          // **The id under the name** since #916 (ADR-0043), where the type used
+          // to sit. It reverses #838 deliberately: that ticket took the id off
+          // this page saying the line heads an account with *what the owner
+          // called it and what kind it is*, and only one of the two is left. The
+          // id is the half that does concrete work — it is what the owner writes
+          // in the `account` column of an import file.
+          const type = row.id
           // `null` where there is no ratio to state — nothing written about this
           // account yet, nothing ever paid in, or more taken out than put in.
           const performance = onContributed(row.gain_absolu, row.net_contributed)

--- a/src/web/src/components/data/ImportPreview.tsx
+++ b/src/web/src/components/data/ImportPreview.tsx
@@ -311,7 +311,7 @@ function AccountsBlock({
   onAnswer,
 }: {
   lines: readonly AccountLine[]
-  declared: { accounts: { id: string; label: string | null; type: string | null }[] }
+  declared: { accounts: { id: string; label: string | null }[] }
   busy: boolean
   onAnswer: (name: string, target: AccountTarget) => void
 }) {
@@ -359,7 +359,7 @@ function AccountRow({
   onAnswer,
 }: {
   line: AccountLine
-  declared: readonly { id: string; label: string | null; type: string | null }[]
+  declared: readonly { id: string; label: string | null }[]
   busy: boolean
   onAnswer: (name: string, target: AccountTarget) => void
 }) {
@@ -438,7 +438,7 @@ function AccountRow({
 function why(
   t: ReturnType<typeof useI18n>['t'],
   line: AccountLine,
-  declared: readonly { id: string; label: string | null; type: string | null }[],
+  declared: readonly { id: string; label: string | null }[],
 ): string {
   if (line.target.kind === 'unanswered') {
     return t('data.import.accounts.why.unanswered', {

--- a/src/web/src/declaration.test.tsx
+++ b/src/web/src/declaration.test.tsx
@@ -103,7 +103,7 @@ describe('the same form as the ledger, not a second one', () => {
     // `Gamma` was declared here too: its pencil opens the panel.
     const panel = await openPanel(user, 'Gamma')
     expect(panel).toHaveAttribute('data-slot', 'sheet-content')
-    expect(within(panel).getByLabelText('Type')).toHaveValue('CTO')
+    expect(within(panel).getByLabelText('Nom')).toHaveValue('Gamma')
   })
 
   it('does not offer the identifier for editing: it is what the events name', async () => {
@@ -116,15 +116,17 @@ describe('the same form as the ledger, not a second one', () => {
 })
 
 describe('the form loses `currency`', () => {
-  it('offers an identifier, a type and a name, and no currency of any kind', async () => {
+  it('offers an identifier and a name, and no currency and no type', async () => {
     const { user } = renderAccounts()
     await detail('Alpha')
     await user.click(screen.getByRole('button', { name: 'Déclarer un compte' }))
 
     const panel = await screen.findByRole('dialog')
     expect(within(panel).getByLabelText('Identifiant')).toBeInTheDocument()
-    expect(within(panel).getByLabelText('Type')).toBeInTheDocument()
     expect(within(panel).getByLabelText('Nom')).toBeInTheDocument()
+    // **And no type** (#916, ADR-0043): the column was read by nothing, so the
+    // declaration is two fields — what the events name, and what it is called.
+    expect(within(panel).queryByLabelText('Type')).not.toBeInTheDocument()
 
     // ADR-0002 deleted `Account.currency` rather than guarding it: two currency
     // levels and not three, so *a EUR account holding a USD security* has no
@@ -142,7 +144,6 @@ describe('the form loses `currency`', () => {
 
     const panel = await screen.findByRole('dialog')
     await user.type(within(panel).getByLabelText('Identifiant'), 'delta')
-    await user.type(within(panel).getByLabelText('Type'), 'CTO')
     await user.type(within(panel).getByLabelText('Nom'), 'Delta')
 
     server.use(
@@ -150,7 +151,7 @@ describe('the form loses `currency`', () => {
         HttpResponse.json(
           anAccountsPayload([
             ...anAccountsPayload().accounts,
-            anAccount({ id: 'delta', label: 'Delta', type: 'CTO' }),
+            anAccount({ id: 'delta', label: 'Delta' }),
           ]),
         ),
       ),
@@ -272,16 +273,19 @@ describe('`default` on this page, under the name the catalogue gives it', () => 
     ])
 
     // `Non affecté` — one `lib/accounts.ts` function, read by the rail and by
-    // the detail, so two surfaces cannot name one thing two ways. Neither the
-    // label nor the type the seed wrote ever crosses the screen: both are the
-    // server's own English about a row nobody declared.
+    // the detail, so two surfaces cannot name one thing two ways. The label the
+    // seed wrote never crosses the screen: it is the server's own English about
+    // a row nobody declared.
     const opened = await detail('Non affecté')
     expect(within(rail()).getByRole('link', { name: /Non affecté/ })).toBeInTheDocument()
-    // **The id is not on this page any more** (#838): the drawing heads an
-    // account with what the owner called it and what kind it is, and nothing
-    // else. It is still what every event names, and it is still read where an
-    // event is — the ledger's `Compte` column and the shares table's chip.
-    expect(opened).not.toHaveTextContent(DEFAULT_ACCOUNT_ID)
+    // **The id is back on this page** (#916, ADR-0043), and this reverses #838
+    // deliberately. That ticket took it off saying the line heads an account
+    // with *what the owner called it and what kind it is* — and the type is
+    // gone, so only one of the two is left. The id is the half that does
+    // concrete work: it is what the owner writes in the `account` column of an
+    // import file, and what the ledger's own `Compte` column shows them.
+    expect(opened).toHaveTextContent(DEFAULT_ACCOUNT_ID)
+    // What is still refused is the **seed's own English**, on either column.
     expect(screen.queryByText('Default account')).not.toBeInTheDocument()
     expect(screen.queryByText('OTHER')).not.toBeInTheDocument()
   })
@@ -294,9 +298,7 @@ describe('`default` on this page, under the name the catalogue gives it', () => 
     // Both seeded columns open **empty**: neither `Default account` nor `OTHER`
     // is a value the reader typed, and handing one back had them typing `PEA`
     // into `OTHER` and saving `OTHERPEA`.
-    expect(within(panel).getByLabelText('Type')).toHaveValue('')
     expect(within(panel).getByLabelText('Nom')).toHaveValue('')
-    await user.type(within(panel).getByLabelText('Type'), 'PEA')
     await user.type(within(panel).getByLabelText('Nom'), 'Mon PEA')
 
     // **The body the server can actually produce**: `declared` stays `false` —
@@ -305,10 +307,10 @@ describe('`default` on this page, under the name the catalogue gives it', () => 
     server.use(
       http.patch(accountPath(DEFAULT_ACCOUNT_ID), async ({ request }) => {
         patched = await request.json()
-        return HttpResponse.json(theSeededAccount({ label: 'Mon PEA', type: 'PEA' }))
+        return HttpResponse.json(theSeededAccount({ label: 'Mon PEA' }))
       }),
       http.get(ROUTES.accounts, () =>
-        HttpResponse.json(noAccountsDeclared({ label: 'Mon PEA', type: 'PEA' })),
+        HttpResponse.json(noAccountsDeclared({ label: 'Mon PEA' })),
       ),
     )
 
@@ -319,14 +321,14 @@ describe('`default` on this page, under the name the catalogue gives it', () => 
     // Renamed, and the row is still `default` underneath — which this page no
     // longer writes down (#838); what proves it is the request the form sent.
     await detail('Mon PEA')
-    expect(patched).toMatchObject({ label: 'Mon PEA', type: 'PEA' })
+    expect(patched).toEqual({ label: 'Mon PEA' })
   })
 
-  it('renames it without demanding a type it already has', async () => {
-    // The type is required where the store requires it — a declaration — and a
-    // blank on an edit is the label's own case: `update_account` keeps what is
-    // there. Refusing here made *renaming* the seeded row, the one gesture this
-    // panel exists for at N = 1, conditional on answering a second question.
+  it('renames it with the one field a rename needs, and sends nothing else', async () => {
+    // Renaming the seeded row is the gesture this panel exists for at N = 1, and
+    // since #916 it is the whole of what the panel can change: there is no
+    // second column left, so nothing can make the rename conditional on
+    // answering a second question.
     const { user } = renderAccounts(noAccountsDeclared(), [])
     const panel = await openPanel(user, 'Non affecté')
 
@@ -343,7 +345,7 @@ describe('`default` on this page, under the name the catalogue gives it', () => 
     await user.click(within(panel).getByRole('button', { name: 'Enregistrer ce compte' }))
 
     expect(await within(rail()).findByRole('link', { name: /Mon PEA/ })).toBeInTheDocument()
-    expect(patched).toEqual({ type: '', label: 'Mon PEA' })
+    expect(patched).toEqual({ label: 'Mon PEA' })
   })
 
   it('is named the same way in the ledger’s create form, one page over', async () => {

--- a/src/web/src/firstRun.test.tsx
+++ b/src/web/src/firstRun.test.tsx
@@ -653,7 +653,7 @@ describe('an account can be declared from inside the walk', () => {
     server.use(
       http.get(ROUTES.accounts, () => HttpResponse.json(current)),
       http.post(ROUTES.accounts, async ({ request }) => {
-        const draft = (await request.json()) as { id: string; type: string; label: string }
+        const draft = (await request.json()) as { id: string; label: string }
         const row = { ...theSeededAccount(), ...draft }
         current = { declared: true, accounts: [...current.accounts, row] }
         return HttpResponse.json(row, { status: 201 })
@@ -669,9 +669,10 @@ describe('an account can be declared from inside the walk', () => {
     const passage = within(modal())
     expect(await passage.findByText('Vos comptes actuels')).toBeInTheDocument()
     // The catalogue's name for the row nobody declared, and beside it the value
-    // a `.csv` would have to spell to land on it.
+    // a `.csv` would have to spell to land on it — the id alone since #916,
+    // where the seeded type used to sit beside it (ADR-0043).
     expect(passage.getByText('Non affecté')).toBeInTheDocument()
-    expect(passage.getByText('default · Autre')).toBeInTheDocument()
+    expect(passage.getByText('default')).toBeInTheDocument()
   })
 
   it('is closed until it is asked for, and the passage is satisfied without it', async () => {
@@ -694,12 +695,14 @@ describe('an account can be declared from inside the walk', () => {
 
     await user.click(await within(modal()).findByRole('button', { name: 'Déclarer un compte' }))
     await user.type(within(modal()).getByLabelText('Identifiant'), 'pea')
-    await user.type(within(modal()).getByLabelText('Type'), 'PEA')
     await user.click(within(modal()).getByRole('button', { name: 'Déclarer ce compte' }))
 
     // Declared, and read back: the list is the installation's own accounts, so
     // the row is there because the server has it and not because a form said so.
-    expect(await within(modal()).findByText('pea · PEA')).toBeInTheDocument()
+    // The declaration carried no name, so the label falls back to the id — and
+    // the row therefore renders `pea` twice, as its name and as the identifier
+    // under it (#916). Both are the row being there.
+    expect(await within(modal()).findAllByText('pea')).not.toHaveLength(0)
     // The form closes behind it — the offer is not a place the reader stays.
     await waitFor(() =>
       expect(within(modal()).queryByLabelText('Identifiant')).not.toBeInTheDocument(),
@@ -715,9 +718,10 @@ describe('an account can be declared from inside the walk', () => {
     await user.click(await within(modal()).findByRole('button', { name: 'Déclarer un compte' }))
     await user.click(within(modal()).getByRole('button', { name: 'Déclarer ce compte' }))
 
-    // The two required fields say so where they are, and nothing crossed the
-    // wire to be told what this form already knew.
-    expect(within(modal()).getAllByText('Ce champ est obligatoire.')).toHaveLength(2)
+    // The one required field says so where it is, and nothing crossed the wire
+    // to be told what this form already knew. It was two until #916: the type
+    // was the other, and there is no type to require.
+    expect(within(modal()).getAllByText('Ce champ est obligatoire.')).toHaveLength(1)
     expect(writes).not.toContain('POST /api/accounts')
   })
 
@@ -736,7 +740,6 @@ describe('an account can be declared from inside the walk', () => {
 
     await user.click(await within(modal()).findByRole('button', { name: 'Déclarer un compte' }))
     await user.type(within(modal()).getByLabelText('Identifiant'), 'default')
-    await user.type(within(modal()).getByLabelText('Type'), 'PEA')
     await user.click(within(modal()).getByRole('button', { name: 'Déclarer ce compte' }))
 
     // The refusal is in the form, and the form stays open on what was typed:

--- a/src/web/src/firstRun.test.tsx
+++ b/src/web/src/firstRun.test.tsx
@@ -700,9 +700,10 @@ describe('an account can be declared from inside the walk', () => {
     // Declared, and read back: the list is the installation's own accounts, so
     // the row is there because the server has it and not because a form said so.
     // The declaration carried no name, so the label falls back to the id — and
-    // the row therefore renders `pea` twice, as its name and as the identifier
-    // under it (#916). Both are the row being there.
-    expect(await within(modal()).findAllByText('pea')).not.toHaveLength(0)
+    // the row therefore renders `pea` **exactly twice**, as its name and as the
+    // identifier beside it (#916). Asserting the count rather than *at least
+    // one* is what makes this fail if either half stops rendering.
+    expect(await within(modal()).findAllByText('pea')).toHaveLength(2)
     // The form closes behind it — the offer is not a place the reader stays.
     await waitFor(() =>
       expect(within(modal()).queryByLabelText('Identifiant')).not.toBeInTheDocument(),

--- a/src/web/src/i18n/en.json
+++ b/src/web/src/i18n/en.json
@@ -304,7 +304,6 @@
   "accounts.reason.empty": "nothing recorded on this account",
 
   "accounts.default.label": "Unassigned",
-  "accounts.default.type": "Other",
   "accounts.default.reassign": "Assign these events to an account",
 
   "accounts.detail.gainTotal.explain": "What this account is worth less what you have paid into it. It counts this account's sold positions, and only the fees taken on its own transfers.",
@@ -345,8 +344,6 @@
   "accounts.form.id": "Identifier",
   "accounts.form.id.fixed": "This is what your events name, in a file as well as here, so it cannot be changed. Declare another account and move the events onto it instead.",
   "accounts.form.id.hint": "This is what your events name. It will not change.",
-  "accounts.form.type": "Type",
-  "accounts.form.type.hint": "What you call it: PEA, brokerage, life insurance…",
   "accounts.form.label": "Name",
   "accounts.form.required": "This field is required.",
   "accounts.form.submit": "Declare this account",

--- a/src/web/src/i18n/fr.json
+++ b/src/web/src/i18n/fr.json
@@ -304,7 +304,6 @@
   "accounts.reason.empty": "rien d’enregistré sur ce compte",
 
   "accounts.default.label": "Non affecté",
-  "accounts.default.type": "Autre",
   "accounts.default.reassign": "Affecter ces événements à un compte",
 
   "accounts.detail.gainTotal.explain": "Ce que vaut ce compte moins ce que vous y avez versé. Il compte les positions soldées de ce compte, et seulement les frais prélevés sur ses propres virements.",
@@ -345,8 +344,6 @@
   "accounts.form.id": "Identifiant",
   "accounts.form.id.fixed": "C’est ce que nomment vos événements, dans un fichier comme ici : il ne peut donc pas changer. Déclarez un autre compte et affectez-y les événements.",
   "accounts.form.id.hint": "C’est ce que nomment vos événements. Il ne changera plus.",
-  "accounts.form.type": "Type",
-  "accounts.form.type.hint": "Comme vous l’appelez : PEA, CTO, assurance-vie…",
   "accounts.form.label": "Nom",
   "accounts.form.required": "Ce champ est obligatoire.",
   "accounts.form.submit": "Déclarer ce compte",

--- a/src/web/src/lib/accounts.test.ts
+++ b/src/web/src/lib/accounts.test.ts
@@ -22,7 +22,6 @@ import {
   buildAccountRows,
   chooseAccount,
   declaredLabel,
-  declaredType,
   degradedReason,
   dividendPayers,
   firstDay,
@@ -410,20 +409,17 @@ describe('the name one account wears, on both pages', () => {
     // declaration table and the accounts page from naming one row two ways:
     // both call this function, so the rule cannot be written twice.
     expect(declaredLabel(theSeededAccount())).toBeNull()
-    expect(declaredType(theSeededAccount())).toBeNull()
     expect(declaredLabel(theSeededAccount({ label: '  ' }))).toBeNull()
   })
 
   it('hands the row back the moment its owner names it', () => {
     // The whole point of the block: a rename rendered nowhere is not a rename.
     expect(declaredLabel(theSeededAccount({ label: 'Mon PEA' }))).toBe('Mon PEA')
-    expect(declaredType(theSeededAccount({ type: 'PEA' }))).toBe('PEA')
   })
 
   it('never sends any other account to the catalogue, and falls back to the id', () => {
     expect(declaredLabel(anAccount({ id: 'pea', label: 'Default account' }))).toBe('Default account')
     expect(declaredLabel(anAccount({ id: 'pea', label: null }))).toBe('pea')
-    expect(declaredType(anAccount({ id: 'pea', type: null }))).toBeNull()
   })
 })
 
@@ -533,10 +529,12 @@ describe('réaffecter, jamais refuser (#725)', () => {
     expect(reassignmentOf(named, unassignedLedger())).toEqual({ kind: 'none' })
 
     // The other seeded column says as much. There was a third road — a file
-    // taking the row over — and it left with the accounts file (ADR-0034): the
-    // two that remain are the owner's own, which are the ones that mattered.
-    const retyped = anAccountsPayload([theSeededAccount({ type: 'PEA' })], false)
-    expect(reassignmentOf(retyped, unassignedLedger())).toEqual({ kind: 'none' })
+    // taking the row over — and it left with the accounts file (ADR-0034). Of
+    // the two that remained, the type left with #916 (ADR-0043), so **the name
+    // is the whole predicate**: a renamed seed is a declaration, and its events
+    // are no longer anybody's to move.
+    const renamed = anAccountsPayload([theSeededAccount({ label: 'Mon PEA' })], false)
+    expect(reassignmentOf(renamed, unassignedLedger())).toEqual({ kind: 'none' })
   })
 
   it('claims nothing while the read has not landed', () => {

--- a/src/web/src/lib/accounts.ts
+++ b/src/web/src/lib/accounts.ts
@@ -93,13 +93,11 @@ export function isDefaultAccount(id: string): boolean {
  * construction is a single entry the two of them read.
  */
 export const DEFAULT_ACCOUNT_LABEL: MessageKey = 'accounts.default.label'
-export const DEFAULT_ACCOUNT_TYPE: MessageKey = 'accounts.default.type'
 
-/** The two members a naming rule needs — an `Account` or an {@link AccountRow}. */
+/** What a naming rule needs — an `Account` or an {@link AccountRow}. */
 interface NamedAccount {
   id: string
   label?: string | null
-  type?: string | null
 }
 
 /**
@@ -127,10 +125,6 @@ export function declaredLabel(account: NamedAccount): string | null {
   return isDefaultAccount(account.id) ? label : label ?? account.id
 }
 
-/** The same clause on the other seeded column. `null` — nothing was declared. */
-export function declaredType(account: NamedAccount): string | null {
-  return account.type?.trim() || null
-}
 
 // ------------------------------------------------------------------------- //
 // The one range control — the dashboard's accounts card, and nowhere else
@@ -316,7 +310,6 @@ export interface AccountRow {
   id: string
   /** As declared. The catalogue owns `default`'s (#745), and it owns it late. */
   label: string | null
-  type: string | null
   /** The day the money figures describe. `null` — no cycle wrote this account. */
   as_of: string | null
   total_value: number | null
@@ -351,7 +344,6 @@ export function buildAccountRows(accounts: readonly Account[]): AccountRow[] {
   return accounts.map((account) => ({
     id: account.id,
     label: account.label ?? null,
-    type: account.type ?? null,
     as_of: account.as_of ?? null,
     total_value: account.total_value ?? null,
     holdings_value: account.holdings_value ?? null,
@@ -649,16 +641,14 @@ export function valueSeries(points: readonly PerfPoint[]): ValuePoint[] {
  * and this is the one place the front spells it (`lib/absence.ts`'s `isQuoted`
  * is the precedent, #774).
  *
- * Both seeded columns, not the label alone: an owner who retyped the row has
- * declared it as much as one who renamed it, and #725's whole correctness rests
- * on *has anybody declared this* rather than on *does it have a name*.
+ * **The label alone**, and it used to be two. An owner who *retyped* the seeded
+ * row had declared it as surely as one who renamed it, so this read both seeded
+ * columns; #916 removed the type (ADR-0043), and the name is the whole of what
+ * *has anybody declared this* can now be read off — server-side too
+ * (`accounts.default_is_declared`).
  */
 function isSeededOnly(account: Account): boolean {
-  return (
-    isDefaultAccount(account.id) &&
-    declaredLabel(account) === null &&
-    declaredType(account) === null
-  )
+  return isDefaultAccount(account.id) && declaredLabel(account) === null
 }
 
 /**

--- a/src/web/src/lib/api.ts
+++ b/src/web/src/lib/api.ts
@@ -402,8 +402,6 @@ export interface Account {
    * empty. The fold lives in `lib/accounts.ts` rather than in each cell.
    */
   label: string | null
-  /** Same clause, same row: `default`'s seeded type is the catalogue's too. */
-  type: string | null
   /**
    * The account's **newest** `account_metrics` row, ridden on this resource
    * rather than on a second one — one accounts resource with two consumers, the
@@ -482,7 +480,6 @@ export interface AccountsResponse {
  */
 export interface AccountDraft {
   id?: string
-  type: string
   label: string
   /**
    * Move the events still naming the seeded row onto this account, in the same

--- a/src/web/src/reassignment.test.tsx
+++ b/src/web/src/reassignment.test.tsx
@@ -81,12 +81,11 @@ describe('the first declaration carries the reassignment', () => {
     expect(box).toBeChecked()
 
     await user.type(within(panel).getByLabelText('Identifiant'), 'pea')
-    await user.type(within(panel).getByLabelText('Type'), 'PEA')
     await user.click(within(panel).getByRole('button', { name: 'Déclarer ce compte' }))
 
     // **One request**, which is what *dans le même geste* means: the declaration
     // and the move are not two gestures a reader can be interrupted between.
-    await waitFor(() => expect(sent).toEqual({ id: 'pea', type: 'PEA', label: 'pea', reassign: true }))
+    await waitFor(() => expect(sent).toEqual({ id: 'pea', label: 'pea', reassign: true }))
   })
 
   it('is never a refusal, and unchecking still declares', async () => {
@@ -108,10 +107,9 @@ describe('the first declaration carries the reassignment', () => {
     const panel = await screen.findByRole('dialog')
     await user.click(within(panel).getByRole('checkbox'))
     await user.type(within(panel).getByLabelText('Identifiant'), 'pea')
-    await user.type(within(panel).getByLabelText('Type'), 'PEA')
     await user.click(within(panel).getByRole('button', { name: 'Déclarer ce compte' }))
 
-    await waitFor(() => expect(sent).toEqual({ id: 'pea', type: 'PEA', label: 'pea' }))
+    await waitFor(() => expect(sent).toEqual({ id: 'pea', label: 'pea' }))
   })
 
   it('asks nothing about the row its owner has already named', async () => {

--- a/src/web/src/test/factories.ts
+++ b/src/web/src/test/factories.ts
@@ -132,7 +132,6 @@ export function anAccount(overrides: Partial<Account> = {}): Account {
   return {
     id: 'alpha',
     label: 'Alpha',
-    type: 'PEA',
     as_of: '2026-03-02',
     total_value: 1800,
     holdings_value: 1300,
@@ -185,7 +184,7 @@ export function anAccountWithoutSeries(overrides: Partial<Account> = {}): Accoun
  * in the same process.
  */
 export function theSeededAccount(overrides: Partial<Account> = {}): Account {
-  return anAccount({ id: 'default', label: null, type: null, ...overrides })
+  return anAccount({ id: 'default', label: null, ...overrides })
 }
 
 export interface PositionOptions extends Partial<Omit<Position, 'price' | 'converted'>> {
@@ -315,11 +314,10 @@ export function noAccountsDeclared(overrides: Partial<Account> = {}): AccountsRe
  */
 export function defaultAccounts(): Account[] {
   return [
-    anAccount({ id: 'alpha', label: 'Alpha', type: 'PEA' }),
+    anAccount({ id: 'alpha', label: 'Alpha' }),
     anAccount({
       id: 'beta',
       label: 'Beta',
-      type: 'CTO',
       total_value: 900,
       holdings_value: 400,
       cash_balance: 500,
@@ -333,7 +331,6 @@ export function defaultAccounts(): Account[] {
     anAccount({
       id: 'gamma',
       label: 'Gamma',
-      type: 'CTO',
       total_value: null,
       cash_balance: null,
       net_contributed: null,
@@ -398,7 +395,6 @@ export function anAccountGoingNowhere(overrides: Partial<Account> = {}): Account
   return anAccount({
     id: 'nowhere',
     label: 'Nowhere',
-    type: 'CTO',
     total_value: 452.35,
     holdings_value: 452.35,
     cash_balance: 0,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,9 +207,8 @@ def declare_ledger():
         for account in (accounts or []):
             opened.execute(
                 'INSERT INTO account (id, type, label) VALUES (?, ?, ?) '
-                'ON CONFLICT (id) DO UPDATE SET type = excluded.type, '
-                '                               label = excluded.label',
-                [account.id, account.type, account.label])
+                'ON CONFLICT (id) DO UPDATE SET label = excluded.label',
+                [account.id, store_module.DEFAULT_ACCOUNT_ROW[1], account.label])
         for symbol in sorted({e.symbol for e in events if e.symbol}):
             opened.execute(
                 'INSERT INTO symbol (symbol) VALUES (?) '

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -85,8 +85,7 @@ def _declare(store, text):
     import io
     import csv as csv_module
     for row in csv_module.DictReader(io.StringIO(text)):
-        accounts_module.create_account(store, row['id'], row['type'],
-                                       row.get('label'))
+        accounts_module.create_account(store, row['id'], row.get('label'))
 
 
 def _accounts(store):
@@ -229,7 +228,7 @@ def test_a_declaration_is_recognised_in_a_workbook_too(store, tmp_path):
 
 def test_the_label_falls_back_to_the_id(store):
     """``label`` is ``NOT NULL``: a row cannot decline to name itself."""
-    accounts_module.create_account(store, 'pea', 'PEA')
+    accounts_module.create_account(store, 'pea')
 
     pea = next(a for a in accounts_module.read_accounts(store) if a.id == 'pea')
     assert pea.label == 'pea'
@@ -282,10 +281,9 @@ def test_the_default_account_is_never_removed(store):
 
 def test_an_account_declared_here_is_renamed_and_removed_here(store):
     """An account is born in the app, so every gesture on it is the app's."""
-    created = accounts_module.create_account(store, 'pea', 'PEA', 'PEA Bourso')
+    created = accounts_module.create_account(store, 'pea', 'PEA Bourso')
 
-    assert (created.id, created.type, created.label) == \
-        ('pea', 'PEA', 'PEA Bourso')
+    assert (created.id, created.label) == ('pea', 'PEA Bourso')
 
     accounts_module.update_account(store, 'pea', label="PEA Fortuneo")
     assert next(a for a in accounts_module.read_accounts(store)
@@ -296,9 +294,9 @@ def test_an_account_declared_here_is_renamed_and_removed_here(store):
 
 
 def test_two_accounts_cannot_share_an_id(store):
-    accounts_module.create_account(store, 'pea', 'PEA')
+    accounts_module.create_account(store, 'pea')
     with pytest.raises(accounts_module.DuplicateAccount):
-        accounts_module.create_account(store, 'pea', 'CTO')
+        accounts_module.create_account(store, 'pea')
 
 
 def test_an_id_no_route_can_carry_is_refused_before_it_is_written(store):
@@ -325,7 +323,7 @@ def test_creating_an_account_makes_a_blank_column_an_error(store, tmp_path):
     a real account existed — which is exactly the second account's events piling
     onto the first.
     """
-    accounts_module.create_account(store, 'pea', 'PEA')
+    accounts_module.create_account(store, 'pea')
 
     with pytest.raises(entries.InvalidEntry) as refusal:
         _upload(store, tmp_path, V4_SINGLE_ACCOUNT)
@@ -410,8 +408,8 @@ def test_a_declaration_changing_republishes_the_snapshot(tmp_path):
 
 def test_portfolio_ids_and_get():
     portfolio = Portfolio(accounts=[
-        Account(id="PEA", type="PEA", label="Mon PEA"),
-        Account(id="CTO", type="CTO", label="CTO"),
+        Account(id="PEA", label="Mon PEA"),
+        Account(id="CTO", label="CTO"),
     ])
     assert portfolio.ids() == {"PEA", "CTO"}
     assert portfolio.get("PEA").label == "Mon PEA"

--- a/tests/test_carrying.py
+++ b/tests/test_carrying.py
@@ -33,7 +33,7 @@ from application.events.schemas import Account, Event, EventType
 
 
 UTC = timezone.utc
-PEA = Account("PEA", "PEA", "Mon PEA")
+PEA = Account("PEA", "Mon PEA")
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_cash.py
+++ b/tests/test_cash.py
@@ -349,7 +349,7 @@ def test_an_account_with_no_cash_event_writes_holdings_and_gain_and_nothing_else
         Event(date(2024, 1, 1), EventType.BUY, "AAPL", "Apple", quantity=2,
               unit_price=100.0, account="PEA"),
     ]
-    portfolio = Portfolio([Account("PEA", "PEA", "Mon PEA")])
+    portfolio = Portfolio([Account("PEA", "Mon PEA")])
     _seed_price(store, "AAPL", date(2024, 1, 1), 110.0)
 
     m = _metrics(store, declare_ledger, events, portfolio)
@@ -375,7 +375,7 @@ def test_an_account_with_a_deposit_keeps_every_field(
         Event(date(2024, 1, 1), EventType.BUY, "AAPL", "Apple", quantity=2,
               unit_price=100.0, account="PEA"),
     ]
-    portfolio = Portfolio([Account("PEA", "PEA", "Mon PEA")])
+    portfolio = Portfolio([Account("PEA", "Mon PEA")])
     _seed_price(store, "AAPL", date(2024, 1, 1), 110.0)
 
     m = _metrics(store, declare_ledger, events, portfolio)
@@ -411,8 +411,8 @@ def test_the_global_is_written_from_the_max_of_the_horizons(
         Event(date(2024, 1, 1), EventType.BUY, "AAPL", "Apple", quantity=2,
               unit_price=100.0, account="PEA"),
     ]
-    portfolio = Portfolio([Account("PEA", "PEA", "Mon PEA"),
-                           Account("CTO", "CTO", "My CTO")])
+    portfolio = Portfolio([Account("PEA", "Mon PEA"),
+                           Account("CTO", "My CTO")])
     _seed_price(store, "AAPL", date(2024, 1, 3), 110.0)
 
     m = _metrics(store, declare_ledger, events, portfolio)
@@ -498,7 +498,7 @@ def test_a_new_line_leaves_no_perf_cycle_writing_an_empty_table(
     _fixed_today(mocker, 2024, 1, 10)
     _seed_price(store, "OLD", date(2020, 1, 2), 100.0)
     m = _metrics(store, declare_ledger, _a_portfolio_that_buys_a_new_line(),
-                 Portfolio([Account("PEA", "PEA", "Mon PEA")]))
+                 Portfolio([Account("PEA", "Mon PEA")]))
     m.backfill_delay = 0
     m._share_info_cache["NEW"] = {"currency": "EUR"}
 
@@ -541,7 +541,7 @@ def test_buying_a_never_quoted_line_does_not_delete_four_years_of_history(
     _fixed_today(mocker, 2024, 1, 10)
     _seed_price(store, "OLD", date(2020, 1, 2), 100.0)
     m = _metrics(store, declare_ledger, _a_portfolio_that_buys_a_new_line(),
-                 Portfolio([Account("PEA", "PEA", "Mon PEA")]))
+                 Portfolio([Account("PEA", "Mon PEA")]))
 
     horizons = m.update_account_metrics()
 
@@ -582,7 +582,7 @@ def test_a_first_purchase_with_no_price_still_writes_nothing_at_all(
         Event(_BOUGHT, EventType.DEPOSIT, amount=1000.0, account="PEA"),
         Event(_BOUGHT, EventType.BUY, "NEW", "New", quantity=5,
               unit_price=50.0, account="PEA"),
-    ], Portfolio([Account("PEA", "PEA", "Mon PEA")]))
+    ], Portfolio([Account("PEA", "Mon PEA")]))
 
     horizons = m.update_account_metrics()
 
@@ -598,7 +598,7 @@ def test_update_account_metrics_writes_series_with_midnight_stamp(
         Event(date(2024, 1, 2), EventType.BUY, "AAPL", "Apple", quantity=2,
               unit_price=100.0, account="PEA"),
     ]
-    portfolio = Portfolio([Account("PEA", "PEA", "Mon PEA")])
+    portfolio = Portfolio([Account("PEA", "Mon PEA")])
     # Price series: AAPL at 110 from 2024-01-02.
     _seed_price(store, "AAPL", date(2024, 1, 2), 110.0)
 
@@ -626,7 +626,7 @@ def test_update_account_metrics_writes_series_with_midnight_stamp(
 def test_update_account_metrics_is_idempotent(store, declare_ledger, mocker):
     """Two cycles with no new event produce the identical point set."""
     events = [Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA")]
-    portfolio = Portfolio([Account("PEA", "PEA", "Mon PEA")])
+    portfolio = Portfolio([Account("PEA", "Mon PEA")])
 
     m = _metrics(store, declare_ledger, events, portfolio)
     _fixed_today(mocker, 2024, 1, 1)
@@ -643,7 +643,7 @@ def test_update_account_metrics_is_idempotent(store, declare_ledger, mocker):
 def test_update_account_metrics_writes_portfolio_totals_single_currency(
         store, declare_ledger, mocker):
     events = [Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA")]
-    portfolio = Portfolio([Account("PEA", "PEA", "Mon PEA")])
+    portfolio = Portfolio([Account("PEA", "Mon PEA")])
 
     m = _metrics(store, declare_ledger, events, portfolio)
     _fixed_today(mocker, 2024, 1, 2)
@@ -669,8 +669,8 @@ def test_two_accounts_are_pooled_because_they_cannot_disagree_on_a_currency(
         Event(date(2024, 1, 1), EventType.DEPOSIT, amount=500.0, account="CTO"),
     ]
     portfolio = Portfolio([
-        Account("PEA", "PEA", "Mon PEA"),
-        Account("CTO", "CTO", "My CTO"),
+        Account("PEA", "Mon PEA"),
+        Account("CTO", "My CTO"),
     ])
     m = _metrics(store, declare_ledger, events, portfolio)
     _fixed_today(mocker, 2024, 1, 2)
@@ -693,7 +693,7 @@ def test_no_base_currency_writes_no_performance_at_all(
     """
     events = [Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0,
                     account="PEA")]
-    portfolio = Portfolio([Account("PEA", "PEA", "Mon PEA")])
+    portfolio = Portfolio([Account("PEA", "Mon PEA")])
 
     m = _metrics(store, declare_ledger, events, portfolio)
     m.base_currency = None
@@ -732,7 +732,7 @@ def test_the_gain_is_written_on_every_day_and_the_rate_only_on_the_last(
         Event(date(2024, 1, 1), EventType.BUY, "AAPL", "Apple", quantity=10,
               unit_price=100.0, account="PEA"),
     ]
-    portfolio = Portfolio([Account("PEA", "PEA", "Mon PEA")])
+    portfolio = Portfolio([Account("PEA", "Mon PEA")])
     _seed_price(store, "AAPL", date(2024, 1, 1), 100.0)
     _seed_price(store, "AAPL", date(2025, 1, 1), 110.0)
 
@@ -800,7 +800,7 @@ def test_every_cycle_rewrites_the_whole_series(store, declare_ledger, mocker):
     that affordable (ADR-0011).
     """
     events = [Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA")]
-    portfolio = Portfolio([Account("PEA", "PEA", "Mon PEA")])
+    portfolio = Portfolio([Account("PEA", "Mon PEA")])
     m = _metrics(store, declare_ledger, events, portfolio)
     _fixed_today(mocker, 2024, 1, 3)
 
@@ -828,7 +828,7 @@ def test_the_series_is_dense_over_calendar_days(store, declare_ledger, mocker):
               unit_price=100.0, account="PEA"),
         Event(date(2024, 1, 6), EventType.DEPOSIT, amount=500.0, account="PEA"),
     ]
-    portfolio = Portfolio([Account("PEA", "PEA", "Mon PEA")])
+    portfolio = Portfolio([Account("PEA", "Mon PEA")])
     _seed_price(store, "AAPL", date(2024, 1, 5), 110.0)   # Friday, and only it
 
     m = _metrics(store, declare_ledger, events, portfolio)
@@ -854,7 +854,7 @@ def test_deleting_the_rows_is_enough_to_rebuild(store, declare_ledger, mocker):
     designed a *rebuild* button has nothing left to design.
     """
     events = [Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA")]
-    portfolio = Portfolio([Account("PEA", "PEA", "Mon PEA")])
+    portfolio = Portfolio([Account("PEA", "Mon PEA")])
     m = _metrics(store, declare_ledger, events, portfolio)
     _fixed_today(mocker, 2024, 1, 3)
 
@@ -885,7 +885,7 @@ def test_the_file_does_not_drift_over_many_cycles(store, declare_ledger, mocker)
         Event(date(2023, 1, 2), EventType.BUY, "AAPL", "Apple", quantity=2,
               unit_price=100.0, account="PEA"),
     ]
-    portfolio = Portfolio([Account("PEA", "PEA", "Mon PEA")])
+    portfolio = Portfolio([Account("PEA", "Mon PEA")])
     _seed_price(store, "AAPL", date(2023, 1, 2), 110.0)
     m = _metrics(store, declare_ledger, events, portfolio)
     _fixed_today(mocker, 2024, 1, 1)          # a year of daily points
@@ -914,7 +914,7 @@ def test_a_day_that_left_the_series_is_pruned(store, declare_ledger, mocker):
         Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA"),
         Event(date(2024, 1, 3), EventType.DEPOSIT, amount=10.0, account="PEA"),
     ]
-    portfolio = Portfolio([Account("PEA", "PEA", "Mon PEA")])
+    portfolio = Portfolio([Account("PEA", "Mon PEA")])
     m = _metrics(store, declare_ledger, events, portfolio)
     _fixed_today(mocker, 2024, 1, 4)
 
@@ -945,8 +945,8 @@ def test_an_account_that_stops_being_written_is_pruned(
         Event(date(2024, 1, 1), EventType.DEPOSIT, amount=500.0, account="CTO"),
     ]
     portfolio = Portfolio([
-        Account("PEA", "PEA", "Mon PEA"),
-        Account("CTO", "CTO", "My CTO"),
+        Account("PEA", "Mon PEA"),
+        Account("CTO", "My CTO"),
     ])
     m = _metrics(store, declare_ledger, events, portfolio)
     _fixed_today(mocker, 2024, 1, 2)
@@ -970,7 +970,7 @@ def test_an_emptied_ledger_empties_both_tables(store, declare_ledger, mocker):
     declares — the rule ``positions.write_state`` already follows.
     """
     events = [Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA")]
-    portfolio = Portfolio([Account("PEA", "PEA", "Mon PEA")])
+    portfolio = Portfolio([Account("PEA", "Mon PEA")])
     m = _metrics(store, declare_ledger, events, portfolio)
     _fixed_today(mocker, 2024, 1, 2)
 
@@ -992,7 +992,7 @@ def test_a_failed_write_leaves_the_previous_cache_whole(
     *complete* one, and the next tick rebuilds it whatever happened here.
     """
     events = [Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA")]
-    portfolio = Portfolio([Account("PEA", "PEA", "Mon PEA")])
+    portfolio = Portfolio([Account("PEA", "Mon PEA")])
     m = _metrics(store, declare_ledger, events, portfolio)
     _fixed_today(mocker, 2024, 1, 3)
 
@@ -1045,7 +1045,7 @@ def test_an_event_dated_in_the_future_does_not_bound_the_series(
               unit_price=50.0, account="PEA"),
     ]
     m = _metrics(store, declare_ledger, events,
-                 Portfolio([Account("PEA", "PEA", "Mon PEA")]))
+                 Portfolio([Account("PEA", "Mon PEA")]))
 
     horizons = m.update_account_metrics()
 
@@ -1085,7 +1085,7 @@ def test_a_future_buy_back_no_longer_holds_a_sold_line_at_today(
               unit_price=70.0, account="PEA"),
     ]
     m = _metrics(store, declare_ledger, events,
-                 Portfolio([Account("PEA", "PEA", "Mon PEA")]))
+                 Portfolio([Account("PEA", "Mon PEA")]))
 
     m.update_account_metrics()
 

--- a/tests/test_entries.py
+++ b/tests/test_entries.py
@@ -65,11 +65,9 @@ def _upload(store, tmp_path, body=ONE_BUY, name='2024.csv'):
     return entries.create_many(store, EventLoader(str(path)).load())
 
 
-def _declare(store, account_id='pea', account_type='PEA',
-             label="Plan d'épargne en actions"):
+def _declare(store, account_id='pea', label="Plan d'épargne en actions"):
     """One account, declared the way the app declares it (ADR-0034)."""
-    return accounts_module.create_account(store, account_id, account_type,
-                                          label)
+    return accounts_module.create_account(store, account_id, label)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -120,13 +120,12 @@ def _declared_rows(path):
 
 def _declare_from(opened, path):
     """The file's accounts, declared the way the app declares them (ADR-0034)."""
-    for account_id, account_type, label in _declared_rows(path):
+    for account_id, _, label in _declared_rows(path):
         if account_id in accounts_module.account_ids(opened):
-            opened.execute(
-                'UPDATE account SET type = ?, label = ? WHERE id = ?',
-                [account_type, label, account_id])
+            opened.execute('UPDATE account SET label = ? WHERE id = ?',
+                           [label, account_id])
             continue
-        accounts_module.create_account(opened, account_id, account_type, label)
+        accounts_module.create_account(opened, account_id, label)
 
 
 def _write_events(opened, path):
@@ -838,7 +837,10 @@ def test_a_figure_appears_once_and_a_name_repeats(tmp_path):
     # to reach the holdings and not the balance line alone.
     assert account['account_label'] == 'PEA Boursorama'
     assert position['account_label'] == 'PEA Boursorama'
-    assert position['account_type'] == 'PEA'
+    # **And there is no `account_type` column at all** (#916, ADR-0043): the
+    # value it carried is written by the app and read by nobody, so every row
+    # of it would have said the same seeded word.
+    assert 'account_type' not in position
     # And nothing of the position is on the account's own row.
     assert account['quantity'] == '' and account['market_value'] == ''
 

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1387,9 +1387,11 @@ def test_a_label_declared_between_the_forecast_and_the_button_is_not_refused(
 
     assert response.status_code == 201
     assert _rows_by_account(opened) == ['TR', 'TR', 'pea']
-    # And it is still the account the reader declared, with the type they gave.
+    # And it is still the account the reader declared. The `type` member they
+    # sent is **read by nothing** (#916, ADR-0043): the request is not refused
+    # for carrying it, and the column keeps the seeded word the app writes.
     assert opened.query('SELECT type FROM account WHERE id = ?', ['TR']) == \
-        [('CTO',)]
+        [(store_module.DEFAULT_ACCOUNT_ROW[1],)]
 
 
 def test_a_correspondence_that_is_not_one_is_refused_before_anything(tmp_path):

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1228,6 +1228,12 @@ def test_a_correspondence_declares_the_account_nobody_had_declared(tmp_path):
     assert _rows_by_account(opened) == ['TR', 'TR', 'pea']
     assert opened.query('SELECT type FROM account WHERE id = ?', ['TR']) == \
         [(store_module.DEFAULT_ACCOUNT_ROW[1],)]
+    # **And its name is its id**, which is what a row nobody named must carry.
+    # The seeded word belongs to the column nothing reads; the moment it reached
+    # the *label* instead, this account was called `OTHER` on every screen — and
+    # the whole suite stayed green, which is why the assertion is here.
+    assert opened.query('SELECT label FROM account WHERE id = ?', ['TR']) == \
+        [('TR',)]
 
 
 def test_the_correspondence_applies_before_the_split_at_both_moments(tmp_path):

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -35,8 +35,8 @@ def _price_at(prices):
     return price_at
 
 
-PEA = Account("PEA", "PEA", "Mon PEA")
-CTO = Account("CTO", "CTO", "My CTO")
+PEA = Account("PEA", "Mon PEA")
+CTO = Account("CTO", "My CTO")
 
 
 # --------------------------------------------------------------------------- #
@@ -405,7 +405,7 @@ def test_a_grants_contribution_does_not_move_with_the_backfill():
 #
 # AAPL quotes 200 € today, so holdings are 2 000,00 €.
 
-WORKED_EXAMPLE_ACCOUNT = Account("CTO", "CTO", "Mon CTO")
+WORKED_EXAMPLE_ACCOUNT = Account("CTO", "Mon CTO")
 TODAY = date(2025, 4, 20)
 
 
@@ -504,7 +504,7 @@ def test_two_accounts_pool_because_an_account_has_no_currency():
 
 
 def test_portfolio_total_aggregates_the_accounts_it_is_given():
-    pea2 = Account("PEA2", "PEA", "PEA 2")
+    pea2 = Account("PEA2", "PEA 2")
     tl = EventAggregator().replay([
         Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA"),
         Event(date(2024, 1, 1), EventType.DEPOSIT, amount=500.0, account="PEA2"),
@@ -940,7 +940,7 @@ def test_the_global_is_written_only_where_every_account_is():
     back, on the one page the product opens on. The consequence is accepted
     rather than worked around: one slow account delays the whole home page.
     """
-    cto = Account("CTO", "CTO", "My CTO")
+    cto = Account("CTO", "My CTO")
     tl = EventAggregator().replay([
         Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA"),
         Event(date(2024, 1, 1), EventType.DEPOSIT, amount=500.0, account="CTO"),
@@ -1012,7 +1012,7 @@ def test_the_global_loses_its_cash_half_when_one_account_has_no_ledger():
     global ``total_value`` carrying it is the very figure the per-field rule
     exists to remove, at the level of the whole portfolio.
     """
-    cto = Account("CTO", "CTO", "My CTO")
+    cto = Account("CTO", "My CTO")
     tl = EventAggregator().replay([
         Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA"),
         Event(date(2024, 1, 1), EventType.BUY, "AAPL", "Apple", quantity=1,
@@ -1044,7 +1044,7 @@ def test_an_account_declared_and_never_used_does_not_veto_the_global():
     to make unwritable — and ADR-0013's seeded row would otherwise take the cash
     half off every install that declared its accounts by hand.
     """
-    cto = Account("CTO", "CTO", "My CTO")
+    cto = Account("CTO", "My CTO")
     tl = EventAggregator().replay([
         Event(date(2024, 1, 1), EventType.DEPOSIT, amount=1000.0, account="PEA"),
     ])

--- a/tests/test_portfolio_view.py
+++ b/tests/test_portfolio_view.py
@@ -482,12 +482,14 @@ def test_a_mover_carries_no_currency_of_its_own():
 # The accounts comparison table (issue #661)
 # --------------------------------------------------------------------- #
 
-def declared(id='pea', label='PEA Bourso', type='PEA'):
+def declared(id='pea', label='PEA Bourso'):
     """A declared account — the shape `Portfolio.accounts` holds.
 
-    No `currency`: `Account.currency` is deleted (#702, ADR-0002).
+    No `currency`: `Account.currency` is deleted (#702, ADR-0002). No `type`
+    either since #916 (ADR-0043): the column was read by nothing, so the
+    declaration has one identity field left and it is the name.
     """
-    return SimpleNamespace(id=id, label=label, type=type)
+    return SimpleNamespace(id=id, label=label)
 
 
 def metrics(account='pea', **overrides):
@@ -510,7 +512,7 @@ def test_accounts_keep_their_declaration_order():
     """The store's `ORDER BY id`, stable across restarts and across a re-drop —
     and the table sorts on demand anyway."""
     summaries = build_accounts(
-        [declared('cto', 'CTO Degiro', 'CTO'), declared('pea')],
+        [declared('cto', 'CTO Degiro'), declared('pea')],
         [metrics('pea'), metrics('cto')])
 
     assert [s.id for s in summaries] == ['cto', 'pea']
@@ -519,14 +521,14 @@ def test_accounts_keep_their_declaration_order():
 def test_a_declared_account_with_no_series_is_a_row_of_absences():
     """Declared but not yet computed. #652 déc. 4 makes the declaration the
     list, so no data cannot remove a row — it empties one."""
-    summaries = build_accounts([declared('pea'), declared('cto', 'CTO', 'CTO')],
+    summaries = build_accounts([declared('pea'), declared('cto', 'CTO')],
                                [metrics('pea')])
 
     assert summaries[1].as_of is None
     assert summaries[1].total_value is None
     assert summaries[1].xirr is None
-    # The identity fields still come from the declaration.
-    assert (summaries[1].label, summaries[1].type) == ('CTO', 'CTO')
+    # The identity field still comes from the declaration.
+    assert summaries[1].label == 'CTO'
 
 
 def test_a_series_without_a_declaration_is_not_a_row():
@@ -536,15 +538,17 @@ def test_a_series_without_a_declaration_is_not_a_row():
     assert [s.id for s in summaries] == ['pea']
 
 
-def test_the_identity_fields_come_from_the_declaration_alone():
-    """Since #700 the series has no column for them at all: `account_type` and
+def test_the_identity_field_comes_from_the_declaration_alone():
+    """Since #700 the series has no column for it at all: `account_type` and
     `account_currency` were InfluxDB *tags*, recording what the account was when
-    the point was written. The declaration is what it is — and since #702 it
-    declares no currency at all, so the row does not carry one."""
+    the point was written. The declaration is what it is — and it declares
+    neither a currency (#702) nor a type (#916), so the row carries just the
+    name and the figures."""
     summaries = build_accounts([declared('pea')], [metrics('pea')])
 
-    assert 'currency' not in summaries[0].to_dict()
-    assert summaries[0].type == 'PEA'
+    for absent in ('currency', 'type'):
+        assert absent not in summaries[0].to_dict()
+    assert summaries[0].label == 'PEA Bourso'
     assert summaries[0].as_of == date(2026, 8, 5)
     assert summaries[0].to_dict()['as_of'] == '2026-08-05'
 
@@ -554,7 +558,7 @@ def test_nothing_is_summed_across_accounts():
     and a second arithmetic path to the same number is how two of them come to
     disagree — besides being plain wrong across currencies."""
     summaries = build_accounts(
-        [declared('pea'), declared('cto', 'CTO', 'CTO')],
+        [declared('pea'), declared('cto', 'CTO')],
         [metrics('pea', total_value=12500.0), metrics('cto', total_value=3000.0)])
 
     assert [s.total_value for s in summaries] == [12500.0, 3000.0]

--- a/tests/test_reassignment.py
+++ b/tests/test_reassignment.py
@@ -67,7 +67,7 @@ def test_the_blank_column_lands_under_the_seeded_row(store, tmp_path):
 def test_reassignment_moves_every_unassigned_event_onto_the_declaration(
         store, tmp_path):
     _the_month_before_declaring(store, tmp_path)
-    accounts_module.create_account(store, 'pea', 'PEA', 'Plan')
+    accounts_module.create_account(store, 'pea', 'Plan')
 
     with store.transaction():
         moved = reassignment.reassign_unassigned(store, 'pea')
@@ -90,7 +90,7 @@ def test_the_column_is_the_whole_population(store, tmp_path):
         'SELECT count(*) FROM event WHERE account = ?', [DEFAULT_ACCOUNT]
     )[0][0] == 3
 
-    accounts_module.create_account(store, 'pea', 'PEA', 'Plan')
+    accounts_module.create_account(store, 'pea', 'Plan')
     with store.transaction():
         reassignment.reassign_unassigned(store, 'pea')
 
@@ -104,7 +104,7 @@ def test_a_row_typed_here_carrying_default_goes_with_them(store, tmp_path):
                                 'Apple Inc', quantity=1, unit_price=10.0))
     assert reassignment.unassigned_events(store) == 4
 
-    accounts_module.create_account(store, 'pea', 'PEA', 'Plan')
+    accounts_module.create_account(store, 'pea', 'Plan')
     with store.transaction():
         assert reassignment.reassign_unassigned(store, 'pea') == 4
 
@@ -117,8 +117,8 @@ def test_after_the_reassignment_nothing_moves_a_row_again(
         store, tmp_path):
     """*Jamais ensuite* — and it is the ``WHERE`` that says so, not a flag."""
     _the_month_before_declaring(store, tmp_path)
-    accounts_module.create_account(store, 'pea', 'PEA', 'Plan')
-    accounts_module.create_account(store, 'cto', 'CTO', 'Titres')
+    accounts_module.create_account(store, 'pea', 'Plan')
+    accounts_module.create_account(store, 'cto', 'Titres')
 
     with store.transaction():
         reassignment.reassign_unassigned(store, 'pea')
@@ -138,8 +138,8 @@ def test_a_reassigned_row_is_then_an_ordinary_row(store, tmp_path):
     rewritten in place afterwards, like any other.
     """
     _the_month_before_declaring(store, tmp_path)
-    accounts_module.create_account(store, 'pea', 'PEA', 'Plan')
-    accounts_module.create_account(store, 'cto', 'CTO', 'Titres')
+    accounts_module.create_account(store, 'pea', 'Plan')
+    accounts_module.create_account(store, 'cto', 'Titres')
     with store.transaction():
         reassignment.reassign_unassigned(store, 'pea')
 
@@ -196,7 +196,7 @@ def test_nothing_declared_means_no_target_at_all(store, tmp_path):
 def test_the_unassigned_line_disappears_from_the_declaration(store, tmp_path):
     """``default`` leaves ``declared_portfolio`` the moment nothing names it."""
     _the_month_before_declaring(store, tmp_path)
-    accounts_module.create_account(store, 'pea', 'PEA', 'Plan')
+    accounts_module.create_account(store, 'pea', 'Plan')
     before = accounts_module.declared_portfolio(store)
     assert sorted(before.ids()) == ['default', 'pea']
 
@@ -210,7 +210,7 @@ def test_the_unassigned_line_disappears_from_the_declaration(store, tmp_path):
 def test_the_seeded_row_becomes_removable_again(store, tmp_path):
     """Not a promise the module makes — a consequence the owner can observe."""
     _the_month_before_declaring(store, tmp_path)
-    accounts_module.create_account(store, 'pea', 'PEA', 'Plan')
+    accounts_module.create_account(store, 'pea', 'Plan')
     with store.transaction():
         reassignment.reassign_unassigned(store, 'pea')
     assert accounts_module.is_named_by_events(store, DEFAULT_ACCOUNT) is False
@@ -220,7 +220,7 @@ def test_the_ledger_it_leaves_is_replayed_before_the_commit(store, tmp_path):
     """:mod:`entries`' last assertion, for the same reason: a ledger that does
     not replay committed here fails the **boot**."""
     _the_month_before_declaring(store, tmp_path)
-    accounts_module.create_account(store, 'pea', 'PEA', 'Plan')
+    accounts_module.create_account(store, 'pea', 'Plan')
     with store.transaction():
         reassignment.reassign_unassigned(store, 'pea')
 
@@ -246,17 +246,24 @@ def test_a_renamed_seed_is_a_declaration_and_its_events_are_assigned(
 
     assert reassignment.unassigned_events(store) == 0
 
-    accounts_module.create_account(store, 'cto', 'CTO', 'Titres')
+    accounts_module.create_account(store, 'cto', 'Titres')
     with store.transaction():
         assert reassignment.reassign_unassigned(store, 'cto') == 0
     assert _accounts_of(store) == [DEFAULT_ACCOUNT] * 3
 
 
-def test_a_retyped_seed_is_a_declaration_too(store, tmp_path):
-    """The other seeded column, and it is one rule on both (``as_declared``)."""
-    _the_month_before_declaring(store, tmp_path)
-    accounts_module.update_account(store, DEFAULT_ACCOUNT, account_type='PEA')
+def test_the_name_is_the_whole_of_what_declares_the_seed(store, tmp_path):
+    """There was a second half to this rule, and #916 removed it.
 
+    ``as_declared`` used to compare **two** seeded columns, so retyping the row
+    declared it as surely as renaming it did. The type is gone (ADR-0043), so the
+    name is the whole predicate — and this asserts the half that is left is
+    genuinely doing the work alone.
+    """
+    _the_month_before_declaring(store, tmp_path)
+    assert reassignment.unassigned_events(store) == 3
+
+    accounts_module.update_account(store, DEFAULT_ACCOUNT, label='Mon PEA')
     assert reassignment.unassigned_events(store) == 0
 
 

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -225,13 +225,12 @@ def declare_accounts(opened, path):
     rather than inserted — which is also the one way an install with a page and
     no file declares its single account.
     """
-    for account_id, account_type, label in _declared_rows(path):
+    for account_id, _, label in _declared_rows(path):
         if account_id in accounts_module.account_ids(opened):
-            opened.execute(
-                'UPDATE account SET type = ?, label = ? WHERE id = ?',
-                [account_type, label, account_id])
+            opened.execute('UPDATE account SET label = ? WHERE id = ?',
+                           [label, account_id])
             continue
-        accounts_module.create_account(opened, account_id, account_type, label)
+        accounts_module.create_account(opened, account_id, label)
 
 
 def write_event_file(opened, path):
@@ -1547,7 +1546,10 @@ def test_accounts_says_undeclared_and_still_serves_the_seeded_row(tmp_path):
     # seed's English on the far side of HTTP — see the test below, which is where
     # that rule is guarded.
     seeded = payload['accounts'][0]
-    assert (seeded['label'], seeded['type']) == (None, None)
+    assert seeded['label'] is None
+    # And no `type` at all since #916 (ADR-0043): the column is written by the
+    # app, read by nobody, and therefore served to nobody.
+    assert 'type' not in seeded
     # And nothing says where the row came from: an account is born in the app
     # (ADR-0034), so the rename is an ordinary `PATCH` with no rule to consult.
     assert not {'source_id', 'editable'} & set(seeded)
@@ -1565,24 +1567,27 @@ def test_renaming_the_seeded_account_is_visible_on_the_resource(tmp_path):
     """
     client = build_client(tmp_path)
 
+    # The `type` member is sent and **read by nothing** (#916): a client that
+    # still carries it is not refused, and nothing of it is written.
     renamed = client.patch('/api/accounts/default',
                            json={'label': 'Mon PEA', 'type': 'PEA'})
 
     assert renamed.status_code == 200
     payload = client.get('/api/accounts').get_json()
     assert payload['declared'] is False
-    assert [(a['id'], a['label'], a['type']) for a in payload['accounts']] == [
-        ('default', 'Mon PEA', 'PEA')]
+    assert [(a['id'], a['label']) for a in payload['accounts']] == [
+        ('default', 'Mon PEA')]
 
 
 def test_the_seed_never_crosses_the_wire_and_the_owners_name_does(tmp_path):
     """What nobody declared goes out as ``null``, and the recognising is here.
 
-    ``store.DEFAULT_ACCOUNT_ROW`` writes ``Default account`` / ``OTHER`` into a
-    row every install owns and nobody asked for. The front must not render
-    either — they are the *server's* English, and ADR-0024 puts every rendering
-    in the reader's language — so one side has to recognise them, and it is the
-    side that writes them.
+    ``store.DEFAULT_ACCOUNT_ROW`` writes ``Default account`` into the label of a
+    row every install owns and nobody asked for. The front must not render it —
+    it is the *server's* English, and ADR-0024 puts every rendering in the
+    reader's language — so one side has to recognise it, and it is the side that
+    writes it. (The seed's other word, ``OTHER``, no longer crosses anything:
+    #916 took the type off the wire entirely.)
 
     Recognising them in the client was written first and undone: it put a third
     copy of this string across HTTP, where nothing spans both ends. The front's
@@ -1599,22 +1604,19 @@ def test_the_seed_never_crosses_the_wire_and_the_owners_name_does(tmp_path):
     client = build_client(tmp_path)
 
     served = client.get('/api/accounts').get_json()['accounts']
-    assert [(a['id'], a['label'], a['type']) for a in served] == [
-        ('default', None, None)]
+    assert [(a['id'], a['label']) for a in served] == [('default', None)]
     # Read off the constant rather than quoted: this assertion has to fail when
     # the seed is reworded, which is the whole reason it exists.
-    _, seeded_type, seeded_label = store.DEFAULT_ACCOUNT_ROW
-    assert (seeded_label, seeded_type) not in [
-        (a['label'], a['type']) for a in served]
+    _, _, seeded_label = store.DEFAULT_ACCOUNT_ROW
+    assert seeded_label not in [a['label'] for a in served]
 
     # An account that is **not** the seeded one keeps whatever it says, the
     # seed's own words included if its owner chose them: what is recognised is
     # one row, never a string.
-    client.post('/api/accounts',
-                json={'id': 'pea', 'label': seeded_label, 'type': seeded_type})
-    named = [(a['id'], a['label'], a['type'])
+    client.post('/api/accounts', json={'id': 'pea', 'label': seeded_label})
+    named = [(a['id'], a['label'])
              for a in client.get('/api/accounts').get_json()['accounts']]
-    assert ('pea', seeded_label, seeded_type) in named
+    assert ('pea', seeded_label) in named
     # The seeded row leaves the list here for its own reason and not this one:
     # nothing names it, so ADR-0013 keeps it out of a declaration it did not
     # join (#698). What is asserted above is that its *words* are not the guard.
@@ -1622,9 +1624,10 @@ def test_the_seed_never_crosses_the_wire_and_the_owners_name_does(tmp_path):
 
 def test_accounts_returns_the_declaration_with_its_labels(tmp_path):
     """Reading the declaration rather than a DISTINCT on the tag (#652 déc. 4)
-    hands over label and type — fields the app writes and zero Grafana panels
-    read. An account is declared in the app and nowhere else (ADR-0034), so
-    there is nothing beside them saying where the row came from."""
+    hands over the label — the one identity field left since #916 took the type
+    away, and one zero Grafana panels ever read. An account is declared in the
+    app and nowhere else (ADR-0034), so there is nothing beside it saying where
+    the row came from."""
     accounts = (
         "id,type,label\n"
         "pea,PEA,PEA Bourso\n"
@@ -1638,8 +1641,8 @@ def test_accounts_returns_the_declaration_with_its_labels(tmp_path):
 
     assert payload['declared'] is True
     row = payload['accounts'][0]
-    assert (row['id'], row['label'], row['type']) == ('pea', 'PEA Bourso', 'PEA')
-    assert not {'source_id', 'editable'} & set(row)
+    assert (row['id'], row['label']) == ('pea', 'PEA Bourso')
+    assert not {'source_id', 'editable', 'type'} & set(row)
     # #661 enriched the resource with the newest perf figures. With nothing
     # written yet they are all null and `as_of` says so — a declared account
     # whose first perf cycle has not run is a row with em dashes, not a missing
@@ -1663,10 +1666,11 @@ def test_accounts_carries_the_newest_figures_of_each_account(tmp_path):
     assert row['gain_absolu'] == 2500.0
     assert row['twr_index'] == 118.4
     assert row['as_of'] == '2026-08-05'
-    # The declaration drives the identity fields, and since #700 it is the only
+    # The declaration drives the identity field, and since #700 it is the only
     # thing that could: `account_type` and `account_currency` were InfluxDB
-    # tags, and the store has no column for either.
-    assert row['type'] == 'PEA'
+    # tags. The type has since left the wire altogether (#916), so the name is
+    # what the declaration hands over.
+    assert row['label'] == 'PEA Bourso'
 
 
 def test_accounts_keeps_a_declared_account_that_has_no_series_yet(tmp_path):
@@ -3434,7 +3438,7 @@ def test_the_report_reads_the_store_and_not_the_published_snapshot(tmp_path):
     client, opened = build_client_and_store(
         tmp_path, accounts=_EXPORTABLE_ACCOUNTS, events=_EXPORTABLE)
 
-    accounts_module.create_account(opened, 'cto', 'CTO', 'Compte-titres')
+    accounts_module.create_account(opened, 'cto', 'Compte-titres')
 
     served = client.get('/api/accounts').get_json()
     assert 'cto' not in [row['id'] for row in served['accounts']]
@@ -4917,20 +4921,21 @@ def test_a_sale_does_not_lower_the_month_that_holds_it(tmp_path):
 # --------------------------------------------------------------------- #
 
 def test_an_account_is_declared_here_renamed_here_and_removed_here(tmp_path):
-    """The one place an account is born, and three members on the wire.
+    """The one place an account is born, and **two** members on the wire.
 
-    No ``source_id`` and no ``editable``: an account is declared in the app and
-    nowhere else (ADR-0034), so there is no second population to tell this row
-    from and no rule about it for the front to re-implement.
+    It was three: the type left with #916 (ADR-0043), read by nothing and
+    therefore served to nobody. No ``source_id`` and no ``editable`` either — an
+    account is declared in the app and nowhere else (ADR-0034), so there is no
+    second population to tell this row from and no rule about it for the front
+    to re-implement.
     """
     client = build_client(tmp_path)
 
     created = client.post('/api/accounts',
-                          json={'id': 'pea', 'type': 'PEA', 'label': 'PEA Bourso'})
+                          json={'id': 'pea', 'label': 'PEA Bourso'})
 
     assert created.status_code == 201
-    assert created.get_json() == {'id': 'pea', 'type': 'PEA',
-                                  'label': 'PEA Bourso'}
+    assert created.get_json() == {'id': 'pea', 'label': 'PEA Bourso'}
     # The replay followed the write: the declaration is already published.
     listed = client.get('/api/accounts').get_json()
     assert listed['declared'] is True

--- a/website/docs/coming-from-v4.mdx
+++ b/website/docs/coming-from-v4.mdx
@@ -75,9 +75,11 @@ column, and the two meet. Rename it on the *Accounts* page whenever you like.
 
 **If version 4 had one**, declare each account before importing, on the
 *Accounts* page, with **the same `id`** your rows already name — that id is the
-whole of the continuity. `type` and `label` carry over as they were; `currency`
-has nowhere to go, because version 5 has one reporting currency for the whole
-install and none on an account at all (ADR-0002). A file naming an account you
+whole of the continuity. `label` carries over as it was; `type` has nowhere to
+go either — version 5 asks for no account type, so put what it said into the
+name if you want to keep it — and `currency` has nowhere to go because version 5
+has one reporting currency for the whole install and none on an account at all
+(ADR-0002). A file naming an account you
 have not declared is **not imported at all** — not partially — and the message
 names the account. See
 [Declaring your accounts](./import-your-events.mdx#declaring-your-accounts).

--- a/website/docs/import-your-events.mdx
+++ b/website/docs/import-your-events.mdx
@@ -165,13 +165,16 @@ ignored, because a deposit that names a ticker means something was misfiled.
 
 An account is user data — not a setting, and not something a file brings with
 it. **It is declared in the app**, on the accounts page, and nowhere else. It
-has three fields, and they are the three columns your events name it by.
+has two fields.
 
 | Field | What it holds |
 |---|---|
 | `id` | the id your events name in their `account` column, e.g. `pea` |
-| `type` | `PEA`, `CTO`, … — free text, used for grouping and display |
 | `label` | the name shown on screen, e.g. `PEA Boursorama` |
+
+There was a third, a `type`, and it is gone: nothing in the app ever read it, so
+it asked you a question to display the answer back to you. Call your account
+what it is — `PEA Boursorama` — and the name carries it.
 
 Declaring an account before importing the file that names it is the whole of
 what you have to remember. A few rules follow, and each of them exists to keep a


### PR DESCRIPTION
Closes #916. Implements [ADR-0043](https://github.com/pbrissaud/suivi-bourse/blob/master/docs/adr/0043-the-account-type-stops-being-a-question.md).

`account.type` was asked twice — the account panel and the first-run walk — served on `/api`, exported, and rendered under every account's name. It was read by nothing: the API copied it out, three components displayed it, and its only non-decorative reader used it as a *has the owner touched this row* marker.

**What goes.** The field in both forms, so declaring an account is two fields. The member on `/api/accounts`, on the front's `Account`, on `AccountSummary`, and the `account_type` column of the portfolio CSV export — which would otherwise have carried the same seeded word on every row. Three message keys, dead in both catalogues.

**What stays, and why.** The column. The DDL runs with `IF NOT EXISTS`, `type` is `NOT NULL`, and nothing can drop it until #926 brings the migration machinery; `create_account` writes the seed's own word and no code reads it back. Existing stores keep whatever their owner typed, shown nowhere and repaired by nothing — there is nothing to repair once nothing reads it.

**`POST` and `PATCH` ignore a `type` member rather than refusing it.** `/api` is the front's interface and not a contract held for anybody else (ADR-0033), so a refusal written for a client that does not exist is code for nobody. `tests/test_ledger.py` asserts exactly that: the request is not refused, and the column keeps the word the app writes.

**The subtitle becomes the account id, and this reverses #838** — deliberately, and the assertion in `declaration.test.tsx` is turned round with its reason written in. #838 took the id off the page saying the line heads an account with *what the owner called it and what kind it is*; only one of the two is left, and the id is the half that does concrete work.

`default_is_declared` and the front's `isSeededOnly` now answer on the label alone, where both read two seeded columns before.

**Gates:** `pytest` 1609 · `flake8` · `conventions.sh` · `pnpm lint` · `pnpm test` 796.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CTPVXAQDrZtU3TssYZT4e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changed**
  - Account declarations now use only an identifier and optional name; the account type field has been removed from forms and requests.
  - Account identifiers now appear alongside account names in account lists and details.
  - Account type is no longer included in API responses, portfolio views, or exported reports.
  - Existing account types can no longer be changed; renaming accounts remains supported.
- **Documentation**
  - Updated migration and import guidance to reflect the simplified account declaration format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->