### PR TITLE
feat(taxation): an account carries a declared opening date, pre-filled and contradicted out loud (#918)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,6 +61,26 @@ own absence and its own lifetime (ADR-0044). *Nothing declared* is the absence o
 a row, and it is not the same sentence as *declared as nothing*.
 _Avoid_: account metadata, account settings
 
+**Opening date**:
+The day a wrapper was opened, **as its owner declared it** (#918). It cannot be
+derived and that is the whole point of it: a PEA opened in 2015 and transferred to
+a broker whose ledger is only imported from 2022 derives three years of seniority
+instead of ten. The form offers the account's **first payment** where there is one
+— a suggestion of the interface, which becomes a declaration the moment it is
+submitted and stops moving afterwards. It is asked for only where the account's
+taxation model counts its threshold **from the opening**: a shape whose years run
+from the first payment — a PEA's do — has an age threshold and no use for this
+date (ADR-0042).
+_Avoid_: account creation date, inception date, start date
+
+**First payment**:
+The earliest `DEPOSIT` an account carries. Derived from the ledger on every read
+and stored nowhere: it is what the opening-date field is pre-filled with, and what
+a declared opening date is contradicted against when it comes *after* it. A
+declared date **earlier** than the first payment is ordinary — it is what a
+transferred wrapper looks like.
+_Avoid_: first contribution, funding date
+
 **Projected tax**:
 What an account's taxation model says would be owed **if its holdings were sold
 today**. A projection and never a tax return: no allowance, no loss carry-forward,

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -355,14 +355,8 @@ def _with_account_facts(row: dict, carried: dict, opened_on: dict,
 
 
 def _declared(facts: dict) -> dict:
-    """The facts there are, and no member for the ones there are not.
-
-    **An absence reaches the reader as an absence** (#845, ADR-0044): an account
-    with no model, no declared opening date or no payment on record gets no
-    member rather than a `null` the front would have to tell from *not yet
-    read*. Written once, because it is one rule and both account payloads obey
-    it.
-    """
+    """The facts there are — **an absence reaches the reader as one** (#845,
+    ADR-0044), never as a `null` it would have to tell from *not yet read*."""
     return {name: value for name, value in facts.items() if value is not None}
 
 

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -47,6 +47,7 @@ from api.problem import (
     storage_unavailable,
     too_large,
     unprocessable,
+    unprocessable_account,
     unprocessable_entry,
     unprocessable_file,
     unprocessable_model,
@@ -327,19 +328,42 @@ def list_accounts():
     # rather than a `null` the front would have to tell from *not yet read*
     # (#845, ADR-0044).
     carried = accounts_module.taxation_models_by_account(_store())
+    opened_on = accounts_module.opening_dates_by_account(_store())
+    # **The pre-fill, served and never stored** (#918). It is the ledger's own
+    # figure — the earliest declared payment — and the form offers it where the
+    # account has declared no opening date. Derived here rather than written
+    # anywhere: a declared fact and a derived one do not share a row (ADR-0006).
+    payments = ledger.first_payments(_store())
     return jsonify({
         'declared': accounts is not None,
         'accounts': [
-            _with_taxation_model(summary.to_dict(), carried)
+            _with_account_facts(summary.to_dict(), carried, opened_on, payments)
             for summary in portfolio_view.build_accounts(
                 declaration, rows, reader.transfer_fees_by_account(through))
         ],
     })
 
 
-def _with_taxation_model(row: dict, carried: dict) -> dict:
-    model = carried.get(row['id'])
-    return row if model is None else {**row, 'taxation_model': model}
+def _with_account_facts(row: dict, carried: dict, opened_on: dict,
+                        payments: dict) -> dict:
+    """The three members an account carries where there is one to carry."""
+    return {**row, **_declared({
+        'taxation_model': carried.get(row['id']),
+        'opened_on': instants.iso(opened_on.get(row['id'])),
+        'first_payment': instants.iso(payments.get(row['id'])),
+    })}
+
+
+def _declared(facts: dict) -> dict:
+    """The facts there are, and no member for the ones there are not.
+
+    **An absence reaches the reader as an absence** (#845, ADR-0044): an account
+    with no model, no declared opening date or no payment on record gets no
+    member rather than a `null` the front would have to tell from *not yet
+    read*. Written once, because it is one rule and both account payloads obey
+    it.
+    """
+    return {name: value for name, value in facts.items() if value is not None}
 
 
 def _seeded_only():
@@ -389,6 +413,11 @@ def create_account():
     if body is None:
         return bad_request("a JSON object is required")
 
+    try:
+        day = _opening_day(body)
+    except _InvalidBody as exc:
+        return unprocessable_account(str(exc), key=exc.field)
+
     runtime = current_runtime()
     try:
         with runtime.config_manager.writing() as opened:
@@ -396,9 +425,13 @@ def create_account():
                 account = accounts_module.create_account(
                     opened, body.get('id'), body.get('label'))
                 # What the form **proposed** is not what is written: the offer
-                # is interface, and the row takes what was submitted (#752).
+                # is interface, and the row takes what was submitted (#752,
+                # #918) — the opening date included, which the form pre-fills
+                # from the first payment and never re-derives afterwards.
                 model = accounts_module.set_taxation_model(
                     opened, account.id, body.get('taxation_model'))
+                opened_on = accounts_module.set_opened_on(
+                    opened, account.id, day)
                 if _flag(body.get('reassign')):
                     reassignment.reassign_unassigned(opened, account.id)
     except accounts_module.DuplicateAccount as exc:
@@ -411,7 +444,7 @@ def create_account():
         return _unreplayable(exc, GESTURE_WRITE)
 
     main.replay_after_write(runtime)
-    return jsonify(_account_to_dict(account, model)), 201
+    return jsonify(_account_to_dict(account, model, opened_on)), 201
 
 
 @api_bp.post('/accounts/<account_id>/reassignment')
@@ -440,6 +473,11 @@ def update_account(account_id: str):
     if body is None:
         return bad_request("a JSON object is required")
 
+    try:
+        day = _opening_day(body)
+    except _InvalidBody as exc:
+        return unprocessable_account(str(exc), key=exc.field)
+
     runtime = current_runtime()
     try:
         with runtime.config_manager.writing() as opened:
@@ -461,13 +499,20 @@ def update_account(account_id: str):
                     if 'taxation_model' not in body
                     else accounts_module.set_taxation_model(
                         opened, account_id, body.get('taxation_model')))
+                # The opening date is read the same way, and for the same
+                # reason (#918): a `PATCH` that renames an account must not
+                # take away a date nobody mentioned.
+                opened_on = (
+                    accounts_module.opening_dates_by_account(opened).get(account_id)
+                    if 'opened_on' not in body
+                    else accounts_module.set_opened_on(opened, account_id, day))
     except accounts_module.UnknownAccount as exc:
         return not_found(str(exc))
     except accounts_module.UnknownTaxationModel as exc:
         return unprocessable_model(str(exc), 'taxation_model')
 
     main.replay_after_write(runtime)
-    return jsonify(_account_to_dict(account, model))
+    return jsonify(_account_to_dict(account, model, opened_on))
 
 
 @api_bp.delete('/accounts/<account_id>')
@@ -486,14 +531,42 @@ def delete_account(account_id: str):
     return jsonify({'id': account_id, 'removed': True})
 
 
-def _account_to_dict(account, taxation_model: Optional[str] = None) -> dict:
-    """One :class:`events.schemas.Account`, on the wire."""
-    row = {
+def _account_to_dict(account, taxation_model: Optional[str] = None,
+                     opened_on: Optional[date] = None) -> dict:
+    """One :class:`events.schemas.Account`, on the wire.
+
+    The two facts it may carry are **absent where it carries none** (#752,
+    #918): the front tells an absence from a value, and never from a sentinel.
+    """
+    return {
         'id': account.id,
         'label': account.label,
+        **_declared({
+            'taxation_model': taxation_model,
+            'opened_on': instants.iso(opened_on),
+        }),
     }
-    return row if taxation_model is None else {
-        **row, 'taxation_model': taxation_model}
+
+
+def _opening_day(body: dict) -> Optional[date]:
+    """The ``opened_on`` member as a **day**, or a refusal naming the field.
+
+    ``None`` covers the two sentences the routes tell apart themselves — the
+    member absent, and the member sent as `null` to take the declaration away —
+    because neither of them is a date to parse.
+    """
+    raw = body.get('opened_on')
+    if raw is None:
+        return None
+    if not isinstance(raw, str) or not _ISO_DAY.fullmatch(raw.strip()):
+        raise _InvalidBody(
+            f"opened_on {raw!r} is not a calendar day (YYYY-MM-DD)",
+            'opened_on')
+    try:
+        return date.fromisoformat(raw.strip())
+    except ValueError:
+        raise _InvalidBody(f"opened_on {raw!r} is not a day that exists",
+                           'opened_on')
 
 
 # --------------------------------------------------------------------------- #

--- a/src/api/problem.py
+++ b/src/api/problem.py
@@ -111,6 +111,17 @@ def unprocessable_model(detail: str, key: Optional[str] = None):
                    key=key or None)
 
 
+def unprocessable_account(detail: str, key: Optional[str] = None):
+    """422 — the body parsed, and a fact declared about the account is not one.
+
+    ``unprocessable_model``'s own shape and its identifier (#918): the reader is
+    holding a form they filled, and *this field is not a day that exists* is the
+    whole of the news.
+    """
+    return problem(422, 'Invalid account', detail, TYPE_BAD_REQUEST,
+                   key=key or None)
+
+
 def model_in_use(detail: str, accounts: Sequence[str]):
     """409 — the model cannot go: these accounts carry it (#752).
 

--- a/src/application/CLAUDE.md
+++ b/src/application/CLAUDE.md
@@ -105,9 +105,13 @@ name: `/healthz` was examined and declined.
   leaves **no row** where the account declares nothing else, because a missing
   row is *never declared* and a null column is *unset*, and on an account fact
   those are two different sentences; where another fact remains, the row stays
-  and the model's column alone goes null. The
-  `opened_on` column is declared here and written by #918: a column added later
-  would exist on no store created between the two releases.
+  and the model's column alone goes null. The `opened_on` column was declared by
+  #752 and is written by #918 — a column added later would exist on no store
+  created between the two releases — and **it is declared, never derived**: the
+  form offers the account's earliest declared payment, and that offer is
+  *interface*. What lands in the row is what was submitted, and nothing
+  re-derives it on a replay (ADR-0006). The figure the offer is made of —
+  `ledger.first_payments` — is read off the ledger every time and held nowhere.
 - **The app ships no rates.** Every rate, bracket bound and threshold in the
   survey is per tax year, so what may ship is only what is *not money* —
   `threshold_years` and `age_basis`, which one kind of five has. The two
@@ -217,9 +221,14 @@ true of the install (`installation_facts.py`) or of the app (`/health`).
   `IF NOT EXISTS` with no migration machinery, so a column added there would
   exist on no store created before it. `advisory_ack` is the twelfth table, and
   it carries the expiry the fact's own row deliberately does not.
-- **One family today** — the cash share of an account, over a constant
-  threshold (`CASH_SHARE_THRESHOLD`, ADR-0036: *"a setting nobody has ever
-  turned is a setting that should not have been written"*). The four **subjects**
+- **Two families** — the cash share of an account, over a constant threshold
+  (`CASH_SHARE_THRESHOLD`, ADR-0036: *"a setting nobody has ever turned is a
+  setting that should not have been written"*), and a declared opening date
+  **later** than that account's first declared payment (#918), which is a
+  contradiction the app states without arbitrating: a wrapper cannot be funded
+  before it exists, and nothing here can say which of the two dates is the wrong
+  one. The opposite order raises nothing — a date earlier than the first payment
+  is what a transferred wrapper looks like. The four **subjects**
   the panel groups by are declared all the same, `portfolio` included: a front
   inventing a heading for a key it does not know would be a second authority on
   the grouping.
@@ -457,14 +466,15 @@ src/application/
 │                       #   the rates, the scheduler, the recorder, the pass lock
 ├── perf_series.py      # account_metrics + portfolio_totals, block upsert + bounded prune
 ├── positions.py        # the replay's two tables — position/account_state
-├── ledger.py           # the ledger's reads: read_events, the stamp, the last write, the orphans
+├── ledger.py           # the ledger's reads: read_events, the stamp, the last write, the orphans,
+│                       #   and each account's first payment (#918) — derived per read
 ├── uploads.py          # the gesture: one file in, read once, refused by name
 ├── entries.py          # the one writer of `event`: the row's four gestures + the bulk one
 │                       #   and the forecast that writes none: the content key, the split, the judgement
 ├── taxation.py         # pure: the closed kinds, their typed parameters, and the
 │                       #   two wrapper templates — structure only, never a rate
 ├── accounts.py         # the account table, the declaration, the refusals —
-│                       #   and the writer of taxation_model/account_fact (#752)
+│                       #   and the writer of taxation_model/account_fact (#752, #918)
 ├── reassignment.py     # the named, bounded exception: the unassigned events
 ├── settings_registry.py / settings.py   # the one list of dials, and the write path
 ├── installation_facts.py  # the three facts: predicate in code, the table holds the ack

--- a/src/application/accounts.py
+++ b/src/application/accounts.py
@@ -3,7 +3,7 @@
 **And the two tables #752 adds**, because they are the same gesture continued:
 ``taxation_model`` holds the models their owner wrote, ``account_fact`` holds
 what they declared *about an account* — which model it carries, and the day the
-wrapper was opened (#918 writes that one; this module declares its column).
+wrapper was opened (#918).
 Both are declaration, both are written here and nowhere else, and
 ``.github/scripts/conventions.sh`` says so on the source (ADR-0006, ADR-0044).
 The arithmetic is not here: :mod:`application.taxation` is pure and holds the
@@ -13,6 +13,7 @@ import csv
 import json
 import uuid
 from dataclasses import dataclass, field, replace
+from datetime import date
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
 
@@ -398,9 +399,9 @@ def set_taxation_model(store, account_id: str,
     ``None`` detaches, and detaching leaves **no row** rather than a row saying
     nothing: a missing row is *never declared* and a null column is *unset*, and
     ADR-0044 is written about the class of defect that follows from spelling the
-    first as the second. The row survives its own emptiness only once #918 puts
-    an opening date beside it — which is why the delete below reads that column
-    rather than dropping the row outright.
+    first as the second. The row survives its own emptiness where the account
+    declares an opening date beside it (#918), which is what
+    :func:`_forget_empty_fact` reads before dropping anything.
     """
     _require(store, account_id)
     target = _text(model_id) or None
@@ -412,10 +413,60 @@ def set_taxation_model(store, account_id: str,
         'ON CONFLICT (account) DO UPDATE SET '
         'taxation_model = excluded.taxation_model',
         [account_id, target])
+    _forget_empty_fact(store, account_id)
+    return target
+
+
+def opening_dates_by_account(store) -> Dict[str, date]:
+    """When each account says it was opened. **Absent means absent** (#845)."""
+    return {row[0]: row[1] for row in store.query(
+        'SELECT account, opened_on FROM account_fact '
+        'WHERE opened_on IS NOT NULL')}
+
+
+def set_opened_on(store, account_id: str,
+                  day: Optional[date]) -> Optional[date]:
+    """Declare the day an account was opened, or take the declaration away.
+
+    **Declared, and only declared** (#918, ADR-0006). The form offers the
+    account's earliest declared payment where there is one, and that offer is
+    *interface*: what lands here is what was submitted, and it stops moving. A
+    date re-derived on every replay would be a derived value in a declared row,
+    which is the one thing this table may not hold.
+
+    ``None`` takes it away, and — :func:`set_taxation_model`'s own rule — a row
+    left saying nothing at all goes rather than staying as two nulls.
+    """
+    _require(store, account_id)
+    # **A ``datetime`` is not a day**, and it is a subclass of one — so the
+    # check is on the type itself. The column is a `DATE`: an instant left
+    # through would be truncated on the way in, and a store's own clause about
+    # a calendar day staying a day would have been broken by the guard that
+    # says so.
+    if day is not None and type(day) is not date:
+        raise AccountSourceError(
+            f"{day!r} is not a calendar day: an opening date is a day, and the "
+            f"store holds it as one")
+
+    store.execute(
+        'INSERT INTO account_fact (account, opened_on) VALUES (?, ?) '
+        'ON CONFLICT (account) DO UPDATE SET opened_on = excluded.opened_on',
+        [account_id, day])
+    _forget_empty_fact(store, account_id)
+    return day
+
+
+def _forget_empty_fact(store, account_id: str) -> None:
+    """Drop a row that declares nothing — **a missing row is an absence**.
+
+    A null column is *unset* and a missing row is *never declared*, and ADR-0044
+    is written about the class of defect that follows from spelling the first as
+    the second. Both writers above end here, so the rule holds whichever fact
+    was the last one taken away.
+    """
     store.execute(
         'DELETE FROM account_fact WHERE account = ? '
         'AND taxation_model IS NULL AND opened_on IS NULL', [account_id])
-    return target
 
 
 __all__ = [
@@ -425,6 +476,7 @@ __all__ = [
     'TaxationModel', 'read_models', 'read_model', 'create_model',
     'update_model', 'delete_model', 'accounts_carrying',
     'taxation_models_by_account', 'set_taxation_model',
+    'opening_dates_by_account', 'set_opened_on',
     'is_accounts_file', 'header_of',
     'read_accounts', 'account_ids', 'accounts_are_declared',
     'default_is_declared', 'declared_portfolio',

--- a/src/application/advisories.py
+++ b/src/application/advisories.py
@@ -5,7 +5,9 @@ from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from logfmt_logger import getLogger
 
+from application import accounts
 from application import instants
+from application import ledger
 
 logger = getLogger("advisories")
 
@@ -17,6 +19,8 @@ SUBJECT_PORTFOLIO = 'portfolio'
 SUBJECT_ACCOUNTS = 'accounts'
 
 CASH_SHARE = 'cash_share'
+#: A declared opening date **later** than the account's first declared payment.
+OPENED_AFTER_FIRST_PAYMENT = 'opened_after_first_payment'
 
 CASH_SHARE_THRESHOLD = 0.10
 
@@ -105,8 +109,57 @@ def _say_cash_share(detail: Mapping[str, Any]) -> str:
         f"uninvested cash. Nothing is wrong with that if it is deliberate.")
 
 
+def _observe_opened_after_first_payment(opened, now: datetime) -> List[Advisory]:
+    """A wrapper that received money before it existed (#918).
+
+    One of the two dates is wrong and the app cannot say which — a transfer
+    carries a real opening date the ledger has no event for, and a typed year is
+    a typed year — so the advisory **states the contradiction** and stops there.
+
+    The other direction raises nothing: a date *earlier* than the first payment
+    is exactly what a wrapper transferred to a new broker looks like, which is
+    the case the declared date exists for.
+    """
+    payments = ledger.first_payments(opened)
+    # Both halves are read through the module that owns them rather than
+    # re-spelled here: a second `SELECT … FROM account_fact` would be a second
+    # place to change the day the row's own rules move.
+    labels = {row.id: row.label for row in accounts.read_accounts(opened)}
+
+    standing: List[Advisory] = []
+    for account, opened_on in sorted(
+            accounts.opening_dates_by_account(opened).items()):
+        label = labels.get(account)
+        first = payments.get(account)
+        if first is None or opened_on <= first:
+            continue
+        detail = {
+            'account': account,
+            'label': label,
+            'opened_on': instants.iso(opened_on),
+            'first_payment': instants.iso(first),
+        }
+        standing.append(Advisory(
+            key=f'{OPENED_AFTER_FIRST_PAYMENT}:{account}',
+            kind=OPENED_AFTER_FIRST_PAYMENT,
+            subject=SUBJECT_ACCOUNTS,
+            detail=detail,
+            message=_say_opened_after_first_payment(detail),
+            observed_at=now,
+        ))
+    return standing
+
+
+def _say_opened_after_first_payment(detail: Mapping[str, Any]) -> str:
+    return (
+        f"{detail['label']} is declared as opened on {detail['opened_on']}, "
+        f"and it received a payment on {detail['first_payment']}. One of the "
+        f"two is wrong.")
+
+
 OBSERVATIONS = (
     _observe_cash_share,
+    _observe_opened_after_first_payment,
 )
 
 
@@ -175,6 +228,7 @@ def acknowledge(opened, key: str,
 __all__ = [
     'Advisory', 'Acknowledgement', 'UnknownAdvisory',
     'ACK_WINDOW', 'CASH_SHARE', 'CASH_SHARE_THRESHOLD',
+    'OPENED_AFTER_FIRST_PAYMENT',
     'SUBJECT_HEALTH', 'SUBJECT_INSTALLATION', 'SUBJECT_PORTFOLIO',
     'SUBJECT_ACCOUNTS',
     'OBSERVATIONS', 'acknowledgements', 'standing', 'listing', 'acknowledge',

--- a/src/application/ledger.py
+++ b/src/application/ledger.py
@@ -86,10 +86,9 @@ def first_payments(store) -> Dict[str, date]:
     A ``WITHDRAWAL`` is not a payment and a ``BUY`` is not one either: what opens
     a wrapper is money coming in from outside.
     """
-    return {account: day for account, day in store.query(
+    return dict(store.query(
         "SELECT account, min(date) FROM event "
-        "WHERE event_type = 'DEPOSIT' GROUP BY account")
-        if day is not None}
+        "WHERE event_type = 'DEPOSIT' GROUP BY account"))
 
 
 def last_write(store) -> Optional[datetime]:

--- a/src/application/ledger.py
+++ b/src/application/ledger.py
@@ -1,8 +1,8 @@
 """The ledger in the store — read here, written in one place, and nowhere else."""
 import hashlib
 from dataclasses import dataclass
-from datetime import datetime
-from typing import List, Optional, Sequence, Tuple
+from datetime import date, datetime
+from typing import Dict, List, Optional, Sequence, Tuple
 
 from logfmt_logger import getLogger
 
@@ -72,6 +72,24 @@ def stamp(store) -> Optional[str]:
     declarations = '|'.join(str(tuple(a)) for a in declared)
     payload = f'{digest or ""}#{declarations}'
     return hashlib.sha256(payload.encode('utf-8')).hexdigest()
+
+
+def first_payments(store) -> Dict[str, date]:
+    """The earliest declared **payment** of every account — a ``DEPOSIT``, dated.
+
+    Derived on every read and stored nowhere (#918): it is a figure the ledger
+    already says, and a column holding it would be a derived value in a declared
+    row (ADR-0006). Two readers ask it — the account form, which offers it as the
+    opening date it pre-fills, and the advisory that contradicts a declared date
+    later than it — and they ask it here so the two cannot disagree.
+
+    A ``WITHDRAWAL`` is not a payment and a ``BUY`` is not one either: what opens
+    a wrapper is money coming in from outside.
+    """
+    return {account: day for account, day in store.query(
+        "SELECT account, min(date) FROM event "
+        "WHERE event_type = 'DEPOSIT' GROUP BY account")
+        if day is not None}
 
 
 def last_write(store) -> Optional[datetime]:
@@ -153,7 +171,7 @@ def currency_to_adopt(store, declared: Optional[str]) -> Optional[str]:
 
 __all__ = [
     'LAST_WRITE_KEY', 'OrphanSymbol',
-    'read_events', 'stamp', 'last_write',
+    'read_events', 'stamp', 'last_write', 'first_payments',
     'orphan_symbols', 'purge_orphan_symbols',
     'currency_to_adopt',
 ]

--- a/src/web/CLAUDE.md
+++ b/src/web/CLAUDE.md
@@ -626,6 +626,19 @@ Five nets hold a rule nothing made true by construction:
   whose options have not arrived would show *no model* about an account that has
   one. The kinds and the templates are **served**, never copied here — what this
   front holds is the words.
+- **And it declares the day it was opened, where that changes a figure** (#918).
+  The field is a `<input type="date">` on the same panel, shown only when the
+  model the account carries counts its threshold **from the opening**
+  (`age_basis`) — asking for a date that moves no figure is asking the reader to
+  work for nothing, and a shape whose years run from the *first payment*, which
+  is what a PEA does, has an age threshold and still no use for this date — and
+  **pre-filled** with the account's earliest declared payment (`first_payment`,
+  served and stored nowhere) where the account has declared none. The pre-fill is
+  an *offer*: submitting is what turns it into a declaration, so the panel sends
+  `opened_on` when the field was shown **and** its value moved, `null` when it
+  was emptied, and nothing at all otherwise — `taxation_model`'s own three-way
+  rule, for the same reason. A declared date later than the first payment is
+  contradicted by an advisory, in the panel, with both dates in it.
 - **An account is a name and an id, and the id sits where the type sat** (#916,
   ADR-0043). The type is gone from the forms, from `Account` and from the wire,
   so declaring an account is two fields. What that slot now holds is the **id** —

--- a/src/web/src/components/accounts/AccountForm.tsx
+++ b/src/web/src/components/accounts/AccountForm.tsx
@@ -152,7 +152,6 @@ export function AccountForm({
   const carried = catalogue.data?.models.find((model) => model.id === taxationModel)
   const ageMatters = carried?.parameters.age_basis === 'opening'
 
-
   const remove = useMutation({
     mutationFn: (id: string) => api.removeAccount(id),
     onSuccess: () => {

--- a/src/web/src/components/accounts/AccountForm.tsx
+++ b/src/web/src/components/accounts/AccountForm.tsx
@@ -37,7 +37,7 @@
  *    ticket is named after.
  */
 import { useEffect, useState, type ReactNode } from 'react'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { Refusal } from '@/components/Refusal'
 import { TaxationModelField } from '@/components/accounts/TaxationModelField'
@@ -76,11 +76,13 @@ const REFUSALS: Record<Exclude<Removal['kind'], 'offered'>, MessageKey> = {
 interface Draft {
   id: string
   label: string
+  /** The declared opening day, `''` for none — a `YYYY-MM-DD`, as it is stored. */
+  openedOn: string
 }
 
 type FieldName = keyof Draft
 
-const EMPTY: Draft = { id: '', label: '' }
+const EMPTY: Draft = { id: '', label: '', openedOn: '' }
 
 interface AccountFormProps {
   open: boolean
@@ -138,6 +140,18 @@ export function AccountForm({
   // one a declaration opens on.
   const [taxationModel, setTaxationModel] = useState<string | null>(null)
 
+  // **The same query as the field below**, which react-query serves from one
+  // cache. What it decides is whether the opening date is asked for at all, and
+  // the answer is **the model's own `age_basis`** rather than its kind: a shape
+  // that counts years from the *first payment* — which is what a PEA does, and
+  // what `taxation.py` warns is not the opening date — has an age threshold and
+  // still no use for this date. Asked on the kind, that reader would be filling
+  // in a day that moves no figure, under a hint telling them it moves one.
+  // Nothing at all while the read is in flight (ADR-0026).
+  const catalogue = useQuery({ queryKey: ['taxation-models'], queryFn: api.taxationModels })
+  const carried = catalogue.data?.models.find((model) => model.id === taxationModel)
+  const ageMatters = carried?.parameters.age_basis === 'opening'
+
 
   const remove = useMutation({
     mutationFn: (id: string) => api.removeAccount(id),
@@ -177,6 +191,13 @@ export function AccountForm({
       account === null
         ? EMPTY
         : {
+            // **The offer is the interface's, and the declaration wins it.**
+            // Where the account declared a day, that day is what shows; where it
+            // declared none, the form offers its earliest declared payment,
+            // which is the guess its owner accepts nine times out of ten. Either
+            // way nothing is written until they submit — and what is then
+            // written is what they submitted, never re-derived (#918).
+            openedOn: account.opened_on ?? account.first_payment ?? '',
             id: account.id,
             // **The seeded name opens empty.** `Default account` is what the
             // *server* wrote about a row nobody declared, so it is not a value
@@ -215,12 +236,23 @@ export function AccountForm({
     // keeps what is there, so clearing the field cannot rewrite the row's name
     // to its own identifier behind the reader's back.
     const label = draft.label.trim()
+    // **Sent only where the field was shown, and only where it moved** (#918).
+    // Shown and left on the pre-filled day, it is sent: submitting is how the
+    // offer becomes a declaration. Never shown, it is absent — a client that
+    // did not ask the question must not answer it, and the server reads an
+    // absent member as *leave it alone*. Emptied, it is `null`: taking the
+    // declaration away is a gesture, and it is that one.
+    const opening =
+      ageMatters && draft.openedOn !== (account?.opened_on ?? '')
+        ? { opened_on: draft.openedOn || null }
+        : {}
     write.mutate(
       account === null
         ? {
             id,
             label: label || id,
             ...(taxationModel === null ? {} : { taxation_model: taxationModel }),
+            ...opening,
             // Sent only where the box was shown **and** left ticked: `reassign`
             // is a request, and a client that never asks must never perform one.
             ...(offered && reassign ? { reassign: true } : {}),
@@ -234,6 +266,7 @@ export function AccountForm({
             ...(taxationModel === (account.taxation_model ?? null)
               ? {}
               : { taxation_model: taxationModel }),
+            ...opening,
           },
     )
   }
@@ -304,6 +337,28 @@ export function AccountForm({
           </Field>
 
           <TaxationModelField value={taxationModel} onChange={setTaxationModel} />
+
+          {/* **Asked for only where it changes a figure**: the shape this
+              account carries counts its threshold from the wrapper's age, and
+              nothing else on this panel does. */}
+          {ageMatters ? (
+            <Field name="openedOn" label="accounts.form.openedOn" optional>
+              {(id) => (
+                <>
+                  <Input
+                    id={id}
+                    type="date"
+                    value={draft.openedOn}
+                    aria-describedby={`${id}-hint`}
+                    onChange={(changed) => set('openedOn', changed.target.value)}
+                  />
+                  <p id={`${id}-hint`} className="max-w-prose text-xs text-muted-foreground">
+                    {t('accounts.form.openedOn.hint')}
+                  </p>
+                </>
+              )}
+            </Field>
+          ) : null}
 
           {offered ? (
             <div className="space-y-1 rounded-md border border-border p-3">

--- a/src/web/src/i18n/en.json
+++ b/src/web/src/i18n/en.json
@@ -75,6 +75,8 @@
   "notification.fact.assumed_base_currency": "Amounts read in your base currency",
   "notification.advisory.cash_share": "{label} · {share, number, percent} in uninvested cash",
   "notification.advisory.cash_share.body": "Part of this account is sitting in cash rather than being invested. Nothing is wrong with that if it is deliberate.",
+  "notification.advisory.opened_after_first_payment": "{label} · opened after its first payment",
+  "notification.advisory.opened_after_first_payment.body": "You declared this account as opened on {opened}, and it received a payment on {payment}. A wrapper cannot be funded before it exists, so one of the two dates is wrong — the app cannot tell which.",
 
   "empty.noCurrency.title": "No base currency yet",
   "empty.noCurrency.body": "Nothing is valued and no gain is computed until you choose a base currency. Your events are recorded all the same, and the ledger stays readable.",
@@ -356,6 +358,8 @@
   "accounts.form.taxation.hint": "How this account is taxed, recorded for the projection to come. Leave it empty and the app shows no figure at all — which is the right answer until you have said what your wrapper is taxed like. A model can be reused across accounts.",
   "accounts.form.taxation.edit": "Correct this model",
   "accounts.form.taxation.remove": "Remove this model",
+  "accounts.form.openedOn": "Opened on",
+  "accounts.form.openedOn.hint": "The day this wrapper was opened — it is what its age is counted from, and the shape you chose above uses that age. We offer the date of its first payment on record; correct it if the wrapper is older than this ledger, which is what a transfer from another broker looks like.",
 
   "taxation.name": "What to call this model",
   "taxation.kind": "Shape",

--- a/src/web/src/i18n/fr.json
+++ b/src/web/src/i18n/fr.json
@@ -75,6 +75,8 @@
   "notification.fact.assumed_base_currency": "Montants lus dans votre devise de base",
   "notification.advisory.cash_share": "{label} · {share, number, percent} de liquidités non investies",
   "notification.advisory.cash_share.body": "Une part de ce compte dort en cash au lieu d’être investie. Rien d’anormal si c’est voulu.",
+  "notification.advisory.opened_after_first_payment": "{label} · ouvert après son premier versement",
+  "notification.advisory.opened_after_first_payment.body": "Vous avez déclaré ce compte ouvert le {opened}, et il a reçu un versement le {payment}. Une enveloppe ne peut pas être alimentée avant d’exister : l’une des deux dates est donc fausse, et l’application ne peut pas dire laquelle.",
 
   "empty.noCurrency.title": "Aucune devise de base",
   "empty.noCurrency.body": "Rien n’est valorisé et aucun gain n’est calculé tant que vous n’avez pas choisi de devise de base. Vos événements sont enregistrés malgré tout, et le grand livre reste lisible.",
@@ -356,6 +358,8 @@
   "accounts.form.taxation.hint": "Comment ce compte est imposé, enregistré pour la projection à venir. Laissez vide et l’application n’affiche aucun chiffre — c’est la bonne réponse tant que vous n’avez pas dit comment votre enveloppe est imposée. Un modèle peut servir à plusieurs comptes.",
   "accounts.form.taxation.edit": "Corriger ce modèle",
   "accounts.form.taxation.remove": "Supprimer ce modèle",
+  "accounts.form.openedOn": "Ouvert le",
+  "accounts.form.openedOn.hint": "Le jour où cette enveloppe a été ouverte : c’est de là que court son ancienneté, et la forme choisie ci-dessus s’en sert. Nous proposons la date de son premier versement connu ; corrigez-la si l’enveloppe est plus ancienne que ce registre, ce qui est le cas d’un transfert depuis un autre courtier.",
 
   "taxation.name": "Le nom de ce modèle",
   "taxation.kind": "Forme",

--- a/src/web/src/lib/api.ts
+++ b/src/web/src/lib/api.ts
@@ -473,6 +473,26 @@ export interface Account {
    * nothing rather than a zero for it.
    */
   taxation_model?: string
+  /**
+   * The day the wrapper was opened, **as its owner declared it** (#918) — and
+   * absent where they declared none, which is ordinary.
+   *
+   * It cannot be derived, which is the whole reason it is typed: a PEA opened
+   * in 2015 and transferred to a broker whose ledger only starts in 2022
+   * derives three years of seniority instead of ten, and the date its owner
+   * cares about is exactly the one no event carries.
+   */
+  opened_on?: string
+  /**
+   * This account's **earliest declared payment** — a `DEPOSIT`, derived on
+   * every read and stored nowhere.
+   *
+   * It is here for one consumer: the form offers it as the opening date it
+   * pre-fills, where the account has declared none. A *suggestion made by the
+   * interface* — accepted it becomes a declaration and stops moving, and
+   * nothing re-derives it afterwards (ADR-0006).
+   */
+  first_payment?: string
 }
 
 export interface AccountsResponse {
@@ -524,6 +544,15 @@ export interface AccountDraft {
    * the same, because the select always has an answer.
    */
   taxation_model?: string | null
+  /**
+   * The opening date, `null` to take it away — and **absent to leave it alone**
+   * (#918), on `taxation_model`'s own three-way rule.
+   *
+   * Sent only where the field was **shown**: it is not asked for when the
+   * account's taxation model counts its threshold from anything but the
+   * opening, and a client that never asked the question must not answer it.
+   */
+  opened_on?: string | null
 }
 
 // ------------------------------------------------------------------------- //

--- a/src/web/src/lib/notifications.ts
+++ b/src/web/src/lib/notifications.ts
@@ -151,28 +151,51 @@ const FACT_TITLES: Record<string, MessageKey> = {
  */
 function advisoryEntry(advisory: Advisory): Entry {
   const account = String(advisory.detail.account ?? '')
-  const known = advisory.kind === 'cash_share' && account !== ''
+  const label = String(advisory.detail.label ?? account)
+  const said = account === '' ? null : sentences(advisory, label)
   return {
     id: advisory.key,
     register: 'advisory',
     subject: subjectOf(advisory.subject),
     pinned: false,
-    title: known
-      ? {
-          key: 'notification.advisory.cash_share',
-          values: {
-            label: String(advisory.detail.label ?? account),
-            share: Number(advisory.detail.share ?? 0),
-          },
-        }
-      : { text: advisory.message },
-    body: known ? { key: 'notification.advisory.cash_share.body' } : { text: '' },
+    title: said?.title ?? { text: advisory.message },
+    body: said?.body ?? { text: '' },
     at: advisory.observed_at,
-    link: known
-      ? { label: 'notification.link.account', to: { to: '/accounts', search: { account } } }
-      : null,
+    link:
+      said === null
+        ? null
+        : { label: 'notification.link.account', to: { to: '/accounts', search: { account } } },
     acknowledge: { register: 'advisory', key: advisory.key },
   }
+}
+
+/** The two sentences of a family this front knows, or `null` for one it does not. */
+function sentences(advisory: Advisory, label: string): Pick<Entry, 'title' | 'body'> | null {
+  if (advisory.kind === 'cash_share') {
+    return {
+      title: {
+        key: 'notification.advisory.cash_share',
+        values: { label, share: Number(advisory.detail.share ?? 0) },
+      },
+      body: { key: 'notification.advisory.cash_share.body' },
+    }
+  }
+  // **It states the contradiction and does not arbitrate it** (#918): one of
+  // the two dates is wrong and the app cannot say which, so both are in the
+  // sentence and neither is called the mistake.
+  if (advisory.kind === 'opened_after_first_payment') {
+    return {
+      title: { key: 'notification.advisory.opened_after_first_payment', values: { label } },
+      body: {
+        key: 'notification.advisory.opened_after_first_payment.body',
+        values: {
+          opened: String(advisory.detail.opened_on ?? ''),
+          payment: String(advisory.detail.first_payment ?? ''),
+        },
+      },
+    }
+  }
+  return null
 }
 
 /** A subject this front knows, or the portfolio — the server decides, we render. */

--- a/src/web/src/openingDate.test.tsx
+++ b/src/web/src/openingDate.test.tsx
@@ -1,0 +1,287 @@
+/**
+ * The opening date an account declares (#918, ADR-0006, ADR-0044).
+ *
+ * At the one seam every page test here uses: the whole app in jsdom, HTTP the
+ * only faked edge, and every assertion on the **accessible rendering** or on
+ * the request that actually left.
+ *
+ * Four of the cases name a reading they prevent:
+ *
+ *  - **it is asked for only where it changes a figure**, so a reader whose
+ *    regime has no age threshold is never asked for a date that moves nothing;
+ *  - **the pre-fill is an offer of the interface**, and what is stored is what
+ *    was submitted — an account edited again does not silently re-derive it;
+ *  - **a date earlier than the first payment is normal**, because that is what
+ *    a wrapper transferred from another broker looks like;
+ *  - **the contradiction is stated, never arbitrated**: one of the two dates is
+ *    wrong and the app cannot say which.
+ */
+import { screen, waitFor, within } from '@testing-library/react'
+import { HttpResponse, http } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { accountPath, ROUTES, type Account } from '@/lib/api'
+import {
+  aLedgerPayload,
+  anAccount,
+  anAccountsPayload,
+  anAdvisory,
+  aTaxationCatalogue,
+  aTaxationModel,
+  ledgerEvents,
+} from '@/test/factories'
+import { renderApp } from '@/test/render'
+import { server } from '@/test/server'
+
+/** A model whose threshold is counted **from the day the wrapper was opened**. */
+const AGED = aTaxationModel({
+  id: 'aged',
+  name: 'Enveloppe à seuil',
+  kind: 'aged_flat_realised',
+  parameters: {
+    rate_before: 0.3,
+    rate_after: 0.172,
+    threshold_years: 5,
+    age_basis: 'opening',
+  },
+})
+
+/**
+ * The same shape, counted **from the first payment** — which is what the PEA
+ * template ships, and what `taxation.py` warns is *not* the opening date.
+ *
+ * An age threshold and no use whatsoever for this date: the two are not the
+ * same question, and a reader on this model must not be asked for a day that
+ * moves no figure.
+ */
+const AGED_FROM_PAYMENT = aTaxationModel({
+  id: 'aged-payment',
+  name: 'Enveloppe à seuil depuis le versement',
+  kind: 'aged_flat_realised',
+  parameters: {
+    rate_before: 0.3,
+    rate_after: 0.172,
+    threshold_years: 5,
+    age_basis: 'first_payment',
+  },
+})
+
+function renderAccounts(account: Partial<Account>) {
+  server.use(
+    http.get(ROUTES.accounts, () =>
+      HttpResponse.json(anAccountsPayload([anAccount({ id: 'alpha', label: 'Alpha', ...account })])),
+    ),
+    http.get(ROUTES.events, () => HttpResponse.json(aLedgerPayload(ledgerEvents()))),
+    http.get(ROUTES.taxationModels, () =>
+      HttpResponse.json(
+        aTaxationCatalogue({ models: [aTaxationModel(), AGED, AGED_FROM_PAYMENT] }),
+      ),
+    ),
+  )
+  return renderApp({ url: '/accounts' })
+}
+
+async function openPanel(user: ReturnType<typeof renderApp>['user']) {
+  await user.click(
+    within(await screen.findByRole('list', { name: 'Vos comptes' })).getByRole('link', {
+      name: /Alpha/,
+    }),
+  )
+  const detail = await screen.findByRole('region', { name: 'Alpha' })
+  await user.click(within(detail).getByRole('button', { name: 'Modifier le compte' }))
+  const panel = await screen.findByRole('dialog')
+  // The catalogue decides whether the field is asked for at all, so nothing is
+  // asserted about it before the read has landed (ADR-0026).
+  await within(panel).findByLabelText(/Modèle d’imposition/)
+  return panel
+}
+
+describe('the date is asked for only where it matters', () => {
+  it('is absent on an account whose shape has no age-dependent parameter', async () => {
+    // A flat rate on the gain has no threshold to count years to, so there is
+    // no figure this date could change — and asking for it is asking the
+    // reader to work for nothing.
+    const { user } = renderAccounts({ taxation_model: 'model-one', first_payment: '2019-03-04' })
+    const panel = await openPanel(user)
+
+    expect(within(panel).queryByLabelText(/Ouvert le/)).not.toBeInTheDocument()
+  })
+
+  it('is absent on a shape whose age runs from the first payment', async () => {
+    // The PEA's own shape. Its five years run from the first payment, so the
+    // opening date changes no figure — and the hint under the field would be
+    // telling this reader the opposite.
+    const { user } = renderAccounts({
+      taxation_model: 'aged-payment',
+      first_payment: '2019-03-04',
+    })
+    const panel = await openPanel(user)
+
+    expect(within(panel).queryByLabelText(/Ouvert le/)).not.toBeInTheDocument()
+  })
+
+  it('is absent on an account that carries no model at all', async () => {
+    const { user } = renderAccounts({ first_payment: '2019-03-04' })
+    const panel = await openPanel(user)
+
+    expect(within(panel).queryByLabelText(/Ouvert le/)).not.toBeInTheDocument()
+  })
+
+  it('appears the moment an age-dependent shape is chosen', async () => {
+    const { user } = renderAccounts({ first_payment: '2019-03-04' })
+    const panel = await openPanel(user)
+
+    await user.selectOptions(
+      within(panel).getByLabelText(/Modèle d’imposition/),
+      within(panel).getByRole('option', { name: 'Enveloppe à seuil' }),
+    )
+
+    expect(within(panel).getByLabelText(/Ouvert le/)).toBeInTheDocument()
+  })
+})
+
+describe('the pre-fill is the interface’s offer', () => {
+  it('offers the account’s earliest declared payment where it has declared none', async () => {
+    const { user } = renderAccounts({ taxation_model: 'aged', first_payment: '2019-03-04' })
+    const panel = await openPanel(user)
+
+    expect(within(panel).getByLabelText(/Ouvert le/)).toHaveValue('2019-03-04')
+  })
+
+  it('shows the declared day rather than the offer, once there is one', async () => {
+    // Accepted, the offer became a declaration and stopped moving: the stored
+    // value is what the owner submitted, and nothing re-derives it.
+    const { user } = renderAccounts({
+      taxation_model: 'aged',
+      opened_on: '2015-06-01',
+      first_payment: '2019-03-04',
+    })
+    const panel = await openPanel(user)
+
+    expect(within(panel).getByLabelText(/Ouvert le/)).toHaveValue('2015-06-01')
+  })
+
+  it('is empty where the account has no payment on record', async () => {
+    const { user } = renderAccounts({ taxation_model: 'aged' })
+    const panel = await openPanel(user)
+
+    expect(within(panel).getByLabelText(/Ouvert le/)).toHaveValue('')
+  })
+})
+
+describe('what the panel sends', () => {
+  async function sentBy(account: Partial<Account>, act: (panel: HTMLElement) => Promise<void>) {
+    const { user } = renderAccounts(account)
+    const panel = await openPanel(user)
+    let sent: unknown = null
+    server.use(
+      http.patch(accountPath('alpha'), async ({ request }) => {
+        sent = await request.json()
+        return HttpResponse.json(anAccount({ id: 'alpha', label: 'Alpha' }))
+      }),
+    )
+    await act(panel)
+    await user.click(within(panel).getByRole('button', { name: 'Enregistrer ce compte' }))
+    await waitFor(() => expect(sent).not.toBeNull())
+    return sent
+  }
+
+  it('writes the offered day when the reader submits on it', async () => {
+    // Submitting **is** accepting: the offer is what the owner will take nine
+    // times out of ten, and it becomes their declaration the moment they do.
+    const sent = await sentBy(
+      { taxation_model: 'aged', first_payment: '2019-03-04' },
+      async () => {},
+    )
+
+    expect(sent).toEqual({ label: 'Alpha', opened_on: '2019-03-04' })
+  })
+
+  it('says nothing about a declared day the reader did not touch', async () => {
+    const sent = await sentBy(
+      { taxation_model: 'aged', opened_on: '2015-06-01', first_payment: '2019-03-04' },
+      async () => {},
+    )
+
+    expect(sent).toEqual({ label: 'Alpha' })
+  })
+
+  it('sends a null when the reader empties it, which takes the declaration away', async () => {
+    const { user } = renderAccounts({
+      taxation_model: 'aged',
+      opened_on: '2015-06-01',
+      first_payment: '2019-03-04',
+    })
+    const panel = await openPanel(user)
+
+    let sent: unknown = null
+    server.use(
+      http.patch(accountPath('alpha'), async ({ request }) => {
+        sent = await request.json()
+        return HttpResponse.json(anAccount({ id: 'alpha', label: 'Alpha' }))
+      }),
+    )
+    await user.clear(within(panel).getByLabelText(/Ouvert le/))
+    await user.click(within(panel).getByRole('button', { name: 'Enregistrer ce compte' }))
+
+    await waitFor(() => expect(sent).toEqual({ label: 'Alpha', opened_on: null }))
+  })
+
+  it('says nothing about a date it never asked for', async () => {
+    // The field is not shown on this shape, so the panel answers no question
+    // about it — a payment date must not reach the store because a reader
+    // renamed an account.
+    const sent = await sentBy(
+      { taxation_model: 'model-one', first_payment: '2019-03-04' },
+      async (panel) => {
+        await within(panel).findByLabelText('Nom')
+      },
+    )
+
+    expect(sent).toEqual({ label: 'Alpha' })
+  })
+})
+
+describe('the contradiction, said out loud', () => {
+  const CONTRADICTED = anAdvisory({
+    key: 'opened_after_first_payment:alpha',
+    kind: 'opened_after_first_payment',
+    message: 'Alpha is declared as opened on 2021-01-01, and it received a payment on 2019-03-04.',
+    detail: {
+      account: 'alpha',
+      label: 'Alpha',
+      opened_on: '2021-01-01',
+      first_payment: '2019-03-04',
+    },
+  })
+
+  async function openNotifications(language: readonly string[]) {
+    server.use(http.get(ROUTES.advisories, () => HttpResponse.json([CONTRADICTED])))
+    const rendered = renderApp({ browserLanguages: language })
+    await rendered.user.click(await screen.findByRole('button', { name: /^Notifications/ }))
+    return screen.findByRole('dialog', { name: 'Notifications' })
+  }
+
+  it('names the account, both dates, and where to go — in French', async () => {
+    const panel = await openNotifications(['fr-FR'])
+
+    expect(within(panel).getByText(/Alpha · ouvert après son premier versement/)).toBeInTheDocument()
+    expect(panel.textContent).toContain('déclaré ce compte ouvert le 2021-01-01')
+    expect(panel.textContent).toContain('versement le 2019-03-04')
+    // It states the contradiction and does not decide which side is wrong.
+    expect(panel.textContent).toContain('l’application ne peut pas dire laquelle')
+    expect(within(panel).getByRole('link', { name: 'Voir le compte' })).toHaveAttribute(
+      'href',
+      expect.stringContaining('account=alpha'),
+    )
+  })
+
+  it('and in English', async () => {
+    const panel = await openNotifications(['en-GB'])
+
+    expect(within(panel).getByText(/Alpha · opened after its first payment/)).toBeInTheDocument()
+    expect(panel.textContent).toContain('opened on 2021-01-01')
+    expect(panel.textContent).toContain('payment on 2019-03-04')
+    expect(within(panel).getByRole('link', { name: 'See the account' })).toBeInTheDocument()
+  })
+})

--- a/src/web/src/test/server.ts
+++ b/src/web/src/test/server.ts
@@ -48,13 +48,18 @@ import {
 } from '@/test/factories'
 
 /**
- * A draft as the row it becomes. `taxation_model: null` is *detach it*, and what
- * comes back from a detached account is the member **absent** — the wire never
- * carries a null there (#752), so the harness must not either.
+ * A draft as the row it becomes. `taxation_model: null` is *detach it* and
+ * `opened_on: null` is *take the date away*, and what comes back from either is
+ * the member **absent** — the wire never carries a null there (#752, #918), so
+ * the harness must not either.
  */
 function echoed(draft: AccountDraft): Partial<Account> {
-  const { reassign: _reassign, taxation_model: model, ...rest } = draft
-  return model === null || model === undefined ? rest : { ...rest, taxation_model: model }
+  const { reassign: _reassign, taxation_model: model, opened_on: day, ...rest } = draft
+  return {
+    ...rest,
+    ...(model === null || model === undefined ? {} : { taxation_model: model }),
+    ...(day === null || day === undefined ? {} : { opened_on: day }),
+  }
 }
 
 export function defaultHandlers() {

--- a/tests/test_advisories.py
+++ b/tests/test_advisories.py
@@ -10,6 +10,7 @@ from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
+from application import accounts
 from application import advisories
 from application import store as store_module
 
@@ -296,3 +297,87 @@ def test_an_expired_row_is_swept_by_the_gesture_and_never_by_a_read(store):
     advisories.acknowledge(store, 'cash_share:pea', late)
     rows = {row[0] for row in store.query('SELECT key FROM advisory_ack')}
     assert rows == {'cash_share:pea'}
+
+
+# --------------------------------------------------------------------------- #
+# The opening date contradicted by the ledger (#918)
+# --------------------------------------------------------------------------- #
+
+def _payment(opened, account: str, day: date, key: int = 0) -> None:
+    """One declared payment — a ``DEPOSIT``, which is what opens a wrapper."""
+    opened.execute(
+        'INSERT INTO event (id, date, event_type, account, amount) '
+        'VALUES (?, CAST(? AS DATE), ?, ?, 1000)',
+        [key, day.isoformat(), 'DEPOSIT', account])
+
+
+def test_a_wrapper_that_received_money_before_it_existed_raises_one(store):
+    """The contradiction, stated — and **not** arbitrated.
+
+    One of the two dates is wrong and the app cannot say which: a transfer
+    carries a real opening date no event of this ledger knows, and a typed year
+    is a typed year. So both are in the detail, and the sentence says they
+    disagree.
+    """
+    _account(store, 'pea', 'PEA Bourso')
+    _payment(store, 'pea', date(2019, 3, 4))
+    accounts.set_opened_on(store, 'pea', date(2021, 1, 1))
+
+    found = advisories.listing(store, NOW)
+
+    assert _keys(found) == ['opened_after_first_payment:pea']
+    one = found[0]
+    assert one.kind == advisories.OPENED_AFTER_FIRST_PAYMENT
+    assert one.subject == advisories.SUBJECT_ACCOUNTS
+    assert one.detail == {
+        'account': 'pea',
+        'label': 'PEA Bourso',
+        'opened_on': '2021-01-01',
+        'first_payment': '2019-03-04',
+    }
+    assert one.observed_at == NOW
+
+
+def test_a_date_earlier_than_the_first_payment_raises_nothing(store):
+    """It is exactly what a transferred wrapper looks like — the case the
+    declared date exists for, and the reason it cannot be derived."""
+    _account(store, 'pea', 'PEA')
+    _payment(store, 'pea', date(2022, 1, 10))
+    accounts.set_opened_on(store, 'pea', date(2015, 6, 1))
+
+    assert advisories.listing(store, NOW) == []
+
+
+def test_the_same_day_raises_nothing(store):
+    """A wrapper funded the day it was opened is the ordinary case."""
+    _account(store, 'pea', 'PEA')
+    _payment(store, 'pea', date(2022, 1, 10))
+    accounts.set_opened_on(store, 'pea', date(2022, 1, 10))
+
+    assert advisories.listing(store, NOW) == []
+
+
+def test_neither_half_alone_raises_anything(store):
+    """A declared date with no payment says nothing, and a payment with no
+    declared date has nothing to contradict."""
+    _account(store, 'pea', 'PEA')
+    accounts.set_opened_on(store, 'pea', date(2021, 1, 1))
+    assert advisories.listing(store, NOW) == []
+
+    _account(store, 'cto', 'CTO')
+    _payment(store, 'cto', date(2019, 3, 4), key=1)
+    assert advisories.listing(store, NOW) == []
+
+
+def test_it_is_acknowledgeable_like_any_other(store):
+    _account(store, 'pea', 'PEA')
+    _payment(store, 'pea', date(2019, 3, 4))
+    accounts.set_opened_on(store, 'pea', date(2021, 1, 1))
+
+    advisories.acknowledge(store, 'opened_after_first_payment:pea', NOW)
+
+    assert advisories.listing(store, NOW) == []
+    # Still true, and still said where the figure is: the acknowledgement is a
+    # *not now*, never an observation that the condition went false.
+    assert _keys(advisories.standing(store, NOW)) == [
+        'opened_after_first_payment:pea']

--- a/tests/test_taxation.py
+++ b/tests/test_taxation.py
@@ -11,10 +11,12 @@ What is deliberately *not* asserted is that a function was called. The rules are
 rules about rows and about which gestures the store refuses.
 """
 import json
+from datetime import date, datetime, timezone
 
 import pytest
 
 from application import accounts as accounts_module
+from application import ledger
 from application import store as store_module
 from application import taxation
 
@@ -365,3 +367,95 @@ def test_a_bracket_with_no_bound_where_one_is_needed_is_refused():
             {'upper_bound': 10_000, 'rate': None},
             {'upper_bound': None, 'rate': 0.3},
         ]})
+
+
+# --------------------------------------------------------------------------- #
+# The opening date: declared, and only declared (#918)
+# --------------------------------------------------------------------------- #
+
+def test_an_account_declares_the_day_it_was_opened(store):
+    """A **day**, held as one, and read back as one.
+
+    The date the owner cares about is exactly the one no event carries — a PEA
+    opened in 2015 and transferred to a broker whose ledger starts in 2022 —
+    which is why it is declared rather than derived.
+    """
+    accounts_module.create_account(store, 'pea', 'PEA')
+
+    assert accounts_module.set_opened_on(
+        store, 'pea', date(2015, 6, 1)) == date(2015, 6, 1)
+    assert store.query('SELECT opened_on FROM account_fact') == [
+        (date(2015, 6, 1),)]
+    assert accounts_module.opening_dates_by_account(store) == {
+        'pea': date(2015, 6, 1)}
+
+
+def test_an_account_with_no_opening_date_has_no_row_at_all(store):
+    """An account without one is ordinary — no row, no null, no sentinel."""
+    accounts_module.create_account(store, 'pea', 'PEA')
+
+    assert accounts_module.opening_dates_by_account(store) == {}
+    assert store.query('SELECT count(*) FROM account_fact')[0][0] == 0
+
+
+def test_the_two_facts_share_a_row_and_outlive_each_other(store):
+    """One row per account, and taking one fact away leaves the other alone.
+
+    This is the case ``set_taxation_model``'s own docstring was written against:
+    the row survives its own emptiness only while something is still declared in
+    it, and it goes when nothing is.
+    """
+    accounts_module.create_account(store, 'pea', 'PEA')
+    model = accounts_module.create_model(
+        store, 'Flat', taxation.FLAT_REALISED, {'rate': 0.3})
+
+    accounts_module.set_taxation_model(store, 'pea', model.id)
+    accounts_module.set_opened_on(store, 'pea', date(2015, 6, 1))
+    assert store.query(
+        'SELECT taxation_model, opened_on FROM account_fact') == [
+            (model.id, date(2015, 6, 1))]
+
+    accounts_module.set_taxation_model(store, 'pea', None)
+    assert store.query('SELECT taxation_model, opened_on FROM account_fact') \
+        == [(None, date(2015, 6, 1))]
+
+    accounts_module.set_opened_on(store, 'pea', None)
+    assert store.query('SELECT count(*) FROM account_fact')[0][0] == 0
+
+
+def test_an_opening_date_that_is_not_a_day_is_refused(store):
+    """The column holds a day, and a string that looks like one is not one."""
+    accounts_module.create_account(store, 'pea', 'PEA')
+
+    with pytest.raises(accounts_module.AccountSourceError):
+        accounts_module.set_opened_on(store, 'pea', '2015-06-01')
+    # And an **instant** is not one either, though it is a `date` to Python:
+    # the column would truncate it, and the guard that says a day stays a day
+    # would be the thing that let one through.
+    with pytest.raises(accounts_module.AccountSourceError):
+        accounts_module.set_opened_on(
+            store, 'pea', datetime(2015, 6, 1, 8, 30, tzinfo=timezone.utc))
+    assert store.query('SELECT count(*) FROM account_fact')[0][0] == 0
+
+
+def test_the_earliest_payment_is_a_deposit_and_nothing_else(store):
+    """What the form offers is a figure of the **ledger**, per account.
+
+    A `BUY` is money moving inside the wrapper and a `WITHDRAWAL` is money
+    leaving it; neither opens anything. And it is derived on every read: no
+    column holds it, because a declared fact and a derived one do not share a
+    row (ADR-0006).
+    """
+    accounts_module.create_account(store, 'pea', 'PEA')
+    accounts_module.create_account(store, 'cto', 'CTO')
+    for key, (day, kind, account) in enumerate((
+            ('2022-03-04', 'BUY', 'pea'),
+            ('2022-05-10', 'DEPOSIT', 'pea'),
+            ('2023-01-02', 'DEPOSIT', 'pea'),
+            ('2021-01-02', 'WITHDRAWAL', 'cto'))):
+        store.execute(
+            'INSERT INTO event (id, date, event_type, account, amount) '
+            'VALUES (?, CAST(? AS DATE), ?, ?, 100)',
+            [key, day, kind, account])
+
+    assert ledger.first_payments(store) == {'pea': date(2022, 5, 10)}

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -5404,3 +5404,136 @@ def test_a_refused_removal_writes_none_of_its_three_statements(tmp_path):
     assert refused.status_code == 409
     assert opened.query("SELECT taxation_model FROM account_fact "
                         "WHERE account = 'pea'") == [(key,)]
+
+
+# --------------------------------------------------------------------- #
+# The opening date an account declares (#918)
+# --------------------------------------------------------------------- #
+
+_PEA_PAYMENTS = (
+    "date,event_type,amount,account\n"
+    "2022-05-10,DEPOSIT,2000,pea\n"
+    "2019-03-04,DEPOSIT,1000,pea\n"
+)
+
+
+def test_an_account_declares_the_day_it_was_opened(tmp_path):
+    client, opened = build_client_and_store(tmp_path)
+
+    declared = client.post('/api/accounts',
+                           json={'id': 'pea', 'label': 'PEA',
+                                 'opened_on': '2015-06-01'})
+
+    assert declared.status_code == 201
+    assert declared.get_json()['opened_on'] == '2015-06-01'
+    # A calendar day stays a day: the column is a `DATE`, and nothing on the
+    # way in or out turns it into an instant.
+    assert opened.query('SELECT account, opened_on FROM account_fact') == [
+        ('pea', date(2015, 6, 1))]
+    listed = client.get('/api/accounts').get_json()['accounts']
+    assert {row['id']: row.get('opened_on') for row in listed} == {
+        'pea': '2015-06-01'}
+
+
+def test_an_account_with_no_opening_date_publishes_no_member(tmp_path):
+    """An account without one is normal — and the absence reaches the reader
+    as an absence (#845, ADR-0044)."""
+    client, opened = build_client_and_store(tmp_path)
+
+    declared = client.post('/api/accounts', json={'id': 'pea', 'label': 'PEA'})
+
+    assert 'opened_on' not in declared.get_json()
+    assert opened.query('SELECT count(*) FROM account_fact') == [(0,)]
+    listed = client.get('/api/accounts').get_json()['accounts']
+    assert all('opened_on' not in row for row in listed)
+
+
+def test_the_read_carries_the_earliest_payment_the_form_pre_fills_with(
+        tmp_path):
+    """**Served, never stored** — a derived figure beside a declared one.
+
+    It is the account's earliest declared payment, which the form offers as the
+    opening date and the owner accepts or corrects. Nothing writes it anywhere:
+    a declared fact and a derived one do not share a row (ADR-0006).
+    """
+    client, opened = build_client_and_store(
+        tmp_path, accounts=ACCOUNTS_FILE, events=_PEA_PAYMENTS)
+
+    listed = client.get('/api/accounts').get_json()['accounts']
+
+    assert {row['id']: row.get('first_payment') for row in listed} == {
+        'pea': '2019-03-04'}
+    assert opened.query('SELECT count(*) FROM account_fact') == [(0,)]
+
+
+def test_the_stored_date_is_what_was_submitted_and_is_never_re_derived(
+        tmp_path):
+    """The pre-fill is the **interface's** offer, and it stops moving once
+    accepted: a later payment older than it does not rewrite the row."""
+    client, opened = build_client_and_store(
+        tmp_path, accounts=ACCOUNTS_FILE, events=_PEA_PAYMENTS)
+    client.patch('/api/accounts/pea', json={'opened_on': '2019-03-04'})
+
+    written = client.post('/api/events',
+                          json={'date': '2017-01-05', 'event_type': 'DEPOSIT',
+                                'amount': 500, 'account': 'pea'})
+    assert written.status_code == 201
+
+    assert opened.query('SELECT opened_on FROM account_fact') == [
+        (date(2019, 3, 4),)]
+    listed = client.get('/api/accounts').get_json()['accounts']
+    (pea,) = [row for row in listed if row['id'] == 'pea']
+    assert (pea['opened_on'], pea['first_payment']) == \
+        ('2019-03-04', '2017-01-05')
+
+
+def test_renaming_an_account_leaves_the_opening_date_alone(tmp_path):
+    """Absent is *leave it alone*, `null` is *take it away* — the model's own
+    two gestures, and for the same reason."""
+    client, opened = build_client_and_store(tmp_path)
+    client.post('/api/accounts',
+                json={'id': 'pea', 'label': 'PEA', 'opened_on': '2015-06-01'})
+
+    renamed = client.patch('/api/accounts/pea', json={'label': 'Mon PEA'})
+    assert renamed.get_json()['opened_on'] == '2015-06-01'
+
+    cleared = client.patch('/api/accounts/pea', json={'opened_on': None})
+    assert 'opened_on' not in cleared.get_json()
+    assert opened.query('SELECT count(*) FROM account_fact') == [(0,)]
+
+
+def test_a_malformed_opening_date_is_refused_and_writes_no_account(tmp_path):
+    client, opened = build_client_and_store(tmp_path)
+
+    for nonsense in ('01/06/2015', '2015-02-30', 2015, '2015-06-01T00:00:00Z'):
+        refused = client.post('/api/accounts',
+                              json={'id': 'pea', 'label': 'PEA',
+                                    'opened_on': nonsense})
+        assert refused.status_code == 422, nonsense
+        body = refused.get_json()
+        assert body['type'] == '/problems/bad-request'
+        assert body['key'] == 'opened_on'
+
+    assert opened.query("SELECT count(*) FROM account WHERE id = 'pea'") == [(0,)]
+
+
+def test_a_declared_date_later_than_the_first_payment_stands_as_an_advisory(
+        tmp_path):
+    """A wrapper cannot receive money before it exists, and the app says so
+    without deciding which of the two dates is the wrong one."""
+    client, _ = build_client_and_store(
+        tmp_path, accounts=ACCOUNTS_FILE, events=_PEA_PAYMENTS)
+    client.patch('/api/accounts/pea', json={'opened_on': '2021-01-01'})
+
+    standing = client.get('/api/advisories').get_json()
+
+    (one,) = [row for row in standing
+              if row['kind'] == 'opened_after_first_payment']
+    assert one['subject'] == 'accounts'
+    assert one['detail']['account'] == 'pea'
+    assert one['detail']['opened_on'] == '2021-01-01'
+    assert one['detail']['first_payment'] == '2019-03-04'
+
+    client.patch('/api/accounts/pea', json={'opened_on': '2015-06-01'})
+    assert [row for row in client.get('/api/advisories').get_json()
+            if row['kind'] == 'opened_after_first_payment'] == []


### PR DESCRIPTION
An account carries the day its wrapper was opened. The column has existed since #752 — this is what first writes it, and `accounts.py` stays its one writer (ADR-0006, ADR-0044).

## Declared, and only declared

It cannot be derived, and the reason is precise: a PEA opened in 2015 and transferred to a broker whose ledger is only imported from 2022 derives three years of seniority instead of ten. The date the owner cares about is exactly the one no event carries.

The form **offers** the account's earliest declared payment — `ledger.first_payments`, derived on every read and stored nowhere — and that offer is *interface*: accepted, it becomes a declaration and stops moving. Nothing re-derives it on a replay.

## Asked for only where it changes a figure

Which is where the model the account carries counts its threshold **from the opening**. A shape whose years run from the first payment — which is what a PEA does — has an age threshold and still no use for this date; asked on the *kind*, that question would have arrived under a hint telling the reader the opposite. That is the defect the review found, and a test now carries the PEA shape.

## An advisory when the declared date is later than the first payment

A wrapper cannot be funded before it exists, so one of the two dates is wrong — and the app states the contradiction without arbitrating it, because it cannot. Both dates are in the `detail`, the card links to the account, and both catalogues say it. The opposite order raises nothing: that is exactly what a transferred wrapper looks like.

## The rest

- `opened_on` absent means *leave it alone*, `null` means *take the declaration away*, and a row that declares nothing any more goes rather than staying as two nulls;
- a malformed date is refused with a 422 naming its field, and a `datetime` is refused as the day it is not, though Python makes it a `date`;
- an absence stays an absence end to end: no member at all rather than a `null` the front would have to tell from *not yet read*.

Three leads raised in review and **not applied** are open as tickets: #932, #933, #934.

## Checks

`uv run pytest tests/` 1671 ✓ · `uv run flake8 src/application src/api --ignore=E501` ✓ · `.github/scripts/conventions.sh` ✓ · `pnpm lint` ✓ · `pnpm test` 824 ✓

Closes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional “Opened on” date to accounts when the selected taxation model uses the account’s opening date.
  - The date defaults to the earliest recorded payment and can be edited or cleared.
  - Account details now show both the declared opening date and first payment date.

- **Advisories**
  - Added a notification when an account’s opening date is later than its first payment, with localized details and dates.

- **Documentation**
  - Added glossary entries and guidance explaining opening dates and first payments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->